### PR TITLE
INTERNAL: Add commands for managing firmware version_regexes

### DIFF
--- a/common/src/stack/command/stack/commands/add/firmware/__init__.py
+++ b/common/src/stack/command/stack/commands/add/firmware/__init__.py
@@ -1,0 +1,18 @@
+# @copyright@
+# Copyright (c) 2006 - 2018 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+#
+# @rocks@
+# Copyright (c) 2000 - 2010 The Regents of the University of California
+# All rights reserved. Rocks(r) v5.4 www.rocksclusters.org
+# https://github.com/Teradata/stacki/blob/master/LICENSE-ROCKS.txt
+# @rocks@
+
+import stack.commands
+from stack.argument_processors.firmware import FirmwareArgumentProcessor
+
+class command(stack.commands.add.command, FirmwareArgumentProcessor):
+	pass
+

--- a/common/src/stack/command/stack/commands/add/firmware/version_regex/__init__.py
+++ b/common/src/stack/command/stack/commands/add/firmware/version_regex/__init__.py
@@ -1,0 +1,46 @@
+# @copyright@
+# Copyright (c) 2006 - 2018 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+#
+# @rocks@
+# Copyright (c) 2000 - 2010 The Regents of the University of California
+# All rights reserved. Rocks(r) v5.4 www.rocksclusters.org
+# https://github.com/Teradata/stacki/blob/master/LICENSE-ROCKS.txt
+# @rocks@
+
+import stack.commands
+
+class Command(stack.commands.add.firmware.command):
+	"""
+	Adds a firmware version regex to the stacki database for use in parsing and validating firmware version numbers.
+
+	<arg type='string' name='regex'>
+	A valid Python regex to use to use against the version number returned from the target hardware.
+	</arg>
+
+	<param type='string' name='name'>
+	The human readable name for this regex.
+	</param>
+
+	<param type='string' name='description' optional='1'>
+	An optional description for this regex. This is useful to describe what the regex does for future travellers.
+	</param>
+
+	<param type='string' name='make'>
+	The make that this regex should apply to.
+	</param>
+
+	<param type='string' name='models' optional='1'>
+	The optional models for the given make that this regex applies to. Multiple models should be specified as a comma separated list.
+	</param>
+
+	<example cmd="add firmware version_regex '(?:\d+\.){2}\d+' name=mellanox_version make=mellanox model='m7800, m6036' description='This turns X86_64 3.6.5009 2018-01-02 07:42:21 x86_64 into 3.6.5009.'">
+	Adds a regex with the name mellanox_version and the description provided that looks for three number groups separated by dots to the Stacki database.
+	It also associates the regex with the m7800 and m6036 models for the mellanox make.
+	</example>
+	"""
+
+	def run(self, params, args):
+		self.runPlugins(args = (params, args))

--- a/common/src/stack/command/stack/commands/add/firmware/version_regex/plugin_basic.py
+++ b/common/src/stack/command/stack/commands/add/firmware/version_regex/plugin_basic.py
@@ -1,0 +1,142 @@
+# @copyright@
+# Copyright (c) 2006 - 2018 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+#
+# @rocks@
+# Copyright (c) 2000 - 2010 The Regents of the University of California
+# All rights reserved. Rocks(r) v5.4 www.rocksclusters.org
+# https://github.com/Teradata/stacki/blob/master/LICENSE-ROCKS.txt
+# @rocks@
+
+import re
+from contextlib import ExitStack
+from stack.util import unique_everseen
+import stack.commands
+from stack.exception import ArgError, ArgRequired, ArgUnique, ParamRequired, ParamError
+
+class Plugin(stack.commands.Plugin):
+	"""Attempts to add a version_regex to the database and associate it with the specified makes and/or models."""
+
+	def provides(self):
+		return "basic"
+
+	def validate_args(self, args):
+		"""Validate that the arguments to this plugin are as expected."""
+		# Require a version regex
+		if not args:
+			raise ArgRequired(cmd = self.owner, arg = "regex")
+
+		# Should only be one
+		if len(args) != 1:
+			raise ArgUnique(cmd = self.owner, arg = "regex")
+
+	def validate_regex(self, regex):
+		"""Make sure the provided regex is a valid Python regex."""
+		# Don't allow empty string, which will compile into a regex fine.
+		if not regex:
+			raise ArgError(
+				cmd = self.owner,
+				arg = "regex",
+				msg = f"Regex cannot be an empty string."
+			)
+
+		# Require the version_regex to be a valid regex
+		try:
+			re.compile(regex)
+		except re.error as exception:
+			raise ArgError(
+				cmd = self.owner,
+				arg = "regex",
+				msg = f"Invalid regex supplied: {exception}."
+			)
+
+	def validate_name(self, name):
+		"""Validate the name is provided and is unique."""
+		# A name is required
+		if not name:
+			raise ParamRequired(cmd = self.owner, param = "name")
+
+		# The name must not already exist
+		if self.owner.version_regex_exists(name = name):
+			raise ParamError(
+				cmd = self.owner,
+				param = "name",
+				msg = f"A version_regex with the name {name} already exists in the database."
+			)
+
+	def validate_make(self, make):
+		"""Validate that the make is provided and exists in the database."""
+		# The make is required.
+		if not make:
+			raise ParamRequired(cmd = self.owner, param = "make")
+
+		# The make must exist
+		if not self.owner.make_exists(make = make):
+			raise ParamError(
+				cmd = self.owner,
+				param = "make",
+				msg = f"The make {make} does not exist."
+			)
+
+	def run(self, args):
+		params, args = args
+		self.validate_args(args = args)
+		version_regex = args[0]
+		self.validate_regex(regex = version_regex)
+
+		name, description, make, models = self.owner.fillParams(
+			names = [
+				("name", ""),
+				("description", ""),
+				("make", ""),
+				("models", ""),
+			],
+			params = params,
+		)
+		name = name.lower()
+		self.validate_name(name = name)
+		make = make.lower()
+		self.validate_make(make = make)
+		models = models.lower()
+		# Process models if specified
+		if models:
+			models = tuple(
+				unique_everseen(
+					(model.strip() for model in models.split(',') if model.strip())
+				)
+			)
+			# The models must exist
+			self.owner.ensure_models_exist(make = make, models = models)
+
+		with ExitStack() as cleanup:
+			# add the regex
+			self.owner.db.execute(
+				"""
+				INSERT INTO firmware_version_regex (
+					regex,
+					name,
+					description
+				)
+				VALUES (%s, %s, %s)
+				""",
+				(version_regex, name, description),
+			)
+			cleanup.callback(self.owner.call, command = "remove.firmware.version_regex", args = [name])
+
+			# If models are specified, associate it with the relevant models for the given make
+			if models:
+				self.owner.call(
+					command = "set.firmware.model.version_regex",
+					args = [*models, f"make={make}", f"version_regex={name}"],
+				)
+			# else associate it with just the make
+			else:
+				self.owner.call(
+					command = "set.firmware.make.version_regex",
+					args = [make, f"version_regex={name}"],
+				)
+
+			# everything worked, dismiss cleanup
+			cleanup.pop_all()

--- a/common/src/stack/command/stack/commands/list/firmware/__init__.py
+++ b/common/src/stack/command/stack/commands/list/firmware/__init__.py
@@ -1,0 +1,18 @@
+# @copyright@
+# Copyright (c) 2006 - 2018 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+#
+# @rocks@
+# Copyright (c) 2000 - 2010 The Regents of the University of California
+# All rights reserved. Rocks(r) v5.4 www.rocksclusters.org
+# https://github.com/Teradata/stacki/blob/master/LICENSE-ROCKS.txt
+# @rocks@
+
+import stack.commands
+from stack.argument_processors.firmware import FirmwareArgumentProcessor
+
+class command(stack.commands.list.command, FirmwareArgumentProcessor):
+	pass
+

--- a/common/src/stack/command/stack/commands/list/firmware/version_regex/__init__.py
+++ b/common/src/stack/command/stack/commands/list/firmware/version_regex/__init__.py
@@ -1,0 +1,34 @@
+# @copyright@
+# Copyright (c) 2006 - 2018 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+#
+# @rocks@
+# Copyright (c) 2000 - 2010 The Regents of the University of California
+# All rights reserved. Rocks(r) v5.4 www.rocksclusters.org
+# https://github.com/Teradata/stacki/blob/master/LICENSE-ROCKS.txt
+# @rocks@
+
+import stack.commands
+
+class Command(stack.commands.list.firmware.command):
+	"""
+	Lists all firmware version regexes tracked by stacki.
+
+	<example cmd="list firmware version_regex">
+	Lists all firmware version regexes tracked in the stacki database.
+	</example>
+	"""
+
+	def run(self, params, args):
+		header = []
+		values = []
+		for provides, results in self.runPlugins():
+			header.extend(results["keys"])
+			values.extend(results["values"])
+
+		self.beginOutput()
+		for owner, vals in values:
+			self.addOutput(owner = owner, vals = vals)
+		self.endOutput(header = header)

--- a/common/src/stack/command/stack/commands/list/firmware/version_regex/plugin_basic.py
+++ b/common/src/stack/command/stack/commands/list/firmware/version_regex/plugin_basic.py
@@ -1,0 +1,29 @@
+# @copyright@
+# Copyright (c) 2006 - 2018 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+#
+# @rocks@
+# Copyright (c) 2000 - 2010 The Regents of the University of California
+# All rights reserved. Rocks(r) v5.4 www.rocksclusters.org
+# https://github.com/Teradata/stacki/blob/master/LICENSE-ROCKS.txt
+# @rocks@
+
+import stack.commands
+
+class Plugin(stack.commands.Plugin):
+	"""Returns the names, regex, and description of all version regexes in the database."""
+
+	def provides(self):
+		return "basic"
+
+	def run(self, args):
+		return {
+			"keys": ["name", "regex", "description"],
+			"values": [
+				(row[0], row[1:]) for row in self.owner.db.select(
+					"name, regex, description FROM firmware_version_regex"
+				)
+			],
+		}

--- a/common/src/stack/command/stack/commands/remove/firmware/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/firmware/__init__.py
@@ -1,0 +1,18 @@
+# @copyright@
+# Copyright (c) 2006 - 2018 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+#
+# @rocks@
+# Copyright (c) 2000 - 2010 The Regents of the University of California
+# All rights reserved. Rocks(r) v5.4 www.rocksclusters.org
+# https://github.com/Teradata/stacki/blob/master/LICENSE-ROCKS.txt
+# @rocks@
+
+import stack.commands
+from stack.argument_processors.firmware import FirmwareArgumentProcessor
+
+class command(stack.commands.remove.command, FirmwareArgumentProcessor):
+	pass
+

--- a/common/src/stack/command/stack/commands/remove/firmware/make/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/firmware/make/__init__.py
@@ -1,0 +1,12 @@
+# @copyright@
+# Copyright (c) 2006 - 2018 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+#
+# @rocks@
+# Copyright (c) 2000 - 2010 The Regents of the University of California
+# All rights reserved. Rocks(r) v5.4 www.rocksclusters.org
+# https://github.com/Teradata/stacki/blob/master/LICENSE-ROCKS.txt
+# @rocks@
+

--- a/common/src/stack/command/stack/commands/remove/firmware/make/version_regex/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/firmware/make/version_regex/__init__.py
@@ -1,0 +1,29 @@
+# @copyright@
+# Copyright (c) 2006 - 2019 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+#
+# @rocks@
+# Copyright (c) 2000 - 2010 The Regents of the University of California
+# All rights reserved. Rocks(r) v5.4 www.rocksclusters.org
+# https://github.com/Teradata/stacki/blob/master/LICENSE-ROCKS.txt
+# @rocks@
+
+import stack.commands
+
+class Command(stack.commands.remove.firmware.command):
+	"""
+	Disassociates firmware version_regexes from one or more makes.
+
+	<arg type='string' name='makes'>
+	One or more makes to disassociate from a version_regex.
+	</arg>
+
+	<example cmd="remove firmware make version_regex mellanox intel">
+	Disassociates the mellanox and intel makes from any version_regexes that were set for them.
+	</example>
+	"""
+
+	def run(self, params, args):
+		self.runPlugins(args = args)

--- a/common/src/stack/command/stack/commands/remove/firmware/make/version_regex/plugin_basic.py
+++ b/common/src/stack/command/stack/commands/remove/firmware/make/version_regex/plugin_basic.py
@@ -1,0 +1,33 @@
+# @copyright@
+# Copyright (c) 2006 - 2019 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+#
+# @rocks@
+# Copyright (c) 2000 - 2010 The Regents of the University of California
+# All rights reserved. Rocks(r) v5.4 www.rocksclusters.org
+# https://github.com/Teradata/stacki/blob/master/LICENSE-ROCKS.txt
+# @rocks@
+
+import stack.commands
+from stack.util import lowered, unique_everseen
+from stack.exception import ArgRequired
+
+class Plugin(stack.commands.Plugin):
+	"""Attempts to disassociate version_regexes from makes."""
+
+	def provides(self):
+		return "basic"
+
+	def run(self, args):
+		# Require make names
+		if not args:
+			raise ArgRequired(cmd = self.owner, arg = "makes")
+		# lowercase all args and remove any duplicates
+		args = tuple(unique_everseen(lowered(args)))
+		# The makes must exist
+		self.owner.ensure_makes_exist(makes = args)
+
+		# disassociate the makes from version_regexes
+		self.owner.db.execute("UPDATE firmware_make SET version_regex_id=NULL WHERE name IN %s", (args,))

--- a/common/src/stack/command/stack/commands/remove/firmware/model/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/firmware/model/__init__.py
@@ -1,0 +1,12 @@
+# @copyright@
+# Copyright (c) 2006 - 2018 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+#
+# @rocks@
+# Copyright (c) 2000 - 2010 The Regents of the University of California
+# All rights reserved. Rocks(r) v5.4 www.rocksclusters.org
+# https://github.com/Teradata/stacki/blob/master/LICENSE-ROCKS.txt
+# @rocks@
+

--- a/common/src/stack/command/stack/commands/remove/firmware/model/version_regex/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/firmware/model/version_regex/__init__.py
@@ -1,0 +1,33 @@
+# @copyright@
+# Copyright (c) 2006 - 2019 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+#
+# @rocks@
+# Copyright (c) 2000 - 2010 The Regents of the University of California
+# All rights reserved. Rocks(r) v5.4 www.rocksclusters.org
+# https://github.com/Teradata/stacki/blob/master/LICENSE-ROCKS.txt
+# @rocks@
+
+import stack.commands
+
+class Command(stack.commands.remove.firmware.command):
+	"""
+	Disassociates firmware version_regexes from one or more models.
+
+	<arg type='string' name='models'>
+	One or more models to disassociate from a version_regex.
+	</arg>
+
+	<param type='string' name='make'>
+	The make of the provided models.
+	</param>
+
+	<example cmd="remove firmware model version_regex m7800 m6036 make=mellanox">
+	Disassociates the m7800 and m6036 models for the mellanox make from any version_regexes that were set for them.
+	</example>
+	"""
+
+	def run(self, params, args):
+		self.runPlugins(args = (params, args))

--- a/common/src/stack/command/stack/commands/remove/firmware/model/version_regex/plugin_basic.py
+++ b/common/src/stack/command/stack/commands/remove/firmware/model/version_regex/plugin_basic.py
@@ -1,0 +1,64 @@
+# @copyright@
+# Copyright (c) 2006 - 2019 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+#
+# @rocks@
+# Copyright (c) 2000 - 2010 The Regents of the University of California
+# All rights reserved. Rocks(r) v5.4 www.rocksclusters.org
+# https://github.com/Teradata/stacki/blob/master/LICENSE-ROCKS.txt
+# @rocks@
+
+import stack.commands
+from stack.util import lowered, unique_everseen
+from stack.exception import ArgRequired, ParamRequired, ParamError
+
+class Plugin(stack.commands.Plugin):
+	"""Attempts to disassociate version_regexes from models."""
+
+	def provides(self):
+		return "basic"
+
+	def validate_args(self, args):
+		"""We require the model names to be passed as arguments."""
+		# Require model names
+		if not args:
+			raise ArgRequired(cmd = self.owner, arg = "models")
+
+	def validate_make(self, make):
+		"""Require a make and make sure it exists."""
+		# The make must be provided
+		if not make:
+			raise ParamRequired(cmd = self.owner, param = "make")
+		# The make must exist
+		if not self.owner.make_exists(make = make):
+			raise ParamError(
+				cmd = self.owner,
+				param = "make",
+				msg = f"The make {make} does not exist.",
+			)
+
+	def run(self, args):
+		params, args = args
+		self.validate_args(args = args)
+		# Lowercase all args and remove any duplicates.
+		args = tuple(unique_everseen(lowered(args)))
+
+		make, = lowered(
+			self.owner.fillParams(names = [("make", "")], params = params)
+		)
+		self.validate_make(make = make)
+
+		# The models must exist for the given make.
+		self.owner.ensure_models_exist(models = args, make = make)
+
+		# disassociate the models from version_regexes
+		self.owner.db.execute(
+			"""
+			UPDATE firmware_model
+				INNER JOIN firmware_make ON firmware_make.id = firmware_model.make_id
+			SET firmware_model.version_regex_id=NULL WHERE firmware_model.name IN %s AND firmware_make.name=%s
+			""",
+			(args, make),
+		)

--- a/common/src/stack/command/stack/commands/remove/firmware/version_regex/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/firmware/version_regex/__init__.py
@@ -1,0 +1,29 @@
+# @copyright@
+# Copyright (c) 2006 - 2019 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+#
+# @rocks@
+# Copyright (c) 2000 - 2010 The Regents of the University of California
+# All rights reserved. Rocks(r) v5.4 www.rocksclusters.org
+# https://github.com/Teradata/stacki/blob/master/LICENSE-ROCKS.txt
+# @rocks@
+
+import stack.commands
+
+class Command(stack.commands.remove.firmware.command):
+	"""
+	Removes firmware version_regexes from the stacki database.
+
+	<arg type='string' name='version_regexes'>
+	One or more version_regexes to remove.
+	</arg>
+
+	<example cmd="remove firmware version_regex mellanox_version intel_version">
+	Removes the mellanox_version and intel_version version_regexes from the database.
+	</example>
+	"""
+
+	def run(self, params, args):
+		self.runPlugins(args = args)

--- a/common/src/stack/command/stack/commands/remove/firmware/version_regex/plugin_basic.py
+++ b/common/src/stack/command/stack/commands/remove/firmware/version_regex/plugin_basic.py
@@ -1,0 +1,33 @@
+# @copyright@
+# Copyright (c) 2006 - 2019 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+#
+# @rocks@
+# Copyright (c) 2000 - 2010 The Regents of the University of California
+# All rights reserved. Rocks(r) v5.4 www.rocksclusters.org
+# https://github.com/Teradata/stacki/blob/master/LICENSE-ROCKS.txt
+# @rocks@
+
+import stack.commands
+from stack.util import lowered, unique_everseen
+from stack.exception import ArgRequired
+
+class Plugin(stack.commands.Plugin):
+	"""Attempts to remove version_regexes."""
+
+	def provides(self):
+		return "basic"
+
+	def run(self, args):
+		# Require version_regex names
+		if not args:
+			raise ArgRequired(cmd = self.owner, arg = "version_regexes")
+		# lowercase all args and remove any duplicates
+		args = tuple(unique_everseen(lowered(args)))
+		# The version_regexes must exist
+		self.owner.ensure_regexes_exist(names = args)
+
+		# remove the version_regexes
+		self.owner.db.execute("DELETE FROM firmware_version_regex WHERE name IN %s", (args,))

--- a/common/src/stack/command/stack/commands/set/firmware/__init__.py
+++ b/common/src/stack/command/stack/commands/set/firmware/__init__.py
@@ -1,0 +1,17 @@
+# @copyright@
+# Copyright (c) 2006 - 2019 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+#
+# @rocks@
+# Copyright (c) 2000 - 2010 The Regents of the University of California
+# All rights reserved. Rocks(r) v5.4 www.rocksclusters.org
+# https://github.com/Teradata/stacki/blob/master/LICENSE-ROCKS.txt
+# @rocks@
+
+import stack.commands
+from stack.argument_processors.firmware import FirmwareArgumentProcessor
+
+class command(stack.commands.set.command, FirmwareArgumentProcessor):
+	pass

--- a/common/src/stack/command/stack/commands/set/firmware/make/version_regex/__init__.py
+++ b/common/src/stack/command/stack/commands/set/firmware/make/version_regex/__init__.py
@@ -1,0 +1,33 @@
+# @copyright@
+# Copyright (c) 2006 - 2019 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+#
+# @rocks@
+# Copyright (c) 2000 - 2010 The Regents of the University of California
+# All rights reserved. Rocks(r) v5.4 www.rocksclusters.org
+# https://github.com/Teradata/stacki/blob/master/LICENSE-ROCKS.txt
+# @rocks@
+
+import stack.commands
+
+class Command(stack.commands.set.firmware.command):
+	"""
+	Associates a firmware version_regex with one or more makes.
+
+	<arg type='string' name='makes'>
+	One or more makes to associate the version_regex with.
+	</arg>
+
+	<param type='string' name='version_regex'>
+	The name of the version_regex to associate with the provided makes.
+	</param>
+
+	<example cmd="set firmware make version_regex mellanox version_regex=mellanox_version">
+	Sets the firmware make mellanox to use the mellanox_version regex when parsing version numbers.
+	</example>
+	"""
+
+	def run(self, params, args):
+		self.runPlugins(args = (params, args))

--- a/common/src/stack/command/stack/commands/set/firmware/make/version_regex/plugin_basic.py
+++ b/common/src/stack/command/stack/commands/set/firmware/make/version_regex/plugin_basic.py
@@ -1,0 +1,52 @@
+# @copyright@
+# Copyright (c) 2006 - 2019 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+#
+# @rocks@
+# Copyright (c) 2000 - 2010 The Regents of the University of California
+# All rights reserved. Rocks(r) v5.4 www.rocksclusters.org
+# https://github.com/Teradata/stacki/blob/master/LICENSE-ROCKS.txt
+# @rocks@
+
+import stack.commands
+from stack.util import lowered, unique_everseen
+from stack.exception import ArgRequired, ParamRequired, ParamError
+
+class Plugin(stack.commands.Plugin):
+	"""Attempts to associate a version_regex with makes."""
+
+	def provides(self):
+		return "basic"
+
+	def run(self, args):
+		params, args = args
+		version_regex, = lowered(
+			self.owner.fillParams(names = [("version_regex", "")], params = params)
+		)
+		# Require make names
+		if not args:
+			raise ArgRequired(cmd = self.owner, arg = "makes")
+
+		args = tuple(unique_everseen(lowered(args)))
+		# The makes must exist
+		self.owner.ensure_makes_exist(makes = args)
+		# A version_regex is required
+		if not version_regex:
+			raise ParamRequired(cmd = self.owner, param = "version_regex")
+		# The version_regex must exist
+		if not self.owner.version_regex_exists(name = version_regex):
+			raise ParamError(
+				cmd = self.owner,
+				param = 'version_regex',
+				msg = f'The version_regex {version_regex} does not exist in the database.',
+			)
+
+		# get the version_regex ID
+		version_regex_id = self.owner.get_version_regex_id(name = version_regex)
+		# associate the makes with the version_regex
+		self.owner.db.execute(
+			"UPDATE firmware_make SET version_regex_id=%s WHERE name in %s",
+			(version_regex_id, args),
+		)

--- a/common/src/stack/command/stack/commands/set/firmware/model/version_regex/__init__.py
+++ b/common/src/stack/command/stack/commands/set/firmware/model/version_regex/__init__.py
@@ -1,0 +1,37 @@
+# @copyright@
+# Copyright (c) 2006 - 2019 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+#
+# @rocks@
+# Copyright (c) 2000 - 2010 The Regents of the University of California
+# All rights reserved. Rocks(r) v5.4 www.rocksclusters.org
+# https://github.com/Teradata/stacki/blob/master/LICENSE-ROCKS.txt
+# @rocks@
+
+import stack.commands
+
+class Command(stack.commands.set.firmware.command):
+	"""
+	Associates a firmware version_regex with one or more models
+
+	<arg type='string' name='models'>
+	One or more models to associate the version_regex with.
+	</arg>
+
+	<param type='string' name='make'>
+	The make of the provided models.
+	</param>
+
+	<param type='string' name='version_regex'>
+	The name of the version_regex to associate with the provided models.
+	</param>
+
+	<example cmd="set firmware make version_regex m7800 m6036 make=mellanox version_regex=mellanox_version">
+	Sets the firmware models m7800 and m6036 for make mellanox to use the mellanox_version regex when parsing version numbers.
+	</example>
+	"""
+
+	def run(self, params, args):
+		self.runPlugins(args = (params, args))

--- a/common/src/stack/command/stack/commands/set/firmware/model/version_regex/plugin_basic.py
+++ b/common/src/stack/command/stack/commands/set/firmware/model/version_regex/plugin_basic.py
@@ -1,0 +1,72 @@
+# @copyright@
+# Copyright (c) 2006 - 2019 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+#
+# @rocks@
+# Copyright (c) 2000 - 2010 The Regents of the University of California
+# All rights reserved. Rocks(r) v5.4 www.rocksclusters.org
+# https://github.com/Teradata/stacki/blob/master/LICENSE-ROCKS.txt
+# @rocks@
+
+import stack.commands
+from stack.util import lowered, unique_everseen
+from stack.exception import ArgRequired, ParamRequired, ParamError
+
+class Plugin(stack.commands.Plugin):
+	"""Attempts to associate a version_regex with models."""
+
+	def provides(self):
+		return "basic"
+
+	def run(self, args):
+		params, args = args
+		make, version_regex, = lowered(
+			self.owner.fillParams(
+				names = [
+					("make", ""),
+					("version_regex", ""),
+				],
+				params = params,
+			),
+		)
+		# Require model names
+		if not args:
+			raise ArgRequired(cmd = self.owner, arg = "models")
+
+		args = tuple(unique_everseen(lowered(args)))
+		# The models must exist
+		self.owner.ensure_models_exist(models = args, make = make)
+		# A make is required
+		if not make:
+			raise ParamRequired(cmd = self.owner, param = "make")
+		# The make must exist
+		if not self.owner.make_exists(make = make):
+			raise ParamError(
+				cmd = self.owner,
+				param = "make",
+				msg = f"The make {make} does not exist.",
+			)
+		# A version_regex is required
+		if not version_regex:
+			raise ParamRequired(cmd = self.owner, param = "version_regex")
+		# The version_regex must exist
+		if not self.owner.version_regex_exists(name = version_regex):
+			raise ParamError(
+				cmd = self.owner,
+				param = "version_regex",
+				msg = f"The version_regex {version_regex} does not exist in the database.",
+			)
+
+		# get the version_regex ID
+		version_regex_id = self.owner.get_version_regex_id(name = version_regex)
+		# associate the models with the version_regex
+		self.owner.db.execute(
+			"""
+			UPDATE firmware_model
+				INNER JOIN firmware_make ON firmware_make.id = firmware_model.make_id
+			SET firmware_model.version_regex_id=%s WHERE firmware_model.name IN %s AND firmware_make.name=%s
+			""",
+			(version_regex_id, args, make),
+		)

--- a/common/src/stack/pylib/stack/util.py
+++ b/common/src/stack/pylib/stack/util.py
@@ -167,3 +167,7 @@ def unique_everseen(iterable, key=None):
 			if k not in seen:
 				seen_add(k)
 				yield element
+
+def lowered(iterable):
+	"""Return a generator that lowercases all strings in the provided iterable."""
+	return (string.lower() for string in iterable)

--- a/test-framework/test-suites/unit/tests/command/stack/commands/add/firmware/version_regex/test_command_stack_commands_add_firmware_version_regex__init__.py
+++ b/test-framework/test-suites/unit/tests/command/stack/commands/add/firmware/version_regex/test_command_stack_commands_add_firmware_version_regex__init__.py
@@ -1,0 +1,30 @@
+from unittest.mock import patch
+import pytest
+from stack.commands.add.firmware.version_regex import Command
+
+class TestAddFirmwareVersionRegexCommand:
+	"""A test case to hold the tests for the add firmware version_regex stacki Command class."""
+
+	class CommandUnderTest(Command):
+		"""A class derived from the Command class under test used to override __init__.
+
+		This allows easier instantiation for testing purposes by excluding the base Command
+		class initialization code.
+		"""
+		def __init__(self):
+			pass
+
+	@pytest.fixture
+	def command(self):
+		"""Fixture to create and return a Command class instance for testing."""
+		return self.CommandUnderTest()
+
+	@patch.object(target = Command, attribute = "runPlugins", autospec = True)
+	def test_run(self, mock_runPlugins, command):
+		"""Test that run will run the plugins passing through the args and params."""
+		mock_params = {"foo": "bar", "baz": "bag"}
+		mock_args = ["foo", "bar", "baz"]
+
+		command.run(params = mock_params, args = mock_args)
+
+		mock_runPlugins.assert_called_once_with(command, args = (mock_params, mock_args))

--- a/test-framework/test-suites/unit/tests/command/stack/commands/add/firmware/version_regex/test_command_stack_commands_add_firmware_version_regex_plugin_basic.py
+++ b/test-framework/test-suites/unit/tests/command/stack/commands/add/firmware/version_regex/test_command_stack_commands_add_firmware_version_regex_plugin_basic.py
@@ -1,0 +1,324 @@
+from unittest.mock import create_autospec, patch, ANY
+import pytest
+from stack.commands import DatabaseConnection
+from stack.commands.add.firmware import command
+from stack.commands.add.firmware.version_regex.plugin_basic import Plugin
+from stack.exception import ArgError, ParamError, StackError
+
+class TestAddVersionRegexBasicPlugin:
+	"""A test case for the add firmware version_regex basic plugin."""
+
+	@pytest.fixture
+	def basic_plugin(self):
+		"""A fixture that returns the plugin instance for use in tests.
+
+		This sets up the required mocks needed to construct the plugin class.
+		"""
+		mock_command = create_autospec(
+			spec = command,
+			instance = True,
+		)
+		mock_command.db = create_autospec(
+			spec = DatabaseConnection,
+			spec_set = True,
+			instance = True,
+		)
+		return Plugin(command = mock_command)
+
+	def test_provides(self, basic_plugin):
+		"""Make sure the plugin returns the correct provides information."""
+		assert basic_plugin.provides() == "basic"
+
+	def test_validate_args(self, basic_plugin):
+		"""Test that validate_args works if the args list has one element."""
+		basic_plugin.validate_args(args = ["foo"])
+
+	@pytest.mark.parametrize("test_input", ([], ["foo", "bar"]))
+	def test_validate_args_failure(self, test_input, basic_plugin):
+		"""Test that validate_args fails with bad input."""
+		with pytest.raises(ArgError):
+			basic_plugin.validate_args(args = test_input)
+
+	def test_validate_regex(self, basic_plugin):
+		"""Test that validate_regex works if the regex provided is valid."""
+		basic_plugin.validate_regex(regex = "(foo)bar")
+
+	@pytest.mark.parametrize("test_input", ("", "(", ")", "(foobar"))
+	def test_validate_regex_failure(self, test_input, basic_plugin):
+		"""Test that validate_regex fails with bad input."""
+		with pytest.raises(ArgError):
+			basic_plugin.validate_regex(regex = test_input)
+
+	def test_validate_name(self, basic_plugin):
+		"""Test that validate_name works if the name provided is not empty and is unique."""
+		basic_plugin.owner.version_regex_exists.return_value = False
+		mock_name = "foo"
+
+		basic_plugin.validate_name(name = mock_name)
+
+		basic_plugin.owner.version_regex_exists.assert_called_once_with(name = mock_name)
+
+	@pytest.mark.parametrize(
+		"test_input, return_value",
+		(
+			("", False),
+			("foo", True),
+		)
+	)
+	def test_validate_name_failure(self, test_input, return_value, basic_plugin):
+		"""Test that validate_name fails with bad input."""
+		basic_plugin.owner.version_regex_exists.return_value = return_value
+
+		with pytest.raises(ParamError):
+			basic_plugin.validate_name(name = test_input)
+
+	def test_validate_make(self, basic_plugin):
+		"""Test that validate_make works if the make provided is not empty and exists."""
+		basic_plugin.owner.make_exists.return_value = True
+		mock_make = "foo"
+
+		basic_plugin.validate_make(make = mock_make)
+
+		basic_plugin.owner.make_exists.assert_called_once_with(make = mock_make)
+
+	@pytest.mark.parametrize(
+		"test_input, return_value",
+		(
+			("", True),
+			("foo", False),
+		)
+	)
+	def test_validate_make_failure(self, test_input, return_value, basic_plugin):
+		"""Test that validate_make fails with bad input."""
+		basic_plugin.owner.make_exists.return_value = return_value
+
+		with pytest.raises(ParamError):
+			basic_plugin.validate_make(make = test_input)
+
+	@patch(target = "stack.commands.add.firmware.version_regex.plugin_basic.unique_everseen", autospec = True)
+	@patch(target = "stack.commands.add.firmware.version_regex.plugin_basic.ExitStack", autospec = True)
+	@patch.object(target = Plugin, attribute = "validate_make", autospec = True)
+	@patch.object(target = Plugin, attribute = "validate_name", autospec = True)
+	@patch.object(target = Plugin, attribute = "validate_regex", autospec = True)
+	@patch.object(target = Plugin, attribute = "validate_args", autospec = True)
+	def test_run(
+		self,
+		mock_validate_args,
+		mock_validate_regex,
+		mock_validate_name,
+		mock_validate_make,
+		mock_exit_stack,
+		mock_unique_everseen,
+		basic_plugin,
+	):
+		"""Test that run performs the expected action in the case where all arguments and parameters are valid."""
+		mock_args = ["mock_regex"]
+		# We're using uppercase to ensure that lower is used correctly when processing args and params.
+		mock_models = ["MOCK_MODEL1", "MOCK_MODEL2", "MOCK_MODEL3"]
+		expected_models = tuple((string.lower() for string in mock_models))
+		mock_params = ["MOCK_NAME", "MOCK_DESCRIPTION", "MOCK_MAKE", ", ".join(mock_models)]
+		expected_name = mock_params[0].lower()
+		expected_make = mock_params[2].lower()
+		basic_plugin.owner.fillParams.return_value = mock_params
+		mock_unique_everseen.return_value = (string for string in expected_models)
+
+		basic_plugin.run(args = (mock_params, mock_args))
+
+		# Make sure the params were filled with defaults.
+		basic_plugin.owner.fillParams.assert_called_once_with(
+			names = [
+				("name", ""),
+				("description", ""),
+				("make", ""),
+				("models", ""),
+			],
+			params = mock_params,
+		)
+		# Expect all the validation functions to be called to validate params and args.
+		mock_validate_args.assert_called_once_with(basic_plugin, args = mock_args)
+		mock_validate_regex.assert_called_once_with(basic_plugin, regex = mock_args[0])
+		mock_validate_name.assert_called_once_with(basic_plugin, name = expected_name)
+		mock_validate_make.assert_called_once_with(basic_plugin, make = expected_make)
+		# Expect the models to be made unique, forced to lowercase, and validated.
+		assert expected_models == tuple(*mock_unique_everseen.call_args[0])
+		basic_plugin.owner.ensure_models_exist.assert_called_once_with(
+			make = expected_make,
+			models = expected_models,
+		)
+		# Expect the DB entries to be made.
+		basic_plugin.owner.db.execute.assert_called_once_with(
+			ANY,
+			(mock_args[0], expected_name, mock_params[1]),
+		)
+		basic_plugin.owner.call.assert_called_once_with(
+			command = "set.firmware.model.version_regex",
+			args = [*expected_models, f"make={expected_make}", f"version_regex={expected_name}"]
+		)
+		# Make sure that ExitStack was used to guard against failures.
+		mock_exit_stack.return_value.__enter__.return_value.callback.assert_called_once_with(
+			basic_plugin.owner.call,
+			command = "remove.firmware.version_regex",
+			args = [expected_name],
+		)
+		mock_exit_stack.return_value.__enter__.return_value.pop_all.assert_called_once_with()
+
+	@patch(target = "stack.commands.add.firmware.version_regex.plugin_basic.unique_everseen", autospec = True)
+	@patch(target = "stack.commands.add.firmware.version_regex.plugin_basic.ExitStack", autospec = True)
+	@patch.object(target = Plugin, attribute = "validate_make", autospec = True)
+	@patch.object(target = Plugin, attribute = "validate_name", autospec = True)
+	@patch.object(target = Plugin, attribute = "validate_regex", autospec = True)
+	@patch.object(target = Plugin, attribute = "validate_args", autospec = True)
+	def test_run_no_models(
+		self,
+		mock_validate_args,
+		mock_validate_regex,
+		mock_validate_name,
+		mock_validate_make,
+		mock_exit_stack,
+		mock_unique_everseen,
+		basic_plugin,
+	):
+		"""Test that run performs the expected action in the case where all arguments and parameters are valid but not models are provided."""
+		mock_args = ["mock_regex"]
+		# We're using uppercase to ensure that lower is used correctly when processing args and params.
+		mock_params = ["MOCK_NAME", "MOCK_DESCRIPTION", "MOCK_MAKE", ""]
+		expected_name = mock_params[0].lower()
+		expected_make = mock_params[2].lower()
+		basic_plugin.owner.fillParams.return_value = mock_params
+
+		basic_plugin.run(args = (mock_params, mock_args))
+
+		# Make sure the params were filled with defaults.
+		basic_plugin.owner.fillParams.assert_called_once_with(
+			names = [
+				("name", ""),
+				("description", ""),
+				("make", ""),
+				("models", ""),
+			],
+			params = mock_params,
+		)
+		# Expect all the validation functions to be called to validate params and args.
+		mock_validate_args.assert_called_once_with(basic_plugin, args = mock_args)
+		mock_validate_regex.assert_called_once_with(basic_plugin, regex = mock_args[0])
+		mock_validate_name.assert_called_once_with(basic_plugin, name = expected_name)
+		mock_validate_make.assert_called_once_with(basic_plugin, make = expected_make)
+		# Expect the models to not be validated.
+		mock_unique_everseen.assert_not_called()
+		basic_plugin.owner.ensure_models_exist.assert_not_called()
+		# Expect the DB entries to be made.
+		basic_plugin.owner.db.execute.assert_called_once_with(
+			ANY,
+			(mock_args[0], expected_name, mock_params[1]),
+		)
+		basic_plugin.owner.call.assert_called_once_with(
+			command = "set.firmware.make.version_regex",
+			args = [expected_make, f"version_regex={expected_name}"]
+		)
+		# Make sure that ExitStack was used to guard against failures.
+		mock_exit_stack.return_value.__enter__.return_value.callback.assert_called_once_with(
+			basic_plugin.owner.call,
+			command = "remove.firmware.version_regex",
+			args = [expected_name],
+		)
+		mock_exit_stack.return_value.__enter__.return_value.pop_all.assert_called_once_with()
+
+	@pytest.mark.parametrize("failure_mock", ("validate_make", "validate_name", "validate_regex", "validate_args"))
+	@patch(target = "stack.commands.add.firmware.version_regex.plugin_basic.unique_everseen", autospec = True)
+	@patch(target = "stack.commands.add.firmware.version_regex.plugin_basic.ExitStack", autospec = True)
+	@patch.object(target = Plugin, attribute = "validate_make", autospec = True)
+	@patch.object(target = Plugin, attribute = "validate_name", autospec = True)
+	@patch.object(target = Plugin, attribute = "validate_regex", autospec = True)
+	@patch.object(target = Plugin, attribute = "validate_args", autospec = True)
+	def test_run_validation_errors(
+		self,
+		mock_validate_args,
+		mock_validate_regex,
+		mock_validate_name,
+		mock_validate_make,
+		mock_exit_stack,
+		mock_unique_everseen,
+		failure_mock,
+		basic_plugin,
+	):
+		"""Test that run fails when the parameters do not validate."""
+		mock_args = ["mock_regex"]
+		mock_params = ["MOCK_NAME", "MOCK_DESCRIPTION", "MOCK_MAKE", "MOCK_MODEL1, MOCK_MODEL2, MOCK_MODEL3"]
+		basic_plugin.owner.fillParams.return_value = mock_params
+		validation_function_mocks = {
+			"validate_args": mock_validate_args,
+			"validate_regex": mock_validate_regex,
+			"validate_name": mock_validate_name,
+			"validate_make": mock_validate_make,
+		}
+		# Set the appropriate mock call to fail
+		validation_function_mocks[failure_mock].side_effect = StackError("Test error")
+
+		with pytest.raises(StackError):
+			basic_plugin.run(args = (mock_params, mock_args))
+
+		# Make sure the database calls are not made if the arguments don't validate
+		basic_plugin.owner.db.execute.assert_not_called()
+
+	@patch(target = "stack.commands.add.firmware.version_regex.plugin_basic.unique_everseen", autospec = True)
+	@patch(target = "stack.commands.add.firmware.version_regex.plugin_basic.ExitStack", autospec = True)
+	@patch.object(target = Plugin, attribute = "validate_make", autospec = True)
+	@patch.object(target = Plugin, attribute = "validate_name", autospec = True)
+	@patch.object(target = Plugin, attribute = "validate_regex", autospec = True)
+	@patch.object(target = Plugin, attribute = "validate_args", autospec = True)
+	def test_run_model_validation_errors(
+		self,
+		mock_validate_args,
+		mock_validate_regex,
+		mock_validate_name,
+		mock_validate_make,
+		mock_exit_stack,
+		mock_unique_everseen,
+		basic_plugin,
+	):
+		"""Test that run fails when the models do not validate."""
+		mock_args = ["mock_regex"]
+		mock_params = ["MOCK_NAME", "MOCK_DESCRIPTION", "MOCK_MAKE", "MOCK_MODEL1, MOCK_MODEL2, MOCK_MODEL3"]
+		basic_plugin.owner.fillParams.return_value = mock_params
+		basic_plugin.owner.ensure_models_exist.side_effect = StackError("Test error")
+
+		with pytest.raises(StackError):
+			basic_plugin.run(args = (mock_params, mock_args))
+
+		# Make sure the database calls are not made if the arguments don't validate
+		basic_plugin.owner.db.execute.assert_not_called()
+
+	@pytest.mark.parametrize("mock_models", ("", "MOCK_MODEL1, MOCK_MODEL2, MOCK_MODEL3"))
+	@patch(target = "stack.commands.add.firmware.version_regex.plugin_basic.unique_everseen", autospec = True)
+	@patch(target = "stack.commands.add.firmware.version_regex.plugin_basic.ExitStack", autospec = True)
+	@patch.object(target = Plugin, attribute = "validate_make", autospec = True)
+	@patch.object(target = Plugin, attribute = "validate_name", autospec = True)
+	@patch.object(target = Plugin, attribute = "validate_regex", autospec = True)
+	@patch.object(target = Plugin, attribute = "validate_args", autospec = True)
+	def test_run_set_relation_fails(
+		self,
+		mock_validate_args,
+		mock_validate_regex,
+		mock_validate_name,
+		mock_validate_make,
+		mock_exit_stack,
+		mock_unique_everseen,
+		mock_models,
+		basic_plugin,
+	):
+		"""Test that run fails and cleans up when setting the relation to the make or model fails."""
+		mock_args = ["mock_regex"]
+		mock_params = ["MOCK_NAME", "MOCK_DESCRIPTION", "MOCK_MAKE", mock_models]
+		basic_plugin.owner.fillParams.return_value = mock_params
+		basic_plugin.owner.call.side_effect = StackError("Test error")
+
+		with pytest.raises(StackError):
+			basic_plugin.run(args = (mock_params, mock_args))
+
+		# Make sure the cleanup is setup to be run, and don't expect it to be dismissed because of the error.
+		mock_exit_stack.return_value.__enter__.return_value.callback.assert_called_once_with(
+			basic_plugin.owner.call,
+			command = "remove.firmware.version_regex",
+			args = [mock_params[0].lower()],
+		)
+		mock_exit_stack.return_value.__enter__.return_value.pop_all.assert_not_called()

--- a/test-framework/test-suites/unit/tests/command/stack/commands/list/firmware/version_regex/test_command_stack_commands_list_firmware_version_regex__init__.py
+++ b/test-framework/test-suites/unit/tests/command/stack/commands/list/firmware/version_regex/test_command_stack_commands_list_firmware_version_regex__init__.py
@@ -1,0 +1,49 @@
+from unittest.mock import patch, call
+import pytest
+from stack.commands.list.firmware.version_regex import Command
+
+class TestListFirmwareVersionRegexCommand:
+	"""A test case to hold the tests for the list firmware version_regex stacki Command class."""
+
+	class CommandUnderTest(Command):
+		"""A class derived from the Command class under test used to override __init__.
+
+		This allows easier instantiation for testing purposes by excluding the base Command
+		class initialization code.
+		"""
+		def __init__(self):
+			pass
+
+	@pytest.fixture
+	def command(self):
+		"""Fixture to create and return a Command class instance for testing."""
+		return self.CommandUnderTest()
+
+	@patch.object(target = Command, attribute = "endOutput", autospec = True)
+	@patch.object(target = Command, attribute = "addOutput", autospec = True)
+	@patch.object(target = Command, attribute = "beginOutput", autospec = True)
+	@patch.object(target = Command, attribute = "runPlugins", autospec = True)
+	def test_run(self, mock_runPlugins, mock_beginOutput, mock_addOutput, mock_endOutput, command):
+		"""Test that run will run the plugins, gather the results, and output them as expected."""
+		mock_header = ["name", "regex", "description"]
+		mock_first_value = ("foo", ["bar", "baz"])
+		mock_second_value = ("bag", ["fizz", "buzz"])
+		mock_runPlugins.return_value = (
+			(
+				"basic",
+				{
+					"keys": mock_header,
+					"values": [mock_first_value, mock_second_value],
+				},
+			),
+		)
+
+		command.run("unused", "unused")
+
+		mock_runPlugins.assert_called_once_with(command)
+		mock_beginOutput.assert_called_once_with(command)
+		assert [
+			call(command, owner = mock_first_value[0], vals = mock_first_value[1]),
+			call(command, owner = mock_second_value[0], vals = mock_second_value[1]),
+		] == mock_addOutput.mock_calls
+		mock_endOutput.assert_called_once_with(command, header = mock_header)

--- a/test-framework/test-suites/unit/tests/command/stack/commands/list/firmware/version_regex/test_command_stack_commands_list_firmware_version_regex_plugin_basic.py
+++ b/test-framework/test-suites/unit/tests/command/stack/commands/list/firmware/version_regex/test_command_stack_commands_list_firmware_version_regex_plugin_basic.py
@@ -1,0 +1,41 @@
+from unittest.mock import create_autospec, ANY
+import pytest
+from stack.commands import DatabaseConnection
+from stack.commands.list.firmware import command
+from stack.commands.list.firmware.version_regex.plugin_basic import Plugin
+
+class TestListVersionRegexBasicPlugin:
+	"""A test case for the list firmware version_regex basic plugin."""
+
+	@pytest.fixture
+	def basic_plugin(self):
+		"""A fixture that returns the plugin instance for use in tests.
+
+		This sets up the required mocks needed to construct the plugin class.
+		"""
+		mock_command = create_autospec(
+			spec = command,
+			instance = True,
+		)
+		mock_command.db = create_autospec(
+			spec = DatabaseConnection,
+			spec_set = True,
+			instance = True,
+		)
+		return Plugin(command = mock_command)
+
+	def test_provides(self, basic_plugin):
+		"""Ensure that provides returns 'basic'."""
+		assert basic_plugin.provides() == "basic"
+
+	def test_run(self, basic_plugin):
+		"""Test that run queries the DB as expected."""
+		basic_plugin.owner.db.select.return_value = [["foo", "bar", "baz"]]
+		expected_results = {
+			"keys": ["name", "regex", "description"],
+			"values": [(row[0], row[1:]) for row in basic_plugin.owner.db.select.return_value],
+		}
+
+		assert expected_results == basic_plugin.run(args = "unused")
+
+		basic_plugin.owner.db.select.assert_called_once_with(ANY)

--- a/test-framework/test-suites/unit/tests/command/stack/commands/remove/firmware/make/version_regex/test_command_stack_commands_remove_firmware_make_version_regex__init__.py
+++ b/test-framework/test-suites/unit/tests/command/stack/commands/remove/firmware/make/version_regex/test_command_stack_commands_remove_firmware_make_version_regex__init__.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch
+import pytest
+from stack.commands.remove.firmware.make.version_regex import Command
+
+class TestRemoveFirmwareMakeVersionRegexCommand:
+	"""A test case to hold the tests for the remove firmware make version_regex stacki Command class."""
+
+	class CommandUnderTest(Command):
+		"""A class derived from the Command class under test used to override __init__.
+
+		This allows easier instantiation for testing purposes by excluding the base Command
+		class initialization code.
+		"""
+		def __init__(self):
+			pass
+
+	@pytest.fixture
+	def command(self):
+		"""Fixture to create and return a Command class instance for testing."""
+		return self.CommandUnderTest()
+
+	@patch.object(target = Command, attribute = "runPlugins", autospec = True)
+	def test_run(self, mock_runPlugins, command):
+		"""Test that run will run the plugins passing through the args."""
+		mock_args = ["foo", "bar", "baz"]
+
+		command.run(params = "unused", args = mock_args)
+
+		mock_runPlugins.assert_called_once_with(command, args = mock_args)

--- a/test-framework/test-suites/unit/tests/command/stack/commands/remove/firmware/make/version_regex/test_command_stack_commands_remove_firmware_make_version_regex_plugin_basic.py
+++ b/test-framework/test-suites/unit/tests/command/stack/commands/remove/firmware/make/version_regex/test_command_stack_commands_remove_firmware_make_version_regex_plugin_basic.py
@@ -1,0 +1,67 @@
+from unittest.mock import create_autospec, ANY, patch
+import pytest
+from stack.commands import DatabaseConnection
+from stack.commands.remove.firmware import command
+from stack.exception import ArgRequired, CommandError
+from stack.commands.remove.firmware.make.version_regex.plugin_basic import Plugin
+
+class TestRemoveFirmwareMakeVersionRegexBasicPlugin:
+	"""A test case for the remove firmware make version_regex basic plugin."""
+
+	@pytest.fixture
+	def basic_plugin(self):
+		"""A fixture that returns the plugin instance for use in tests.
+
+		This sets up the required mocks needed to construct the plugin class.
+		"""
+		mock_command = create_autospec(
+			spec = command,
+			instance = True,
+		)
+		mock_command.db = create_autospec(
+			spec = DatabaseConnection,
+			spec_set = True,
+			instance = True,
+		)
+		return Plugin(command = mock_command)
+
+	def test_provides(self, basic_plugin):
+		"""Ensure that provides returns 'basic'."""
+		assert basic_plugin.provides() == "basic"
+
+	@patch(target = "stack.commands.remove.firmware.make.version_regex.plugin_basic.lowered", autospec = True)
+	@patch(target = "stack.commands.remove.firmware.make.version_regex.plugin_basic.unique_everseen", autospec = True)
+	def test_run(self, mock_unique_everseen, mock_lowered, basic_plugin):
+		"""Test that run updates the database as expected when all arguments are valid."""
+		mock_args = ["foo", "bar", "baz"]
+		expected_args = tuple(mock_args)
+		mock_unique_everseen.return_value = (arg for arg in mock_args)
+
+		basic_plugin.run(args = mock_args)
+
+		basic_plugin.owner.db.execute.assert_called_once_with(ANY, (expected_args,))
+		mock_lowered.assert_called_once_with(mock_args)
+		mock_unique_everseen.assert_called_once_with(mock_lowered.return_value)
+		basic_plugin.owner.ensure_makes_exist.assert_called_once_with(makes = expected_args)
+
+	@patch(target = "stack.commands.remove.firmware.make.version_regex.plugin_basic.lowered", autospec = True)
+	@patch(target = "stack.commands.remove.firmware.make.version_regex.plugin_basic.unique_everseen", autospec = True)
+	def test_run_missing_args(self, mock_unique_everseen, mock_lowered, basic_plugin):
+		"""Test that run fails if no args are passed."""
+		with pytest.raises(ArgRequired):
+			basic_plugin.run(args = [])
+
+		# Make sure the DB is not modified with bad arguments.
+		basic_plugin.owner.db.execute.assert_not_called()
+
+	@patch(target = "stack.commands.remove.firmware.make.version_regex.plugin_basic.lowered", autospec = True)
+	@patch(target = "stack.commands.remove.firmware.make.version_regex.plugin_basic.unique_everseen", autospec = True)
+	def test_run_makes_do_not_exist(self, mock_unique_everseen, mock_lowered, basic_plugin):
+		"""Test that run fails if no ensure makes exist fails."""
+		basic_plugin.owner.ensure_makes_exist.side_effect = CommandError(cmd = basic_plugin.owner, msg = "Test error")
+
+		with pytest.raises(CommandError):
+			basic_plugin.run(args = ["foo", "bar", "baz"])
+
+		# Make sure the DB is not modified with bad arguments.
+		basic_plugin.owner.db.execute.assert_not_called()

--- a/test-framework/test-suites/unit/tests/command/stack/commands/remove/firmware/model/version_regex/test_command_stack_commands_remove_firmware_model_version_regex__init__.py
+++ b/test-framework/test-suites/unit/tests/command/stack/commands/remove/firmware/model/version_regex/test_command_stack_commands_remove_firmware_model_version_regex__init__.py
@@ -1,0 +1,30 @@
+from unittest.mock import patch
+import pytest
+from stack.commands.remove.firmware.model.version_regex import Command
+
+class TestRemoveFirmwareModelVersionRegexCommand:
+	"""A test case to hold the tests for the remove firmware model version_regex stacki Command class."""
+
+	class CommandUnderTest(Command):
+		"""A class derived from the Command class under test used to override __init__.
+
+		This allows easier instantiation for testing purposes by excluding the base Command
+		class initialization code.
+		"""
+		def __init__(self):
+			pass
+
+	@pytest.fixture
+	def command(self):
+		"""Fixture to create and return a Command class instance for testing."""
+		return self.CommandUnderTest()
+
+	@patch.object(target = Command, attribute = "runPlugins", autospec = True)
+	def test_run(self, mock_runPlugins, command):
+		"""Test that run will run the plugins passing through the args."""
+		mock_args = ["foo", "bar", "baz"]
+		mock_params = {"fizz": "buzz"}
+
+		command.run(params = mock_params, args = mock_args)
+
+		mock_runPlugins.assert_called_once_with(command, args = (mock_params, mock_args))

--- a/test-framework/test-suites/unit/tests/command/stack/commands/remove/firmware/model/version_regex/test_command_stack_commands_remove_firmware_model_version_regex_plugin_basic.py
+++ b/test-framework/test-suites/unit/tests/command/stack/commands/remove/firmware/model/version_regex/test_command_stack_commands_remove_firmware_model_version_regex_plugin_basic.py
@@ -1,0 +1,120 @@
+from unittest.mock import create_autospec, ANY, patch, MagicMock, call
+import pytest
+from stack.commands import DatabaseConnection
+from stack.commands.remove.firmware import command
+from stack.exception import ArgRequired, ParamRequired, ParamError, CommandError
+from stack.commands.remove.firmware.model.version_regex.plugin_basic import Plugin
+
+class TestRemoveFirmwareModelVersionRegexBasicPlugin:
+	"""A test case for the remove firmware model version_regex basic plugin."""
+
+	@pytest.fixture
+	def basic_plugin(self):
+		"""A fixture that returns the plugin instance for use in tests.
+
+		This sets up the required mocks needed to construct the plugin class.
+		"""
+		mock_command = create_autospec(
+			spec = command,
+			instance = True,
+		)
+		mock_command.db = create_autospec(
+			spec = DatabaseConnection,
+			spec_set = True,
+			instance = True,
+		)
+		return Plugin(command = mock_command)
+
+	def test_provides(self, basic_plugin):
+		"""Ensure that provides returns "basic"."""
+		assert basic_plugin.provides() == "basic"
+
+	def test_validate_args(self, basic_plugin):
+		"""Test that validate args works when args are provided."""
+		basic_plugin.validate_args(args = ["foo", "bar", "baz"])
+
+	def test_validate_args_error(self, basic_plugin):
+		"""Test that validate args fails when args are not provided."""
+		with pytest.raises(ArgRequired):
+			basic_plugin.validate_args(args = [])
+
+	def test_validate_make(self, basic_plugin):
+		"""Test that validate_make works when the make name is provided and the make exists in the database."""
+		basic_plugin.owner.make_exists.return_value = True
+		mock_make = "foo"
+
+		basic_plugin.validate_make(make = mock_make)
+
+		basic_plugin.owner.make_exists.assert_called_once_with(make = mock_make)
+
+	def test_validate_make_empty_string(self, basic_plugin):
+		"""Test that validate_make fails when the make name is an empty string."""
+		with pytest.raises(ParamRequired):
+			basic_plugin.validate_make(make = "")
+
+	def test_validate_make_not_in_database(self, basic_plugin):
+		"""Test that validate_make fails when the make name is not present in the database."""
+		basic_plugin.owner.make_exists.return_value = False
+
+		with pytest.raises(ParamError):
+			basic_plugin.validate_make(make = "foo")
+
+	@patch.object(target = Plugin, attribute = "validate_make", autospec = True)
+	@patch.object(target = Plugin, attribute = "validate_args", autospec = True)
+	@patch(target = "stack.commands.remove.firmware.model.version_regex.plugin_basic.lowered", autospec = True)
+	@patch(target = "stack.commands.remove.firmware.model.version_regex.plugin_basic.unique_everseen", autospec = True)
+	def test_run(self, mock_unique_everseen, mock_lowered, mock_validate_args, mock_validate_make, basic_plugin):
+		"""Test that run updates the database as expected when all arguments are valid."""
+		mock_args = ["foo", "bar", "baz"]
+		mock_params = {"make": "fizz"}
+		expected_args = tuple(mock_args)
+		expected_param = mock_params["make"]
+		mock_unique_everseen.return_value = (arg for arg in mock_args)
+		# Since we don't care about the first return value, as it should be passed directly into unique_everseen(),
+		# we just use a MagicMock so we can do equality testing later in assert_called_once_with().
+		first_lowered_return = MagicMock()
+		mock_lowered.side_effect = (
+			first_lowered_return,
+			(make for make in mock_params.values()),
+		)
+
+		basic_plugin.run(args = (mock_params, mock_args))
+
+		# Ensure that the database update was performed
+		basic_plugin.owner.db.execute.assert_called_once_with(ANY, (expected_args, expected_param))
+		# Ensure that the expected calls happened for validating args and params.
+		assert [call(mock_args), call(basic_plugin.owner.fillParams.return_value)] == mock_lowered.mock_calls
+		mock_unique_everseen.assert_called_once_with(first_lowered_return)
+		basic_plugin.owner.ensure_models_exist.assert_called_once_with(models = expected_args, make = expected_param)
+		mock_validate_args.assert_called_once_with(basic_plugin, args = mock_args)
+		mock_validate_make.assert_called_once_with(basic_plugin, make = expected_param)
+
+	@pytest.mark.parametrize("failure_mock", ("validate_args", "validate_make", "ensure_models_exist"))
+	@patch.object(target = Plugin, attribute = "validate_make", autospec = True)
+	@patch.object(target = Plugin, attribute = "validate_args", autospec = True)
+	@patch(target = "stack.commands.remove.firmware.model.version_regex.plugin_basic.lowered", autospec = True)
+	@patch(target = "stack.commands.remove.firmware.model.version_regex.plugin_basic.unique_everseen", autospec = True)
+	def test_run_errors(
+		self,
+		mock_unique_everseen,
+		mock_lowered,
+		mock_validate_args,
+		mock_validate_make,
+		failure_mock,
+		basic_plugin,
+	):
+		"""Test that run fails if the arguments do not validate."""
+		mock_validation_functions = {
+			"validate_args": mock_validate_args,
+			"validate_make": mock_validate_make,
+			"ensure_models_exist": basic_plugin.owner.ensure_models_exist,
+		}
+		# Set the appropriate mock function to fail.
+		mock_validation_functions[failure_mock].side_effect = CommandError(cmd = basic_plugin.owner, msg = "Test failure")
+		mock_lowered.return_value = ("foo",)
+
+		with pytest.raises(CommandError):
+			basic_plugin.run(args = ({"foo": "bar"}, ["baz"]))
+
+		# Ensure that the database update was not performed due to argument and/or param errors
+		basic_plugin.owner.db.execute.assert_not_called()

--- a/test-framework/test-suites/unit/tests/command/stack/commands/remove/firmware/version_regex/test_command_stack_commands_remove_firmware_version_regex__init__.py
+++ b/test-framework/test-suites/unit/tests/command/stack/commands/remove/firmware/version_regex/test_command_stack_commands_remove_firmware_version_regex__init__.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch
+import pytest
+from stack.commands.remove.firmware.version_regex import Command
+
+class TestRemoveFirmwareVersionRegexCommand:
+	"""A test case to hold the tests for the remove firmware version_regex stacki Command class."""
+
+	class CommandUnderTest(Command):
+		"""A class derived from the Command class under test used to override __init__.
+
+		This allows easier instantiation for testing purposes by excluding the base Command
+		class initialization code.
+		"""
+		def __init__(self):
+			pass
+
+	@pytest.fixture
+	def command(self):
+		"""Fixture to create and return a Command class instance for testing."""
+		return self.CommandUnderTest()
+
+	@patch.object(target = Command, attribute = "runPlugins", autospec = True)
+	def test_run(self, mock_runPlugins, command):
+		"""Test that run will run the plugins passing through the args."""
+		mock_args = ["foo", "bar", "baz"]
+
+		command.run(params = "unused", args = mock_args)
+
+		mock_runPlugins.assert_called_once_with(command, args = mock_args)

--- a/test-framework/test-suites/unit/tests/command/stack/commands/remove/firmware/version_regex/test_command_stack_commands_remove_firmware_version_regex_plugin_basic.py
+++ b/test-framework/test-suites/unit/tests/command/stack/commands/remove/firmware/version_regex/test_command_stack_commands_remove_firmware_version_regex_plugin_basic.py
@@ -1,0 +1,67 @@
+from unittest.mock import create_autospec, ANY, patch
+import pytest
+from stack.commands import DatabaseConnection
+from stack.commands.remove.firmware import command
+from stack.exception import ArgRequired, CommandError
+from stack.commands.remove.firmware.version_regex.plugin_basic import Plugin
+
+class TestRemoveFirmwareVersionRegexBasicPlugin:
+	"""A test case for the remove firmware version_regex basic plugin."""
+
+	@pytest.fixture
+	def basic_plugin(self):
+		"""A fixture that returns the plugin instance for use in tests.
+
+		This sets up the required mocks needed to construct the plugin class.
+		"""
+		mock_command = create_autospec(
+			spec = command,
+			instance = True,
+		)
+		mock_command.db = create_autospec(
+			spec = DatabaseConnection,
+			spec_set = True,
+			instance = True,
+		)
+		return Plugin(command = mock_command)
+
+	def test_provides(self, basic_plugin):
+		"""Ensure that provides returns 'basic'."""
+		assert basic_plugin.provides() == "basic"
+
+	@patch(target = "stack.commands.remove.firmware.version_regex.plugin_basic.lowered", autospec = True)
+	@patch(target = "stack.commands.remove.firmware.version_regex.plugin_basic.unique_everseen", autospec = True)
+	def test_run(self, mock_unique_everseen, mock_lowered, basic_plugin):
+		"""Test that run updates the database as expected when all arguments are valid."""
+		mock_args = ["foo", "bar", "baz"]
+		expected_args = tuple(mock_args)
+		mock_unique_everseen.return_value = (arg for arg in mock_args)
+
+		basic_plugin.run(args = mock_args)
+
+		basic_plugin.owner.db.execute.assert_called_once_with(ANY, (expected_args,))
+		mock_lowered.assert_called_once_with(mock_args)
+		mock_unique_everseen.assert_called_once_with(mock_lowered.return_value)
+		basic_plugin.owner.ensure_regexes_exist.assert_called_once_with(names = expected_args)
+
+	@patch(target = "stack.commands.remove.firmware.version_regex.plugin_basic.lowered", autospec = True)
+	@patch(target = "stack.commands.remove.firmware.version_regex.plugin_basic.unique_everseen", autospec = True)
+	def test_run_missing_args(self, mock_unique_everseen, mock_lowered, basic_plugin):
+		"""Test that run fails if no args are passed."""
+		with pytest.raises(ArgRequired):
+			basic_plugin.run(args = [])
+
+		#  sure the DB is not modified with bad arguments.
+		basic_plugin.owner.db.execute.assert_not_called()
+
+	@patch(target = "stack.commands.remove.firmware.version_regex.plugin_basic.lowered", autospec = True)
+	@patch(target = "stack.commands.remove.firmware.version_regex.plugin_basic.unique_everseen", autospec = True)
+	def test_run_s_do_not_exist(self, mock_unique_everseen, mock_lowered, basic_plugin):
+		"""Test that run fails if no ensure s exist fails."""
+		basic_plugin.owner.ensure_regexes_exist.side_effect = CommandError(cmd = basic_plugin.owner, msg = "Test error")
+
+		with pytest.raises(CommandError):
+			basic_plugin.run(args = ["foo", "bar", "baz"])
+
+		#  sure the DB is not modified with bad arguments.
+		basic_plugin.owner.db.execute.assert_not_called()

--- a/test-framework/test-suites/unit/tests/pylib/stack/test_pylib_stack_util.py
+++ b/test-framework/test-suites/unit/tests/pylib/stack/test_pylib_stack_util.py
@@ -91,3 +91,7 @@ class TestUtil:
 	def test_unique_everseen(self, key, test_input, expected):
 		"""Test that duplicates are removed and order is preserved."""
 		assert expected == tuple(stack.util.unique_everseen(test_input, key = key))
+
+	def test_lowered(self):
+		"""Expect lowered to lowercase all strings in an interable."""
+		assert ["foo", "bar", "baz"] == list(stack.util.lowered(["FOO", "BAR", "BAZ"]))


### PR DESCRIPTION
This is the next follow on chunk after #569 that adds the commands for managing the firmware version_regex table. This doesn't really work on its own, but was a logical small chunk to break out for review. Some of the empty, or mostly empty, `__init__.py` files in this changeset will be filled in as later commands are added in subsequent PRs.

The idea behind tracking these is to allow for telling stacki how to parse a potentially verbose version string returned from hardware, as well as how to validate at some level that the user typed in a reasonably valid version number when adding new firmware files.

There is a distinction made between regexes associated to makes versus models. You could set a regex for the entire Dell make, for example, as well as one for a specific model of device (like x1052). The Stacki code will prefer the x1052 specific one when parsing version numbers for the Dell x1052 device over the general Dell one.

I've made these optional, but I will be adding them for the hardware we have tested thus far (Dell x1052 and Mellanox m6036 and m7800) in the initial DB data initialization node in a later PR.