### PR TITLE
Fix issue 200 caused by str vs byte errors

### DIFF
--- a/common/src/stack/admin/gen_random_pw.py
+++ b/common/src/stack/admin/gen_random_pw.py
@@ -30,6 +30,6 @@ if __name__ == '__main__':
 		cleartext_password = sys.argv[2].strip('\n')
 
 	if password_type == 'crypt':
-		print(p.get_crypt_pw(cleartext_password).decode())
+		print(p.get_crypt_pw(cleartext_password))
 	else:
-		print(p.get_cleartext_pw(cleartext_password).decode())
+		print(p.get_cleartext_pw(cleartext_password))

--- a/common/src/stack/pylib/stack/password.py
+++ b/common/src/stack/pylib/stack/password.py
@@ -33,7 +33,7 @@ class Password:
 		if not c_pw:
 			c = self.get_rand()
 			c_pw = base64.urlsafe_b64encode(c)
-			c_pw = c_pw.rstrip('='.encode())
+			c_pw = c_pw.rstrip(b'=').decode()
 		return c_pw
 
 	def get_crypt_pw(self, c_pw=None):


### PR DESCRIPTION
This small patch fixes the issues in #200 caused by mixing bytes and stings. The get_crypt_pw and get_cleartext_pw functions always return strings now.