### PR TITLE
INTERNAL: Add accessors for the before and after buffers

### DIFF
--- a/common/src/stack/pylib/stack/expectmore.py
+++ b/common/src/stack/pylib/stack/expectmore.py
@@ -87,7 +87,7 @@ class ExpectMore():
 
 		self.match_index = self._proc.match_index
 
-		output = self._proc.before.decode('utf-8').splitlines()
+		output = self.before
 		self._session_script.extend(output)
 
 		return output
@@ -169,3 +169,13 @@ class ExpectMore():
 
 	def __repr__(self):
 		return f"{self.__class__.__name__}('{self.cmd}', {self.PROMPTS})"
+
+	@property
+	def before(self):
+		"""Returns the lines in the buffer before the most recently matched prompt."""
+		return self._proc.before.decode().splitlines()
+
+	@property
+	def after(self):
+		"""Returns the lines in the buffer after the most recently matched prompt."""
+		return self._proc.after.decode().splitlines()

--- a/test-framework/test-suites/unit/tests/pylib/stack/test_pylib_stack_expectmore.py
+++ b/test-framework/test-suites/unit/tests/pylib/stack/test_pylib_stack_expectmore.py
@@ -1,0 +1,33 @@
+from unittest.mock import create_autospec, PropertyMock
+import pexpect
+import tempfile
+import pytest
+from contextlib import ExitStack
+from stack.expectmore import ExpectMore
+
+class TestExpectMore:
+	"""A test case containing tests for the expectmore class."""
+	# A list of the names of the buffer properties of the ExpectMore class to test.
+	# This will need to be updated should the class definition change.
+	EXPECTMORE_BUFFER_PROPERTIES = ["before", "after"]
+
+	@pytest.mark.parametrize("property_name", EXPECTMORE_BUFFER_PROPERTIES)
+	def test_before_after(self, property_name):
+		"""Test that the property returns the value of the associated buffer attribute of pexpect.spawn split across lines."""
+		mock_pexpect_spawn = create_autospec(
+			spec = pexpect.spawn,
+			instance = True,
+		)
+		mock_attribute = PropertyMock(return_value = b"foo\nbar")
+		setattr(type(mock_pexpect_spawn), property_name, mock_attribute)
+		# Need to add the mock spawn instance as the _proc on the expectmore instance.
+		test_expectmore = ExpectMore()
+		test_expectmore._proc = mock_pexpect_spawn
+
+		# Read the property
+		result = getattr(test_expectmore, property_name)
+
+		# Expect the attribute to be accessed
+		mock_attribute.assert_called_once_with()
+		# Expect the result to match the expected result
+		assert mock_attribute.return_value.decode().splitlines() == result


### PR DESCRIPTION
This provides an interface to the before and after buffers of the
pexpect.spawn instance that is consistent with what ExpectMore.wait()
returned prior to this change. This is needed for the x1052 switch.