### PR TITLE
BUGFIX: Fix permission error when installing host with new interface

### DIFF
--- a/common/src/stack/kickstart/profile.py
+++ b/common/src/stack/kickstart/profile.py
@@ -23,6 +23,7 @@ import stack.lock
 import stack.api
 import stack.bool
 import stack.mq
+import stack.commands
 
 
 class Client:
@@ -249,6 +250,7 @@ if profile_update_macs:
 	if len(ifaces) > 0 and len(macs) > 0:
 		params.append('interface=%s' % ','.join(ifaces))
 		params.append('mac=%s' % ','.join(macs))
+		params.append('sync=False')
 
 		if len(modules) > 0:
 			params.append('module=%s' % (','.join(modules)))


### PR DESCRIPTION
When a backend is reinstalled and there is an interface not in the database,
the apache user would attempt to do a sync config and cause a permission error
to appear in the install logs. This isn't necessary during this stage (it's
worked fine until now with that error message) so pass in a flag to skip it.