### PR TITLE
INTERNAL: We need more time to fetch the source.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,17 +41,25 @@ pipeline {
                 // and do it here with retries.
                 dir('stacki') {
                     retry(3) {
-                        timeout(5) {
-                            // Note: there is currently a bug in scm checkout where it doesn't
-                            // set environment variables, we we do by hand in a script
-                            script {
-                                checkout(scm).each { k,v -> env.setProperty(k, v) }
+                        script {
+                            // Note: There is a bug in Jenkins where a timeout causes the job to
+                            // abort unless you catch the FlowInterruptedException.
+                            // https://issues.jenkins-ci.org/browse/JENKINS-51454
+                            try {
+                                timeout(15) {
+                                    // Note: there is currently a bug in scm checkout where it doesn't
+                                    // set environment variables, we we do by hand in a script
+                                    checkout(scm).each { k,v -> env.setProperty(k, v) }
 
-                                // Add the last git log subject as the description in the GUI
-                                currentBuild.description = sh(
-                                    returnStdout: true,
-                                    script: 'git log -1 --pretty=format:%s'
-                                )
+                                    // Add the last git log subject as the description in the GUI
+                                    currentBuild.description = sh(
+                                        returnStdout: true,
+                                        script: 'git log -1 --pretty=format:%s'
+                                    )
+                                }
+                            }
+                            catch (err) {
+                                error 'Source checkout timed out'
                             }
                         }
                     }
@@ -147,9 +155,10 @@ pipeline {
 
                 // Build our ISO
                 dir('stacki-iso-builder') {
-                    retry(1) {
-                        // Give the build up to 60 minutes to finish
-                        timeout(60) {
+                    // Retry a few times, because CentOS mirrors are flaky
+                    retry(2) {
+                        // Give the build up to 120 minutes to finish
+                        timeout(120) {
                             sh './do-build.sh $PLATFORM ../stacki $GIT_BRANCH'
                         }
                     }
@@ -404,8 +413,8 @@ pipeline {
                     steps {
                         // Run the unit tests
                         dir('unit') {
-                            // Give the tests up to 60 minutes to finish
-                            timeout(60) {
+                            // Give the tests up to 120 minutes to finish
+                            timeout(120) {
                                 // branches develop, master, and those ending in _cov get coverage reports
                                 script {
                                     if (env.GIT_BRANCH ==~ /develop|master|.*_cov/) {
@@ -454,8 +463,8 @@ pipeline {
 
                         // Run the integration tests
                         dir('integration') {
-                            // Give the tests up to 60 minutes to finish
-                            timeout(60) {
+                            // Give the tests up to 120 minutes to finish
+                            timeout(120) {
                                 // branches develop, master, and those ending in _cov get coverage reports
                                 script {
                                     if (env.GIT_BRANCH ==~ /develop|master|.*_cov/) {
@@ -494,8 +503,8 @@ pipeline {
 
                         // Run the system tests
                         dir('system') {
-                            // Give the tests up to 60 minutes to finish
-                            timeout(60) {
+                            // Give the tests up to 120 minutes to finish
+                            timeout(120) {
                                 script {
                                     if (env.PLATFORM == 'sles11') {
                                         // If we're SLES 11, use the latest SLES 12 release to be our frontend

--- a/test-framework/test-suites/system/set-up.d/stacki-sles11.sh
+++ b/test-framework/test-suites/system/set-up.d/stacki-sles11.sh
@@ -43,17 +43,18 @@ then
     vagrant up backend-0-1 &
     wait
 
-    # Wait until the frontend sees that backend-0-0 is online
-    while [[ -z $(vagrant ssh frontend -c "sudo -i stack list host status backend-0-0 output-format=json | grep online") ]]
-    do
-        echo "Waiting for backend-0-0..."
-        sleep 60
-    done
+    # NOTE: Enable this once SLES 11 status is reliable
+    # # Wait until the frontend sees that backend-0-0 is online
+    # while [[ -z $(vagrant ssh frontend -c "sudo -i stack list host status backend-0-0 output-format=json | grep online") ]]
+    # do
+    #     echo "Waiting for backend-0-0..."
+    #     sleep 60
+    # done
 
-    # And backend-0-1
-    while [[ -z $(vagrant ssh frontend -c "sudo -i stack list host status backend-0-1 output-format=json | grep online") ]]
-    do
-        echo "Waiting for backend-0-1..."
-        sleep 60
-    done
+    # # And backend-0-1
+    # while [[ -z $(vagrant ssh frontend -c "sudo -i stack list host status backend-0-1 output-format=json | grep online") ]]
+    # do
+    #     echo "Waiting for backend-0-1..."
+    #     sleep 60
+    # done
 fi


### PR DESCRIPTION
There is also a bug in Jenkins where retries won't work when a timeout is in them, unless you catch the exception raised and then flag an error.