### PR TITLE
INTERNAL: Add report system test for checking database partition info…

### DIFF
--- a/common/src/stack/report-system/command/report/system/tests/stack_test_util.py
+++ b/common/src/stack/report-system/command/report/system/tests/stack_test_util.py
@@ -1,0 +1,123 @@
+import paramiko
+import math
+
+def get_partitions(testinfra_host):
+
+	# For a given testinfra host, return a list of all partitions across disks
+	try:
+		return testinfra_host.check_output(f'lsblk -r -n -o name').split('\n')
+
+	# If we can't ssh, return a blank list
+	except paramiko.ssh_exception.NoValidConnectionsError:
+		return []
+
+def get_part_label(testinfra_host, partition):
+
+	# For a given partition and testinfra host, return the partition label
+	# if it is has one, otherwise return 'no label'
+	try:
+		labels = testinfra_host.check_output(f'lsblk -r -n -o name,label').split('\n')
+
+	# If we can't ssh, return 'no label'
+	except paramiko.ssh_exception.NoValidConnectionsError:
+		return None
+
+	# Try all labels on the host
+	for label in labels:
+		try:
+			curr_part = label.split(' ')[0]
+			curr_label = label.split(' ')[1]
+
+		except IndexError:
+			return None
+
+		# If the partition matches the argument one, return the label
+		if curr_part == partition:
+			return curr_label
+
+	# Otherwise return no label
+	return None
+
+def get_part_mountpoint(testinfra_host, partition):
+
+	# For a given partition and testinfra host, return the partition mountpoint
+	# if it is has one, otherwise return 'no mountpoint'
+	try:
+		mounts = testinfra_host.check_output(f'lsblk -r -n -o name,mountpoint').split('\n')
+
+	# If we can't ssh, return there is no mountpoint
+	except paramiko.ssh_exception.NoValidConnectionsError:
+		return None
+
+	# Try all mountpoints on the host
+	for mount in mounts:
+		try:
+			curr_part = mount.split(' ')[0]
+			curr_mount = mount.split(' ')[1]
+
+		except IndexError:
+			return None
+
+		# If the partition matches the argument one, return the mountpoint
+		if curr_part == partition:
+			return curr_mount
+
+	# Otherwise return no mountpoint
+	return None
+
+def get_part_fs(testinfra_host, partition):
+
+	# For a testinfra host and partition, return the partition
+	# filesystem
+	try:
+		fstypes = testinfra_host.check_output(f'lsblk -r -n -o name,fstype').split('\n')
+
+	# Return blank if we can't ssh into the host
+	except paramiko.ssh_exception.NoValidConnectionsError:
+		return ''
+
+	# Go through all found partitions on the host
+	for fs in fstypes:
+		try:
+			curr_part = fs.split(' ')[0]
+			curr_fs = fs.split(' ')[1]
+
+		except IndexError:
+			return None
+
+		# If the current partition matches the the input one
+		# return the file system
+		if curr_part == partition:
+			return curr_fs
+
+	# Otherwise return blank
+	return None
+
+def get_part_size(testinfra_host, partition):
+
+	# For a testinfra host and partition, return the partition's
+	# size if it can be found
+	try:
+		sizes = testinfra_host.check_output(f'lsblk -b -r -n -o name,size').split('\n')
+
+	# If we can't ssh into the host, return an invalid size
+	except paramiko.ssh_exception.NoValidConnectionsError:
+		return -1
+
+	# Go through all the partitions
+	for size in sizes:
+		try:
+			curr_part = size.split(' ')[0]
+			curr_size = size.split(' ')[1]
+
+		except IndexError:
+			return None
+
+		# If the current partition matches the input one
+		# return the partition size in megabytes since
+		# lsblk can only do bytes precisely
+		if curr_part == partition:
+			return int(curr_size) / math.pow(2,20)
+
+	# Otherwise return an invalid size
+	return None

--- a/common/src/stack/report-system/command/report/system/tests/test_partitions.py
+++ b/common/src/stack/report-system/command/report/system/tests/test_partitions.py
@@ -1,0 +1,134 @@
+import pytest
+import math
+import json
+import testinfra
+import paramiko
+from collections import namedtuple, defaultdict
+from stack import api
+from stack.commands.report.system.tests.stack_test_util import get_partitions, get_part_label, get_part_size, get_part_fs
+
+testinfra_hosts = list(set([host['host'] for host in api.Call('list host partition')]))
+class TestStoragePartition:
+
+	""" Test if the way stacki configured the disks is still how they are partitioned """
+
+	def test_storage_partition(self, host):
+
+		# Get current hostname and test if we can ssh into the host
+		# Otherwise fail the test
+		try:
+			hostname = host.check_output('hostname')
+
+		except paramiko.ssh_exception.NoValidConnectionsError:
+			pytest.fail(f'Could not ssh into host')
+
+		# Get stacki storage config using proper scoping
+		storage_config = api.Call(f'list host storage partition {hostname}')
+		check_config = defaultdict(dict)
+		partition_info = namedtuple('partition', ['name', 'mountpoint', 'label', 'fstype', 'size'])
+		errors = []
+
+		# Otherwise if we are on an older version of stacki without proper scoping,
+		# use report host instead and convert the dict output as a string into an actual dict
+		if not storage_config:
+			report_storage = api.Call(f'report host storage partition {hostname}')
+
+			# If we still cannot get stacki's storage config for the current host,
+			# skip the test
+			if not report_storage or report_storage[0] == '[]':
+				pytest.skip(f'Using default stacki partition config for host {hostname}')
+			else:
+				storage_config = json.loads(report_storage[0].replace("'", '"').replace('None', '""'))
+
+		# Get a list of the partitions that are actually on the disk
+		host_partitions = get_partitions(host)
+
+		if not host_partitions:
+			pytest.fail(f'No partitions found on host {hostname}')
+
+		# Go through the stacki storage config and see
+		# if it matches what's actually on the disk/disks
+		for partition in storage_config:
+			# Info needed for each partiton
+			disk = partition['device']
+			disk_num = str(partition['partid'])
+			partition_name = disk + disk_num
+			partition_size = get_part_size(host, partition_name)
+			conf_mntpt = partition['mountpoint']
+			part_label = ''
+
+			# If a partition cannot be found on the actual disk, return an error
+			if partition_name not in host_partitions:
+				errors.append(f'/dev/{partition_name} not found on host')
+				continue
+
+			# Because testinfra only has mountpoint based partition functions
+			# use them when we can but if there is a partition without a mountpoint
+			# check using a fixture that directly calls lsblk
+			if conf_mntpt:
+
+				if not host.mount_point(conf_mntpt).exists:
+					errors.append(f'Could not find {conf_mntpt} on disk')
+
+				else:
+					curr_mnt_part = host.mount_point(conf_mntpt).device
+					curr_fs = host.mount_point(conf_mntpt).filesystem
+
+					if curr_mnt_part != f'/dev/{partition_name}':
+						msg = f'Mountpoint {conf_mntpt} found at {curr_mnt_part} but was configured to be at /dev/{partition_name}'
+						errors.append(msg)
+
+					if (curr_fs != partition['fstype']) and partition['fstype']:
+						errors.append(
+							f'/dev/{partition_name} found with file system {curr_fs} but was configured with {partition["fstype"]}'
+						)
+
+			else:
+
+				# Use fixture instead of testinfra since there isn't a mountpoint
+				curr_fs = get_part_fs(host, partition_name)
+				if curr_fs != partition['fstype'] and (partition['fstype'] != None):
+					errors.append(
+						f'/dev/{partition_name} found with file system {curr_fs} but was configured with {partition["fstype"]}'
+					)
+
+			# Check if the a label should be present for the current partition
+			# and check if it matches the actual partition
+			if 'label=' in partition['options']:
+				config_label = partition['options'].split('label=')[1]
+				curr_label = get_part_label(host, partition_name)
+
+				if not curr_label:
+					errors.append(f'/dev/{partition_name} configured with label {config_label} but no label found')
+
+				elif config_label != curr_label:
+					errors.append(f'/dev/{partition_name} configured with label {config_label} but found with {curr_label}')
+
+			# Check partition size within 100MB due to lsblk bytes conversion
+			# If a partition size is 0, we assume that means it fills the rest of the disk
+			# So check that as well
+			if not math.isclose(int(partition['size']), partition_size, abs_tol=100):
+
+				# Initial check will not match if partition size as 0, as it fills the rest
+				# of the disk
+				if int(partition['size']) == 0:
+					disk_size = get_part_size(host, disk)
+					rest_of_disk = 0
+
+					# Find the size of the disk for all the other partitions
+					for partition in storage_config:
+						curr_partition = partition['device'] + str(partition['partid'])
+
+						# Don't include the current partition
+						if curr_partition != partition_name:
+							part_size = get_part_size(host, curr_partition)
+							if part_size:
+								rest_of_disk += part_size
+
+					# Check if the disk size matches all the partitions added up
+					if not math.isclose(partition_size+rest_of_disk, disk_size, abs_tol=100):
+						errors.append(f'/dev/{partition_name} size different from configuration')
+				else:
+					errors.append(f'/dev/{partition_name} size different from configuration')
+
+		assert not errors, f'Host {hostname} found with partitioning mismatch from original config: {", ".join(errors)}'


### PR DESCRIPTION
~~This also adds a new pytest fixture that when given a dictionary will ssh into a host, see if the partitions match, and return the partition attributes that don't match.~~

Adds a new utilities file that contains helper functions to do various partition info getting. 

~~Side note: since the fixtures folder is new to stacki core, I copied the init file from tdc, so when this branch get's merged that file should be deleted from the tdc repo.~~



Depends on `feature/scope-the-partitions_cov`