### PR TITLE
Feature/better web reportsys

### DIFF
--- a/common/src/stack/ws/setup/ws_setup.sh
+++ b/common/src/stack/ws/setup/ws_setup.sh
@@ -27,6 +27,7 @@ DJANGO_SETTINGS_MODULE=stack.restapi.settings \
 # Blacklist commands that must not be run
 /opt/stack/bin/stack add api blacklist command command="list host message"
 /opt/stack/bin/stack add api blacklist command command="add api sudo command"
+/opt/stack/bin/stack add api blacklist command command="report system"
 
 # Commands that require "sudo" to be run
 STACK_CMDS=( "sync *"	\


### PR DESCRIPTION
~~This makes report system a sudo command so that all it's tests can run properly when run by the web client (this shouldn't be a security problem but if anyone can find one let me know) and fixes the paths in two tests so they run under the apache user. The goal of this was so that when the web service runs report-system, the actual test output is given vs just a message saying one or more tests failed. This also depends on my other branch `bugfix/get-your-output` which has some needed changes to the ws views file.~~

After discussion of the security implications of making report system a sudo command, it was decided to just blacklist from the web service for now until it can be found how to make it work as a non root user.