### PR TITLE
INTERNAL: Add foundations for firmware management framework

### DIFF
--- a/common/nodes/database-schema.xml
+++ b/common/nodes/database-schema.xml
@@ -407,6 +407,74 @@ CREATE TABLE ib_memberships (
   INDEX (switch, part_name, interface)
 );
 
+<!-- Firmware -->
+<!-- need to drop in reverse order of creation because of FK constraints -->
+DROP TABLE IF EXISTS firmware_mapping;
+DROP TABLE IF EXISTS firmware;
+DROP TABLE IF EXISTS firmware_model;
+DROP TABLE IF EXISTS firmware_make;
+DROP TABLE IF EXISTS firmware_imp;
+DROP TABLE IF EXISTS firmware_version_regex;
+
+CREATE TABLE firmware_version_regex (
+	id INT AUTO_INCREMENT PRIMARY KEY,
+	name VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
+	regex VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
+	description VARCHAR(2048) NOT NULL,
+	INDEX (name),
+	CONSTRAINT unique_name UNIQUE (name)
+);
+
+CREATE TABLE firmware_imp (
+	id INT AUTO_INCREMENT PRIMARY KEY,
+	name VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
+	INDEX (name),
+	CONSTRAINT unique_name UNIQUE (name)
+);
+
+CREATE TABLE firmware_make (
+	id INT AUTO_INCREMENT PRIMARY KEY,
+	name VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
+	version_regex_id INT DEFAULT NULL,
+	FOREIGN KEY (version_regex_id) REFERENCES firmware_version_regex(id) ON DELETE SET NULL,
+	INDEX (name),
+	CONSTRAINT unique_name UNIQUE (name)
+);
+
+CREATE TABLE firmware_model (
+	id INT AUTO_INCREMENT PRIMARY KEY,
+	name VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
+	make_id INT NOT NULL,
+	imp_id INT NOT NULL,
+	version_regex_id INT DEFAULT NULL,
+	FOREIGN KEY (make_id) REFERENCES firmware_make(id),
+	FOREIGN KEY (imp_id) REFERENCES firmware_imp(id),
+	FOREIGN KEY (version_regex_id) REFERENCES firmware_version_regex(id) ON DELETE SET NULL,
+	INDEX (name),
+	CONSTRAINT unique_make_model UNIQUE (make_id, name)
+);
+
+CREATE TABLE firmware (
+	id INT AUTO_INCREMENT PRIMARY KEY,
+	model_id INT NOT NULL,
+	source VARCHAR(2048) NOT NULL,
+	version VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
+	hash_alg VARCHAR(255) NOT NULL default 'md5',
+	hash VARCHAR(2048) NOT NULL,
+	file VARCHAR(2048) NOT NULL,
+	FOREIGN KEY (model_id) REFERENCES firmware_model(id),
+	INDEX (version),
+	CONSTRAINT unique_model_version UNIQUE (model_id, version)
+);
+
+CREATE TABLE firmware_mapping (
+	id INT AUTO_INCREMENT PRIMARY KEY,
+	node_id INT NOT NULL,
+	firmware_id INT NOT NULL,
+	FOREIGN KEY (node_id) REFERENCES nodes(ID) ON DELETE CASCADE,
+	FOREIGN KEY (firmware_id) REFERENCES firmware(id) ON DELETE CASCADE,
+	CONSTRAINT unique_node_firmware UNIQUE (node_id, firmware_id)
+);
 
 </stack:file>
 

--- a/common/src/stack/command/stack/argument_processors/firmware.py
+++ b/common/src/stack/command/stack/argument_processors/firmware.py
@@ -1,0 +1,332 @@
+from pathlib import Path
+from collections import namedtuple, OrderedDict
+from stack.exception import CommandError
+
+class FirmwareArgumentProcessor:
+	"""A mixin to process firmware command arguments."""
+
+	def get_make_id(self, make):
+		"""Get the ID of the make with the provided name.
+
+		This will raise a CommandError if the make with the provided name doesn't exist.
+		"""
+		row = self.db.select("id FROM firmware_make WHERE name=%s", make)
+		if not row:
+			raise CommandError(cmd = self, msg = f"Firmware make {make} doesn't exist.")
+
+		return row[0][0]
+
+	def make_exists(self, make):
+		"""Returns whether the given make exists in the database."""
+		return self.db.count("(id) FROM firmware_make WHERE name=%s", make)
+
+	def ensure_unique_makes(self, makes):
+		"""Validates that none of the names in the list of makes provided already exist in the database."""
+		# ensure the make names don't already exist
+		existing_makes = [
+			make
+			for make, exists in (
+				(make, self.make_exists(make)) for make in makes
+			)
+			if exists
+		]
+		if existing_makes:
+			raise CommandError(cmd = self, msg = f"The following firmware makes already exist: {existing_makes}.")
+
+	def ensure_makes_exist(self, makes):
+		"""Validates that all of the names in the list of makes provided already exist in the datbase."""
+		# ensure the make names already exist
+		missing_makes = [
+			make
+			for make, exists in (
+				(make, self.make_exists(make)) for make in makes
+			)
+			if not exists
+		]
+		if missing_makes:
+			raise CommandError(cmd = self, msg = f"The following firmware makes don't exist: {missing_makes}.")
+
+	def get_model_id(self, make, model):
+		"""Get the ID of the model with the provided name related to the provided make.
+
+		This will raise a CommandError if the make + model combo doesn't exist.
+		"""
+		row = self.db.select(
+			"""
+			firmware_model.id
+			FROM firmware_model
+				INNER JOIN firmware_make
+					ON firmware_model.make_id=firmware_make.id
+			WHERE firmware_make.name=%s AND firmware_model.name=%s
+			""",
+			(make, model),
+		)
+		if not row:
+			raise CommandError(cmd = self, msg = f"Firmware model {model} doesn't exist for make {make}.")
+
+		return row[0][0]
+
+	def model_exists(self, make, model):
+		"""Returns whether the given model exists for the given make."""
+		return self.db.count(
+			"""
+			(firmware_model.id)
+			FROM firmware_model
+				INNER JOIN firmware_make
+					ON firmware_model.make_id=firmware_make.id
+			WHERE firmware_make.name=%s AND firmware_model.name=%s
+			""",
+			(make, model),
+		)
+
+	def ensure_unique_models(self, make, models):
+		"""Validates that none of the given model names already exist in the database for the given make."""
+		# ensure the model name doesn't already exist for the given make
+		existing_makes_models = [
+			(make, model)
+			for make, model, exists in (
+				(make, model, self.model_exists(make, model)) for model in models
+			)
+			if exists
+		]
+		if existing_makes_models:
+			raise CommandError(cmd = self, msg = f"The following make and model combinations already exist {existing_makes_models}.")
+
+	def ensure_models_exist(self, make, models):
+		"""Validates that all of the given model names already exist in the database for the given make."""
+		# ensure the models exist
+		missing_models = [
+			model
+			for model, exists in (
+				(model, self.model_exists(make, model)) for model in models
+			)
+			if not exists
+		]
+		if missing_models:
+			raise CommandError(
+				cmd = self,
+				msg = f"The following firmware models don't exist for make {make}: {missing_models}."
+			)
+
+	def firmware_exists(self, make, model, version):
+		"""Returns whether the given firmware version exists for the make + model combo."""
+		return self.db.count(
+			"""
+			(firmware.id)
+			FROM firmware
+				INNER JOIN firmware_model
+					ON firmware.model_id=firmware_model.id
+				INNER JOIN firmware_make
+					ON firmware_model.make_id=firmware_make.id
+			WHERE firmware_make.name=%s AND firmware_model.name=%s AND firmware.version=%s
+			""",
+			(make, model, version)
+		)
+
+	def ensure_firmwares_exist(self, make, model, versions):
+		"""Validates that all the firmware versions provided exist for the given make and model."""
+		# ensure the versions exist in the DB
+		missing_versions = [
+			version
+			for version, exists in (
+				(version, self.firmware_exists(make, model, version)) for version in versions
+			)
+			if not exists
+		]
+		if missing_versions:
+			raise CommandError(
+				cmd = self,
+				msg = f"The following firmware versions don't exist for make {make} and model {model}: {missing_versions}."
+			)
+
+	def get_firmware_id(self, make, model, version):
+		"""Get the ID of the firmware version with the provided version for the provided make and model.
+
+		This will raise a CommandError if the firmware version matching the provided information doesn't exist.
+		"""
+		row = self.db.select(
+			"""
+			firmware.id
+			FROM firmware
+				INNER JOIN firmware_model
+					ON firmware.model_id=firmware_model.id
+				INNER JOIN firmware_make
+					ON firmware_model.make_id=firmware_make.id
+			WHERE firmware_make.name=%s AND firmware_model.name=%s AND firmware.version=%s
+			""",
+			(make, model, version)
+		)
+		if not row:
+			raise CommandError(cmd = self, msg = f"Firmware version {version} doesn't exist for make {make} and model {model}.")
+
+		return row[0][0]
+
+	def get_common_frontend_ip(self, hostname):
+		"""Attempts to get an IP of one of the front end interfaces that shares a network with the provided host.
+
+		If the frontend and the host have no common networks, a CommandError is raised.
+		If none of the interfaces on the common network have IP addresses, a CommandError is raised.
+		"""
+		host_interface_frontend = self.call(command = "list.host.interface", args = ["a:frontend"])
+		# try to get the set of all common networks between the front end and the target host
+		host_networks = set(host["network"] for host in self.call(command = "list.host.interface", args = [hostname]))
+		frontend_networks = set(frontend_interface["network"] for frontend_interface in host_interface_frontend)
+		common_networks = list(host_networks & frontend_networks)
+
+		if not common_networks:
+			raise CommandError(
+				cmd = self,
+				msg = (
+					f"{hostname} does not share a network with the frontend, and thus cannot fetch firmware"
+					f" from it. Please configure {hostname} to share a common network with the frontend."
+				)
+			)
+
+		# try to get the IP addresses of frontend interfaces on the common networks
+		ip_addr = [
+			frontend_interface["ip"] for frontend_interface in host_interface_frontend
+			if frontend_interface["network"] in common_networks and frontend_interface["ip"]
+		]
+
+		if not ip_addr:
+			raise CommandError(
+				cmd = self,
+				msg = (
+					f"None of the network interfaces on the frontend attached to the following common networks"
+					f"have an IP address. Please configure at least one interface to have an IP address on one"
+					f"of the following networks: {common_networks}"
+				)
+			)
+		# pick the first one and use it
+		return ip_addr[0]
+
+	def get_firmware_url(self, hostname, firmware_file):
+		"""Attempts to get a url to allow a backend to download the provided firmware file from the front end.
+
+		If the frontend and the backend have no common networks, a CommandError is raised.
+		If none of the interfaces on the common network have IP addresses, a CommandError is raised.
+		If the file doesn't exist on disk, a CommandError is raised.
+		"""
+		try:
+			firmware_file = Path(firmware_file).resolve(strict = True)
+		except FileNotFoundError as exception:
+			raise CommandError(
+				cmd = self,
+				msg = f"Cannot resolve frontend URL for firmware file that does not exist: {exception}",
+			)
+
+		ip_addr = self.get_common_frontend_ip(hostname = hostname)
+		# remove the /export/stack prefix from the file path, as /install points to /export/stack
+		firmware_file = Path().joinpath(*(part for part in firmware_file.parts if part not in ("/", "export", "stack")))
+
+		return f"http://{ip_addr}/install/{firmware_file}"
+
+	def imp_exists(self, imp):
+		"""Returns whether the given implementation name exists in the database."""
+		return self.db.count("(id) FROM firmware_imp WHERE name=%s", imp)
+
+	def ensure_imps_exist(self, imps):
+		"""Validates that all of the given imp names already exist in the database."""
+		# ensure the imps exist
+		missing_imps = [
+			imp
+			for imp, exists in (
+				(imp, self.imp_exists(imp)) for imp in imps
+			)
+			if not exists
+		]
+		if missing_imps:
+			raise CommandError(
+				cmd = self,
+				msg = f"The following firmware implementations don't exist in the database: {missing_imps}."
+			)
+
+	def get_imp_id(self, imp):
+		"""Get the ID of the implementation with the provided name.
+
+		This will raise a CommandError if the implementation with the provided name doesn't exist.
+		"""
+		row = self.db.select('id FROM firmware_imp WHERE name=%s', imp)
+		if not row:
+			raise CommandError(cmd = self, msg = f"Firmware implementation {imp} doesn't exist in the database.")
+
+		return row[0][0]
+
+	def version_regex_exists(self, name):
+		"""Returns whether the given version_regex name exists in the database."""
+		return self.db.count("(id) FROM firmware_version_regex WHERE name=%s", name)
+
+	def ensure_regexes_exist(self, names):
+		"""Validates that all of the given version_regex names already exist in the database."""
+		# ensure the version_regexes exist
+		missing_version_regexes = [
+			name
+			for name, exists in (
+				(name, self.version_regex_exists(name)) for name in names
+			)
+			if not exists
+		]
+		if missing_version_regexes:
+			raise CommandError(
+				cmd = self,
+				msg = f"The following firmware version regexes don't exist in the database: {missing_version_regexes}."
+			)
+
+	def get_version_regex_id(self, name):
+		"""Get the ID of the version_regex with the provided name.
+
+		This will raise a CommandError if the version_regex with the provided name doesn't exist.
+		"""
+		row = self.db.select("id FROM firmware_version_regex WHERE name=%s", name)
+		if not row:
+			raise CommandError(cmd = self, msg = f"Firmware version_regex {name} doesn't exist in the database.")
+
+		return row[0][0]
+
+	def try_get_version_regex(self, make, model):
+		"""Attempts to return the most relevant version regex for the make and model combination provided.
+
+		If found, a namedtuple is returned with the members 'regex', 'name', and 'description'. The
+		regex member is the actual regular expression to use for validation while name and description
+		are the user friendly name and an optional description of the regex, respectively.
+
+		A version regex set on the model will be preferred to one set on the make.
+
+		If neither the make nor the model have a version regex set, None will be returned.
+		"""
+		regex = None
+		row = self.db.select(
+			"""
+			make_regex.regex, make_regex.name, make_regex.description, model_regex.regex, model_regex.name, model_regex.description
+			FROM firmware_make
+				INNER JOIN firmware_model
+					ON firmware_model.make_id = firmware_make.id
+				LEFT JOIN firmware_version_regex as make_regex
+					ON firmware_make.version_regex_id = make_regex.id
+				LEFT JOIN firmware_version_regex as model_regex
+					ON firmware_model.version_regex_id = model_regex.id
+			WHERE firmware_make.name = %s AND firmware_model.name = %s
+			""",
+			(make, model)
+		)
+		if row:
+			make_regex, make_regex_name, make_regex_description = row[0][0:3]
+			model_regex, model_regex_name, model_regex_description = row[0][3:6]
+			RegexInfo = namedtuple("RegexInfo", ("regex", "name", "description"))
+			# prefer the model regex
+			if model_regex:
+				regex = RegexInfo(
+					regex = model_regex,
+					name = model_regex_name,
+					description = model_regex_description
+				)
+			# else use the make regex
+			elif make_regex:
+				regex = RegexInfo(
+					regex = make_regex,
+					name = make_regex_name,
+					description = make_regex_description
+				)
+			# Otherwise we return nothing.
+
+		return regex

--- a/common/src/stack/pylib/stack/firmware.py
+++ b/common/src/stack/pylib/stack/firmware.py
@@ -1,0 +1,125 @@
+import hashlib
+from pathlib import Path
+import uuid
+from urllib.parse import urlparse
+from enum import Enum, auto, unique
+import stack.download
+
+# Base path to store managed firmware files under
+BASE_PATH = Path("/export/stack/firmware/")
+
+@unique
+class SUPPORTED_SCHEMES(Enum):
+	"""Supported schemes to fetch firmware from a source to be managed by stacki"""
+	file = auto()
+	http = auto()
+	https = auto()
+
+	@classmethod
+	def pretty_string(cls):
+		"""Return a nice human readable list of names."""
+		return ", ".join(cls.__members__.keys())
+
+	def __str__(self):
+		"""Return the human readable name of the enum when printing or stringifying."""
+		return f"{self.name}"
+
+
+# Require the supported hash algorithms to be the always present ones
+SUPPORTED_HASH_ALGS = hashlib.algorithms_guaranteed
+
+class FirmwareError(Exception):
+	"""The exception type raised by the firmware utilities in this module."""
+	pass
+
+def calculate_hash(file_path, hash_alg, hash_value = None, digest_length = 256):
+	"""Calculates the hash of the provided file using the provided algorithm and returns it as a hex string.
+
+	hash_alg is required to be one of the SUPPORTED_HASH_ALGS and a FirmwareError will be raised if it is not.
+
+	If a hash value is provided, this checks the calculated hash against the provided hash. The hash_value should
+	be a string of the form provided by hash.hexdigest(). A FirmwareError is raised if the hashes do not match.
+
+	For some algorithms a length is required (shake_128 and shake_256 at the time of this writing). The digest_length
+	parameter allows the overriding of the default length used. This parameter is ignored if the algorithm does not
+	allow specifying the digest length.
+	"""
+	if hash_alg not in SUPPORTED_HASH_ALGS:
+		raise FirmwareError(
+			f"hash_alg must be one of the following: {SUPPORTED_HASH_ALGS}"
+		)
+
+	hasher = hashlib.new(name = hash_alg, data = Path(file_path).read_bytes())
+	# Handle case where the hash algorithm requires a digest length.
+	try:
+		calculated_hash = hasher.hexdigest()
+	except TypeError:
+		calculated_hash = hasher.hexdigest(digest_length)
+
+	# check the hash if one was provided to check against
+	if hash_value is not None and hash_value != calculated_hash:
+		raise FirmwareError(
+			f"Calculated hash {calculated_hash} does not match expected hash {hash_value}. Algorithm was {hash_alg}."
+		)
+
+	return calculated_hash
+
+def fetch_firmware(source, make, model, filename = None, **kwargs):
+	"""Fetches the firmware file from the provided source and copies it into a stacki managed file.
+
+	source should be the URL from which to pull the firmware image from. If this is not one of the
+	supported schemes, a FirmwareError is raised.
+
+	make and model must be set to the make and model the firmware image applies to.
+
+	filename is the optional file name to write the image out to locally. This does not change the
+	destination folder, only the file name.
+
+	The remaining kwargs will be captured and passed through as necessary to the underlying mechanism
+	used to fetch the file from the source. For example, fetching via HTTP might need a username and
+	a password for authentication.
+
+	A FirmwareError is raised if fetching the file from the source fails.
+	"""
+	# parse the URL to figure out how we're going to fetch it
+	url = urlparse(url = source)
+
+	# build file path to write out to
+	dest_dir = BASE_PATH / make / model
+	dest_dir = dest_dir.resolve()
+	dest_dir.mkdir(parents = True, exist_ok = True)
+	# set a random file name if the name is not set
+	final_file = dest_dir / (uuid.uuid4().hex if filename is None else filename)
+
+	try:
+		scheme = SUPPORTED_SCHEMES[url.scheme]
+	except KeyError:
+		raise FirmwareError(
+			f"Scheme {url.scheme} is not supported. The source must use one of the following supported"
+			f" schemes: {SUPPORTED_SCHEMES.pretty_string()}."
+		)
+
+	if scheme == SUPPORTED_SCHEMES.file:
+		# grab the source file and copy it into the destination file
+		try:
+			source_file = Path(url.path).resolve(strict = True)
+		except FileNotFoundError as exception:
+			raise FirmwareError(f"{exception}")
+
+		final_file.write_bytes(source_file.read_bytes())
+
+	elif scheme in (SUPPORTED_SCHEMES.http, SUPPORTED_SCHEMES.https):
+		try:
+			stack.download.fetch(url = source, file_path = final_file, verbose = True, **kwargs)
+		except stack.download.FetchError as exception:
+			raise FirmwareError(f"{exception}")
+
+	# add more supported schemes here
+	# elif scheme == SUPPORTED_SCHEMES.foo:
+	else:
+		# Case where we forgot to add a elif case for a new scheme that was added.
+		raise RuntimeError(
+			f"Someone wrote a bug! Code needs to be added to handle the {scheme} scheme."
+		)
+
+	return final_file

--- a/common/src/stack/pylib/stack/util.py
+++ b/common/src/stack/pylib/stack/util.py
@@ -1,5 +1,5 @@
 #! /opt/stack/bin/python
-# 
+#
 # @copyright@
 # Copyright (c) 2006 - 2019 Teradata
 # All rights reserved. Stacki(r) v5.x stacki.com
@@ -13,7 +13,6 @@
 # @rocks@
 
 import os
-import sys
 import subprocess
 import shlex
 import itertools
@@ -74,7 +73,7 @@ def list_isprefix(l1, l2):
 
 def getNativeArch():
 	"""Returns the canotical arch as reported by the operating system"""
-	
+
 	arch = os.uname()[4]
 	if arch in [ 'i386', 'i486', 'i586', 'i686']:
 		arch = 'i386'
@@ -90,7 +89,7 @@ def mkdir(newdir):
 	if os.path.isdir(newdir):
 		pass
 	elif os.path.isfile(newdir):
-		raise OSError("a file with the same name as the desired dir, '%s', already exists." % 
+		raise OSError("a file with the same name as the desired dir, '%s', already exists." %
 			      newdir)
 	else:
 		head, tail = os.path.split(newdir)
@@ -112,7 +111,7 @@ class ParseXML(handler.ContentHandler,
 		handler.ContentHandler.__init__(self)
 		self.app = app
 		self.text = ''
-		
+
 
 	def startElement(self, name, attrs):
 		"""The Mason Katz school of parsers. Make small functions
@@ -145,5 +144,26 @@ def system(cmd):
 def blank_str_to_None(string):
 	if isinstance(string, str) and string.strip() == '':
 		return None
-	
+
 	return string
+
+def unique_everseen(iterable, key=None):
+	"""List unique elements, preserving order. Remember all elements ever seen.
+
+	unique_everseen('AAAABBBCCDAABBB') --> A B C D
+	unique_everseen('ABBCcAD', str.lower) --> A B C D
+
+	Source: https://docs.python.org/3/library/itertools.html#itertools-recipes
+	"""
+	seen = set()
+	seen_add = seen.add
+	if key is None:
+		for element in itertools.filterfalse(seen.__contains__, iterable):
+			seen_add(element)
+			yield element
+	else:
+		for element in iterable:
+			k = key(element)
+			if k not in seen:
+				seen_add(k)
+				yield element

--- a/test-framework/test-suites/unit/tests/command/stack/argument_processors/test_firmware.py
+++ b/test-framework/test-suites/unit/tests/command/stack/argument_processors/test_firmware.py
@@ -1,0 +1,483 @@
+from unittest.mock import MagicMock, ANY, patch, call
+import pytest
+from stack.exception import CommandError
+import stack.commands
+from stack.argument_processors.firmware import FirmwareArgumentProcessor
+
+class TestFirmwareArgumentProcessor:
+	"""A test case for the firmware argument processor."""
+
+	@pytest.fixture
+	def argument_processor(self):
+		test_argument_processor = FirmwareArgumentProcessor()
+		test_argument_processor.db = MagicMock(spec_set = ["select", "count"])
+		return test_argument_processor
+
+	def test_get_make_id(self, argument_processor):
+		"""Test that get make ID works as expected in the normal case."""
+		argument_processor.db.select.return_value = [[1]]
+		mock_make = "foo"
+
+		# Expect our result to be returned.
+		assert argument_processor.db.select.return_value[0][0] == argument_processor.get_make_id(
+			make = mock_make,
+		)
+		# Ensure that select was called appropriately.
+		argument_processor.db.select.assert_called_once_with(ANY, mock_make)
+
+	def test_get_make_id_error(self, argument_processor):
+		"""Test that get make ID fails if no make exists in the DB with that name."""
+		argument_processor.db.select.return_value = []
+
+		with pytest.raises(CommandError):
+			argument_processor.get_make_id(make = "foo")
+
+	@pytest.mark.parametrize("return_value", (0, 1))
+	def test_make_exists(self, argument_processor, return_value):
+		"""Test that make exists returns the correct results."""
+		argument_processor.db.count.return_value = return_value
+
+		assert return_value == argument_processor.make_exists(make = "foo")
+		argument_processor.db.count.assert_called_once_with(ANY, "foo")
+
+	@patch.object(target = FirmwareArgumentProcessor, attribute = "make_exists", autospec = True)
+	def test_ensure_unique_makes(self, mock_make_exists, argument_processor):
+		"""Test that ensure_unique_makes works as expected in the case where the makes don't already exist."""
+		mock_make_exists.return_value = False
+		mock_makes = ("foo", "bar", "baz")
+
+		argument_processor.ensure_unique_makes(makes = mock_makes)
+
+		assert [call(argument_processor, mock_make) for mock_make in mock_makes] == mock_make_exists.mock_calls
+
+	@patch.object(target = FirmwareArgumentProcessor, attribute = "make_exists", autospec = True)
+	def test_ensure_unique_makes_error(self, mock_make_exists, argument_processor):
+		"""Test that ensure_unique_makes raises an error when one or more makes already exist."""
+		mock_make_exists.side_effect = (False, True, False)
+		mock_makes = ("foo", "bar", "baz")
+
+		with pytest.raises(CommandError):
+			argument_processor.ensure_unique_makes(makes = mock_makes)
+
+	@patch.object(target = FirmwareArgumentProcessor, attribute = "make_exists", autospec = True)
+	def test_ensure_makes_exist(self, mock_make_exists, argument_processor):
+		"""Test that ensure_makes_exist works as expected in the case where the makes already exist."""
+		mock_make_exists.return_value = True
+		mock_makes = ("foo", "bar", "baz")
+
+		argument_processor.ensure_makes_exist(makes = mock_makes)
+
+		assert [call(argument_processor, mock_make) for mock_make in mock_makes] == mock_make_exists.mock_calls
+
+	@patch.object(target = FirmwareArgumentProcessor, attribute = "make_exists", autospec = True)
+	def test_ensure_makes_exist_error(self, mock_make_exists, argument_processor):
+		"""Test that ensure_makes_exist raises an error when one or more makes don't already exist."""
+		mock_make_exists.side_effect = (False, True, False)
+		mock_makes = ("foo", "bar", "baz")
+
+		with pytest.raises(CommandError):
+			argument_processor.ensure_makes_exist(makes = mock_makes)
+
+	def test_get_model_id(self, argument_processor):
+		"""Test that get model ID works as expected when the make + model exist in the database."""
+		argument_processor.db.select.return_value = [[1]]
+		mock_make = "foo"
+		mock_model = "bar"
+
+		assert argument_processor.db.select.return_value[0][0] == argument_processor.get_model_id(
+			make = mock_make,
+			model = mock_model,
+		)
+		argument_processor.db.select.assert_called_once_with(ANY, (mock_make, mock_model))
+
+	def test_get_model_id_error(self, argument_processor):
+		"""Test that get model ID fails as expected when the make + model do not exist in the database."""
+		argument_processor.db.select.return_value = []
+		mock_make = "foo"
+		mock_model = "bar"
+
+		with pytest.raises(CommandError):
+			argument_processor.get_model_id(make = mock_make, model = mock_model)
+
+	@pytest.mark.parametrize("return_value", (0, 1))
+	def test_model_exists(self, return_value, argument_processor):
+		"""Test that model exists returns the correct results."""
+		mock_make = "foo"
+		mock_model = "bar"
+		argument_processor.db.count.return_value = return_value
+
+		assert return_value == argument_processor.model_exists(make = mock_make, model = mock_model)
+		argument_processor.db.count.assert_called_once_with(ANY, (mock_make, mock_model))
+
+	@patch.object(target = FirmwareArgumentProcessor, attribute = "model_exists", autospec = True)
+	def test_ensure_unique_models(self, mock_model_exists, argument_processor):
+		"""Test that ensure_unique_models works as expected when the make + model combinations do not already exist."""
+		mock_model_exists.return_value = False
+		mock_make = "foo"
+		mock_models = ("bar", "baz", "bag")
+
+		argument_processor.ensure_unique_models(make = mock_make, models = mock_models)
+
+		assert [
+			call(argument_processor, mock_make, mock_model)
+			for mock_model in mock_models
+		] == mock_model_exists.mock_calls
+
+	@patch.object(target = FirmwareArgumentProcessor, attribute = "model_exists", autospec = True)
+	def test_ensure_unique_models_error(self, mock_model_exists, argument_processor):
+		"""Test that ensure_unique_models fails as expected when the make + model combinations already exist."""
+		mock_model_exists.side_effect = (False, True, False)
+		mock_make = "foo"
+		mock_models = ("bar", "baz", "bag")
+
+		with pytest.raises(CommandError):
+			argument_processor.ensure_unique_models(make = mock_make, models = mock_models)
+
+	@patch.object(target = FirmwareArgumentProcessor, attribute = "model_exists", autospec = True)
+	def test_ensure_models_exist(self, mock_model_exists, argument_processor):
+		"""Test that ensure_models_exist works as expected when the make + model combinations already exist."""
+		mock_model_exists.return_value = True
+		mock_make = "foo"
+		mock_models = ("bar", "baz", "bag")
+
+		argument_processor.ensure_models_exist(make = mock_make, models = mock_models)
+
+		assert [
+			call(argument_processor, mock_make, mock_model)
+			for mock_model in mock_models
+		] == mock_model_exists.mock_calls
+
+	@patch.object(target = FirmwareArgumentProcessor, attribute = "model_exists", autospec = True)
+	def test_ensure_models_exist_error(self, mock_model_exists, argument_processor):
+		"""Test that ensure_models_exist fails as expected when the make + model combinations do not already exist."""
+		mock_model_exists.side_effect = (False, True, False)
+		mock_make = "foo"
+		mock_models = ("bar", "baz", "bag")
+
+		with pytest.raises(CommandError):
+			argument_processor.ensure_models_exist(make = mock_make, models = mock_models)
+
+	@pytest.mark.parametrize("return_value", (0, 1))
+	def test_firmware_exists(self, return_value, argument_processor):
+		"""Test that firmware exists returns the correct results."""
+		mock_make = "foo"
+		mock_model = "bar"
+		mock_version = "baz"
+		argument_processor.db.count.return_value = return_value
+
+		assert return_value == argument_processor.firmware_exists(
+			make = mock_make,
+			model = mock_model,
+			version = mock_version,
+		)
+		argument_processor.db.count.assert_called_once_with(ANY, (mock_make, mock_model, mock_version))
+
+	@patch.object(target = FirmwareArgumentProcessor, attribute = "firmware_exists", autospec = True)
+	def test_ensure_firmwares_exist(self, mock_firmware_exists, argument_processor):
+		"""Test that ensure_firmwares_exist works as expected when the firmware files exist for the given make + model."""
+		mock_firmware_exists.return_value = True
+		mock_make = "foo"
+		mock_model = "bar"
+		mock_versions = ("baz", "bag", "boo")
+
+		argument_processor.ensure_firmwares_exist(
+			make = mock_make,
+			model = mock_model,
+			versions = mock_versions,
+		)
+
+		assert [
+			call(argument_processor, mock_make, mock_model, mock_version)
+			for mock_version in mock_versions
+		] == mock_firmware_exists.mock_calls
+
+	@patch.object(target = FirmwareArgumentProcessor, attribute = "firmware_exists", autospec = True)
+	def test_ensure_firmwares_exist_errors(self, mock_firmware_exists, argument_processor):
+		"""Test that ensure_firmwares_exist fails as expected when the firmware files don't exist for the given make + model."""
+		mock_firmware_exists.side_effect = (False, True, False)
+		mock_make = "foo"
+		mock_model = "bar"
+		mock_versions = ("baz", "bag", "boo")
+
+		with pytest.raises(CommandError):
+			argument_processor.ensure_firmwares_exist(
+				make = mock_make,
+				model = mock_model,
+				versions = mock_versions,
+			)
+
+	def test_get_firmware_id(self, argument_processor):
+		"""Test that get_firmware_id works as expected when the firmware exists."""
+		argument_processor.db.select.return_value = [[1]]
+		mock_make = "foo"
+		mock_model = "bar"
+		mock_version = "baz"
+
+		assert argument_processor.db.select.return_value[0][0] == argument_processor.get_firmware_id(
+			make = mock_make,
+			model = mock_model,
+			version = mock_version,
+		)
+		argument_processor.db.select.assert_called_once_with(ANY, (mock_make, mock_model, mock_version))
+
+	def test_get_firmware_id_error(self, argument_processor):
+		"""Test that get_firmware_id works as expected."""
+		argument_processor.db.select.return_value = []
+		mock_make = "foo"
+		mock_model = "bar"
+		mock_version = "baz"
+
+		with pytest.raises(CommandError):
+			argument_processor.get_firmware_id(
+				make = mock_make,
+				model = mock_model,
+				version = mock_version,
+			)
+
+	# Use create = True here because the self.call method comes from the Command class,
+	# which the class under test is expected to be mixed in with.
+	@patch.object(target = FirmwareArgumentProcessor, attribute = "call", create = True)
+	def test_get_common_frontend_ip(self, mock_call, argument_processor):
+		"""Test that get_common_frontend_ip gets the expected common frontend IP when the frontend and the target host share a network."""
+		mock_hostname = "sd-stacki-mock-backend"
+		# Set up the call("list.host.interface") returns, ensuring each separate return value contains one shared network.
+		mock_call_return_values = (
+			# Mock front end interfaces
+			[{"network": "foo", "ip": "1.2.3.4"}, {"network": "bar", "ip": "2.3.4.5"}],
+			# Mock other host interfaces
+			[{"network": "baz", "ip": "3.4.5.6"}, {"network": "foo", "ip": "1.2.3.10"}],
+		)
+		mock_call.side_effect = mock_call_return_values
+
+		result = argument_processor.get_common_frontend_ip(hostname = mock_hostname)
+
+		# Make sure the right IP was returned
+		assert mock_call_return_values[0][0]["ip"] == result
+		# Make sure the list host interface calls happened
+		assert mock_call.mock_calls == [
+			call(command = "list.host.interface", args = ["a:frontend"]),
+			call(command = "list.host.interface", args = [mock_hostname]),
+		]
+
+	# Use create = True here because the self.call method comes from the Command class,
+	# which the class under test is expected to be mixed in with.
+	@patch.object(target = FirmwareArgumentProcessor, attribute = "call", create = True)
+	def test_get_common_frontend_ip_no_common_network(self, mock_call, argument_processor):
+		"""Test that get_common_frontend_ip fails when there is no common network."""
+		mock_hostname = "sd-stacki-mock-backend"
+		# Set up the call("list.host.interface") returns, ensuring each separate return value contains no shared networks.
+		mock_call_return_values = (
+			# Mock front end interfaces
+			[{"network": "foo", "ip": "1.2.3.4"}, {"network": "bar", "ip": "2.3.4.5"}],
+			# Mock other host interfaces
+			[{"network": "baz", "ip": "3.4.5.6"}, {"network": "bag", "ip": "1.2.3.10"}],
+		)
+		mock_call.side_effect = mock_call_return_values
+
+		with pytest.raises(CommandError):
+			argument_processor.get_common_frontend_ip(hostname = mock_hostname)
+
+	# Use create = True here because the self.call method comes from the Command class,
+	# which the class under test is expected to be mixed in with.
+	@patch.object(target = FirmwareArgumentProcessor, attribute = "call", create = True)
+	def test_get_common_frontend_ip_no_interface_ip(self, mock_call, argument_processor):
+		"""Test that get_common_frontend_ip fails when there is no IP on the interface on the common network."""
+		mock_hostname = "sd-stacki-mock-backend"
+		# Set up the call("list.host.interface") returns, ensuring each separate return value contains one shared network.
+		mock_call_return_values = (
+			# Mock front end interfaces
+			[{"network": "foo", "ip": ""}, {"network": "bar", "ip": "2.3.4.5"}],
+			# Mock other host interfaces
+			[{"network": "baz", "ip": "3.4.5.6"}, {"network": "foo", "ip": "1.2.3.10"}],
+		)
+		mock_call.side_effect = mock_call_return_values
+
+		with pytest.raises(CommandError):
+			argument_processor.get_common_frontend_ip(hostname = mock_hostname)
+
+	@patch.object(target = FirmwareArgumentProcessor, attribute = "get_common_frontend_ip", autospec = True)
+	@patch(target = "stack.argument_processors.firmware.Path", autospec = True)
+	def test_get_firmware_url(self, mock_path, mock_get_common_frontend_ip, argument_processor):
+		"""Test that get_firmware_url returns the correct URL."""
+		mock_get_common_frontend_ip.return_value = "1.2.3.4"
+		# need to mock out Path.parts.
+		mock_path_parts = (
+			"/",
+			"export",
+			"stack",
+			"firmware",
+			"make",
+			"model",
+			"file",
+		)
+		mock_path.return_value.resolve.return_value.parts = mock_path_parts
+		expected_path_parts = mock_path_parts[3:]
+		expected_path = "/".join(expected_path_parts)
+		mock_path.return_value.joinpath.return_value.__str__.return_value = expected_path
+		expected_url = f"http://{mock_get_common_frontend_ip.return_value}/install/{expected_path}"
+		mock_firmware_file = "foo"
+		mock_hostname = "bar"
+
+		result = argument_processor.get_firmware_url(
+			hostname = mock_hostname,
+			firmware_file = mock_firmware_file,
+		)
+
+		# Make sure the returned URL is correct.
+		assert expected_url == result
+		# Check that the path was resolved.
+		assert all(
+			call in mock_path.mock_calls
+			for call in call(mock_firmware_file).resolve(strict = True).call_list()
+		)
+		# Make sure the IP was retrieved
+		mock_get_common_frontend_ip.assert_called_once_with(argument_processor, hostname = mock_hostname)
+		# Make sure the path was rebuilt excluding the right elements
+		mock_path.return_value.joinpath.assert_called_once_with(*expected_path_parts)
+
+	@patch.object(target = FirmwareArgumentProcessor, attribute = "get_common_frontend_ip", autospec = True)
+	@patch(target = "stack.argument_processors.firmware.Path", autospec = True)
+	def test_get_firmware_url_file_does_not_exist(self, mock_path, mock_get_common_frontend_ip, argument_processor):
+		"""Test that get_firmware_url raises a CommandError if the firmware file does not exist."""
+		mock_path.return_value.resolve.side_effect = FileNotFoundError("Test error")
+
+		with pytest.raises(CommandError):
+			argument_processor.get_firmware_url(
+				hostname = "foo",
+				firmware_file = "bar",
+			)
+
+	@patch.object(target = FirmwareArgumentProcessor, attribute = "get_common_frontend_ip", autospec = True)
+	@patch(target = "stack.argument_processors.firmware.Path", autospec = True)
+	def test_get_firmware_url_no_common_ip(self, mock_path, mock_get_common_frontend_ip, argument_processor):
+		"""Test that get_firmware_url passes through the CommandError if get_common_frontend_ip fails."""
+		mock_get_common_frontend_ip.side_effect = CommandError(cmd = "", msg = "Test error")
+
+		with pytest.raises(CommandError):
+			argument_processor.get_firmware_url(
+				hostname = "foo",
+				firmware_file = "bar",
+			)
+
+	@pytest.mark.parametrize("return_value", (0, 1))
+	def test_imp_exists(self, return_value, argument_processor):
+		"""Test that imp_exists works as expected."""
+		mock_imp = "foo"
+		argument_processor.db.count.return_value = return_value
+
+		assert return_value == argument_processor.imp_exists(imp = mock_imp)
+		argument_processor.db.count.assert_called_once_with(ANY, mock_imp)
+
+	@patch.object(target = FirmwareArgumentProcessor, attribute = "imp_exists", autospec = True)
+	def test_ensure_imps_exist(self, mock_imp_exists, argument_processor):
+		"""Test that ensure_imps_exist works as expected when all implementations exist in the database."""
+		mock_imp_exists.return_value = True
+		mock_imps = ("foo", "bar", "baz")
+
+		argument_processor.ensure_imps_exist(imps = mock_imps)
+
+		assert [call(argument_processor, mock_imp) for mock_imp in mock_imps] == mock_imp_exists.mock_calls
+
+	@patch.object(target = FirmwareArgumentProcessor, attribute = "imp_exists", autospec = True)
+	def test_ensure_imps_exist_error(self, mock_imp_exists, argument_processor):
+		"""Test that ensure_imps_exist fails when at least one implementation doesn't exist in the database."""
+		mock_imp_exists.side_effect = (False, True, False)
+		mock_imps = ("foo", "bar", "baz")
+
+		with pytest.raises(CommandError):
+			argument_processor.ensure_imps_exist(imps = mock_imps)
+
+	def test_get_imp_id(self, argument_processor):
+		"""Test that get_imp_id works as expected when the implementation exists in the database."""
+		argument_processor.db.select.return_value = [[1]]
+		mock_imp = "foo"
+
+		assert argument_processor.db.select.return_value[0][0] == argument_processor.get_imp_id(
+			imp = mock_imp,
+		)
+		argument_processor.db.select.assert_called_once_with(ANY, mock_imp)
+
+	def test_get_imp_id_error(self, argument_processor):
+		"""Test that get_imp_id fails as expected when the implementation does not exist in the database."""
+		argument_processor.db.select.return_value = []
+		mock_imp = "foo"
+
+		with pytest.raises(CommandError):
+			argument_processor.get_imp_id(imp = mock_imp)
+
+	@pytest.mark.parametrize("return_value", (0, 1))
+	def test_version_regex_exists(self, return_value, argument_processor):
+		"""Test that version_regex_exists works as expected."""
+		argument_processor.db.count.return_value = return_value
+		mock_name = "foo"
+
+		assert return_value == argument_processor.version_regex_exists(name = mock_name)
+		argument_processor.db.count.assert_called_once_with(ANY, mock_name)
+
+	@patch.object(target = FirmwareArgumentProcessor, attribute = "version_regex_exists", autospec = True)
+	def test_ensure_regexes_exist(self, mock_version_regex_exists, argument_processor):
+		"""Test that ensure_regexes_exist works in the case where all the version regexes exist in the database."""
+		mock_version_regex_exists.return_value = True
+		mock_names = ("foo", "bar", "baz")
+
+		argument_processor.ensure_regexes_exist(names = mock_names)
+
+		assert [call(argument_processor, mock_name) for mock_name in mock_names] == mock_version_regex_exists.mock_calls
+
+	@patch.object(target = FirmwareArgumentProcessor, attribute = "version_regex_exists", autospec = True)
+	def test_ensure_regexes_exist_error(self, mock_version_regex_exists, argument_processor):
+		"""Test that ensure_regexes_exist fails in the case where at least one of the version regexes does not exist in the database."""
+		mock_version_regex_exists.side_effect = (False, True, False)
+		mock_names = ("foo", "bar", "baz")
+
+		with pytest.raises(CommandError):
+			argument_processor.ensure_regexes_exist(names = mock_names)
+
+	def test_get_version_regex_id(self, argument_processor):
+		"""Test that get_version_regex_id works as expected when the version_regex exists in the database."""
+		argument_processor.db.select.return_value = [[1]]
+		mock_name = "foo"
+
+		assert argument_processor.db.select.return_value[0][0] == argument_processor.get_version_regex_id(
+			name = mock_name,
+		)
+		argument_processor.db.select.assert_called_once_with(ANY, mock_name)
+
+	def test_get_version_regex_id_error(self, argument_processor):
+		"""Test that get_version_regex_id fails as expected when the version_regex does not exist in the database."""
+		argument_processor.db.select.return_value = []
+		mock_name = "foo"
+
+		with pytest.raises(CommandError):
+			argument_processor.get_version_regex_id(name = mock_name)
+
+	@pytest.mark.parametrize(
+		"test_input, expected",
+		(
+			(
+				[[None, None, None, "mock_model_regex", "mock_model_regex_name", "mock_model_regex_description"]],
+				("mock_model_regex", "mock_model_regex_name", "mock_model_regex_description"),
+			),
+			(
+				[["mock_make_regex", "mock_make_regex_name", "mock_make_regex_description", None, None, None,]],
+				("mock_make_regex", "mock_make_regex_name", "mock_make_regex_description"),
+			),
+			(
+				[["mock_make_regex", "mock_make_regex_name", "mock_make_regex_description", "mock_model_regex", "mock_model_regex_name", "mock_model_regex_description"]],
+				("mock_model_regex", "mock_model_regex_name", "mock_model_regex_description"),
+			),
+			([], None),
+		)
+	)
+	def test_try_get_version_regex(self, test_input, expected, argument_processor):
+		"""Test that try_get_version_regex works as expected, preferring a model regex over a make one."""
+		argument_processor.db.select.return_value = test_input
+		mock_make = "foo"
+		mock_model = "bar"
+
+		# Make sure the expected result is returned.
+		assert expected == argument_processor.try_get_version_regex(
+			make = mock_make,
+			model = mock_model,
+		)
+		argument_processor.db.select.assert_called_once_with(ANY, (mock_make, mock_model))

--- a/test-framework/test-suites/unit/tests/pylib/stack/test_pylib_stack_firmware.py
+++ b/test-framework/test-suites/unit/tests/pylib/stack/test_pylib_stack_firmware.py
@@ -1,0 +1,195 @@
+from unittest.mock import patch, call
+import hashlib
+import pytest
+import stack.download
+import stack.firmware
+
+class TestSupportedSchemes:
+	"""A test case for the schemes enum logic."""
+
+	def test_pretty_string(self):
+		"""Ensure pretty_string works as expected."""
+		assert ", ".join(
+			stack.firmware.SUPPORTED_SCHEMES.__members__.keys()
+		) == stack.firmware.SUPPORTED_SCHEMES.pretty_string()
+
+	@pytest.mark.parametrize("scheme", stack.firmware.SUPPORTED_SCHEMES)
+	def test__str__(self, scheme):
+		"""Ensure the __str__ for each enum instance works as expected."""
+		assert scheme.name == str(scheme)
+
+class TestFirmware:
+	"""A test case to hold the tests for the firmware utilities."""
+
+	@pytest.mark.parametrize("hash_alg", stack.firmware.SUPPORTED_HASH_ALGS)
+	@patch(target = "stack.firmware.Path", autospec = True)
+	def test_calculate_hash(self, mock_path, hash_alg):
+		"""Test that calculate_hash works for all supported hash types."""
+		mock_path.return_value.read_bytes.return_value = b"bar"
+
+		try:
+			expected_hash = hashlib.new(
+				name = hash_alg,
+				data = mock_path.return_value.read_bytes.return_value
+			).hexdigest()
+		except TypeError:
+			# Need to handle shake_128 and shake_256 case where a digest length is required.
+			expected_hash = hashlib.new(
+				name = hash_alg,
+				data = mock_path.return_value.read_bytes.return_value
+			).hexdigest(256)
+
+		# Call providing the expected hash
+		mock_file = "foo"
+		assert expected_hash == stack.firmware.calculate_hash(
+			file_path = mock_file,
+			hash_alg = hash_alg,
+			hash_value = expected_hash,
+		)
+		# Expect the path to be used to read the file
+		mock_path.assert_called_once_with(mock_file)
+		mock_path.return_value.read_bytes.assert_called_once_with()
+
+		# Reset mocks for the next set of assertions
+		mock_path.reset_mock()
+		# Call without providing the expected hash
+		assert expected_hash == stack.firmware.calculate_hash(
+			file_path = mock_file,
+			hash_alg = hash_alg,
+		)
+		# Expect the path to be used to read the file
+		mock_path.assert_called_once_with(mock_file)
+		mock_path.return_value.read_bytes.assert_called_once_with()
+
+	@pytest.mark.parametrize("hash_alg", stack.firmware.SUPPORTED_HASH_ALGS)
+	@patch(target = "stack.firmware.Path", autospec = True)
+	def test_calculate_hash_mismatched_provided_hash(self, mock_path, hash_alg):
+		"""Test that calculate_hash fails if the provided hash doesn't match the calculated one."""
+		mock_path.return_value.read_bytes.return_value = b"bar"
+
+		with pytest.raises(stack.firmware.FirmwareError):
+			stack.firmware.calculate_hash(
+				file_path = "foo",
+				hash_alg = hash_alg,
+				hash_value = "foo",
+			)
+
+	@patch(target = "stack.firmware.Path", autospec = True)
+	def test_calculate_hash_unsupported_hash(self, mock_path):
+		"""Test that calculate_hash fails if the provided hash_alg isn't supported."""
+		mock_path.return_value.read_bytes.return_value = b"bar"
+
+		with pytest.raises(stack.firmware.FirmwareError):
+			stack.firmware.calculate_hash(
+				file_path = "foo",
+				hash_alg = "foo",
+			)
+
+	@pytest.mark.parametrize("scheme", stack.firmware.SUPPORTED_SCHEMES)
+	@patch(target = "uuid.uuid4", autospec = True)
+	@patch(target = "stack.firmware.Path", autospec = True)
+	@patch(target = "stack.firmware.BASE_PATH", autospec = True)
+	@patch(target = "stack.download.fetch", autospec = True)
+	def test_fetch_firmware(self, mock_fetch, mock_base_path, mock_path, mock_uuid4, scheme):
+		"""Test that fetch_firmware works as expected for each supported scheme."""
+		mock_url = f"{scheme}://localhost/foo/bar"
+		mock_make = "foo"
+		mock_model = "bar"
+		mock_username = "baz"
+
+		result = stack.firmware.fetch_firmware(
+			source = mock_url,
+			make = mock_make,
+			model = mock_model,
+			username = mock_username,
+		)
+
+		# Make sure base_dir is used to properly build the target directory
+		chained_calls = call.__truediv__(mock_make).__truediv__(mock_model).resolve().mkdir(parents = True, exist_ok = True)
+		call_list = chained_calls.call_list()
+		call_list.append(call.__truediv__().__truediv__().resolve().__truediv__(mock_uuid4.return_value.hex))
+		assert all(mock_call in mock_base_path.mock_calls for mock_call in call_list)
+		# Make sure the final file is built using the hex uuid4
+		mock_base_path.__truediv__.return_value.__truediv__.return_value.resolve.return_value.__truediv__.assert_called_once_with(
+			mock_uuid4.return_value.hex
+		)
+		mock_final_file = mock_base_path.__truediv__.return_value.__truediv__.return_value.resolve.return_value.__truediv__.return_value
+		# Make sure the returned file is the final file
+		assert mock_final_file == result
+
+		# We make assertions based on the scheme in use.
+		if scheme == stack.firmware.SUPPORTED_SCHEMES.file:
+			# Ensure the file was constructed using the url path
+			mock_path.assert_called_once_with("/foo/bar")
+			mock_path.return_value.resolve.assert_called_once_with(strict = True)
+			# Make sure the final file is written
+			mock_final_file.write_bytes.assert_called_once_with(
+				mock_path.return_value.resolve.return_value.read_bytes.return_value
+			)
+
+		elif scheme in (stack.firmware.SUPPORTED_SCHEMES.http, stack.firmware.SUPPORTED_SCHEMES.https):
+			# Ensure the source was downloaded
+			mock_fetch.assert_called_once_with(
+				url = mock_url,
+				file_path = mock_final_file,
+				verbose = True,
+				username = mock_username,
+			)
+
+	@pytest.mark.parametrize("scheme", stack.firmware.SUPPORTED_SCHEMES)
+	@patch(target = "uuid.uuid4", autospec = True)
+	@patch(target = "stack.firmware.Path", autospec = True)
+	@patch(target = "stack.firmware.BASE_PATH", autospec = True)
+	@patch(target = "stack.download.fetch", autospec = True)
+	def test_fetch_firmware_errors(self, mock_fetch, mock_base_path, mock_path, mock_uuid4, scheme):
+		"""Test that fetch_firmware fails as expected for each supported scheme when fetching from the source fails."""
+		mock_url = f"{scheme}://localhost/foo/bar"
+		mock_make = "foo"
+		mock_model = "bar"
+
+		# Set up exceptions
+		mock_path.return_value.resolve.side_effect = FileNotFoundError("Test error")
+		mock_fetch.side_effect = stack.download.FetchError("Test error")
+
+		with pytest.raises(stack.firmware.FirmwareError):
+			stack.firmware.fetch_firmware(
+				source = mock_url,
+				make = mock_make,
+				model = mock_model,
+			)
+
+	@patch(target = "uuid.uuid4", autospec = True)
+	@patch(target = "stack.firmware.Path", autospec = True)
+	@patch(target = "stack.firmware.BASE_PATH", autospec = True)
+	@patch(target = "stack.download.fetch", autospec = True)
+	def test_fetch_firmware_unsupoorted_scheme(self, mock_fetch, mock_base_path, mock_path, mock_uuid4):
+		"""Test that fetch_firmware fails when given an unsupported scheme."""
+		mock_url = f"baz://localhost/foo/bar"
+		mock_make = "foo"
+		mock_model = "bar"
+
+		with pytest.raises(stack.firmware.FirmwareError):
+			stack.firmware.fetch_firmware(
+				source = mock_url,
+				make = mock_make,
+				model = mock_model,
+			)
+
+	@patch(target = "stack.firmware.SUPPORTED_SCHEMES")
+	@patch(target = "uuid.uuid4", autospec = True)
+	@patch(target = "stack.firmware.Path", autospec = True)
+	@patch(target = "stack.firmware.BASE_PATH", autospec = True)
+	@patch(target = "stack.download.fetch", autospec = True)
+	def test_fetch_firmware_forgotten_scheme(self, mock_fetch, mock_base_path, mock_path, mock_uuid4, mock_schemes):
+		"""Test that fetch_firmware fails when a case is not added to handle a supported scheme."""
+		mock_url = f"baz://localhost/foo/bar"
+		mock_make = "foo"
+		mock_model = "bar"
+		mock_schemes.__getitem__.return_value = "baz"
+
+		with pytest.raises(RuntimeError):
+			stack.firmware.fetch_firmware(
+				source = mock_url,
+				make = mock_make,
+				model = mock_model,
+			)

--- a/test-framework/test-suites/unit/tests/pylib/stack/test_pylib_stack_util.py
+++ b/test-framework/test-suites/unit/tests/pylib/stack/test_pylib_stack_util.py
@@ -77,4 +77,17 @@ class TestUtil:
 		with pytest.raises(FileNotFoundError):
 			_exec('whodis')
 
-
+	@pytest.mark.parametrize(
+		"key, test_input, expected",
+		(
+			(None, ("a", "a", "b", "a", "c"), ("a", "b", "c")),
+			(None, ("b", "a", "a", "a", "c"), ("b", "a", "c")),
+			(None, ("b", "c", "a", "a", "a"), ("b", "c", "a")),
+			(str.lower, ("a", "A", "b", "A", "c"), ("a", "b", "c")),
+			(str.lower, ("b", "a", "A", "A", "c"), ("b", "a", "c")),
+			(str.lower, ("b", "c", "a", "A", "a"), ("b", "c", "a")),
+		)
+	)
+	def test_unique_everseen(self, key, test_input, expected):
+		"""Test that duplicates are removed and order is preserved."""
+		assert expected == tuple(stack.util.unique_everseen(test_input, key = key))

--- a/tools/use_the_source/use_the_source.py
+++ b/tools/use_the_source/use_the_source.py
@@ -5,6 +5,7 @@ from pathlib import Path
 dest_base = Path("/opt/stack/lib/python3.7/site-packages")
 
 grafts_to_site_packages = (
+	("command/stack/argument_processors", "stack/argument_processors"),
 	("command/stack/commands", "stack/commands"),
 	("discovery/command", "stack/commands"),
 	("discovery/pylib", "stack"),


### PR DESCRIPTION
The first change set that lays the foundation for the stacki firmware management commands to come. This also includes an argument processor and a pylib file that collect some general utilities used by the firmware code.

I'd prefer people to yell quickly if any major changes are desired, as I'm going to start writing tests for this code and don't want to spend a bunch of time on them only to throw them away when I have to make changes.

If you're feeling brave and want more context, the rest of the code lives in `feature/more-firmware-less-attr`. That branch will continue to be broken apart and PRed as things move along, and probably will be cleaned up along the way.