### PR TITLE
INTERNAL: Use temp directory for mount point during add pallet

### DIFF
--- a/common/src/stack/command/stack/commands/add/pallet/imp_foreign_sles.py
+++ b/common/src/stack/command/stack/commands/add/pallet/imp_foreign_sles.py
@@ -23,8 +23,8 @@ class Implementation(stack.commands.Implementation):
 	arch = None
 
 	def check_impl(self):
-		if os.path.exists('/mnt/cdrom/content'):
-			file = open('/mnt/cdrom/content', 'r')
+		if os.path.exists(f'{self.owner.mountPoint}/content'):
+			file = open(f'{self.owner.mountPoint}/content', 'r')
 
 			for line in file.readlines():
 				l = line.split()

--- a/common/src/stack/command/stack/commands/add/pallet/imp_foreign_sles12.py
+++ b/common/src/stack/command/stack/commands/add/pallet/imp_foreign_sles12.py
@@ -32,8 +32,8 @@ class Implementation(stack.commands.Implementation):
 		self.arch = 'x86_64'
 
 		found_distro = False
-		if os.path.exists('/mnt/cdrom/content'):
-			file = open('/mnt/cdrom/content', 'r')
+		if os.path.exists(f'{self.owner.mountPoint}/content'):
+			file = open(f'{self.owner.mountPoint}/content', 'r')
 
 			for line in file.readlines():
 				l = line.split(None, 1)


### PR DESCRIPTION
Previous behavior was to use /mnt/cdrom unless there was something already mounted in /mnt
which in that case a temp directory was used. Now instead a temp directory is always used
unless no pallet name was specified, which in that case see if something is mounted in
/mnt/cdrom and try to add that.