### PR TITLE
FEATURE: Relocate the host interface `alias` commands

### DIFF
--- a/common/src/stack/command/stack/commands/add/host/interface/alias/__init__.py
+++ b/common/src/stack/command/stack/commands/add/host/interface/alias/__init__.py
@@ -17,7 +17,7 @@ from stack.exception import ArgRequired, ArgUnique, CommandError
 
 class Command(stack.commands.add.host.command):
 	"""
-	Adds an alias to a host
+	Adds an alias to a host interface.
 
 	<arg type='string' name='host'>
 	Host name of machine
@@ -31,7 +31,7 @@ class Command(stack.commands.add.host.command):
 	Alias for the host.
 	</param>
 
-	<example cmd='add host alias backend-0-0 interface=eth0 alias=b00'>
+	<example cmd='add host interface alias backend-0-0 interface=eth0 alias=b00'>
 	Add a host alias "b00" to host "backend-0-0" on interface "eth0".
 	</example>
 	"""
@@ -39,12 +39,12 @@ class Command(stack.commands.add.host.command):
 	def run(self, params, args):
 		host = self.getSingleHost(args)
 
-		(alias, interface) = self.fillParams([
+		alias, interface = self.fillParams([
 			('alias', None, True),
 			('interface', None, True)
 		])
 
-		if any(alias in hostnames for hostnames in self.getHostnames()):
+		if alias in self.getHostnames():
 			raise CommandError(self, 'hostname already in use')
 
 		if alias.isdigit():
@@ -56,27 +56,23 @@ class Command(stack.commands.add.host.command):
 		except socket.error:
 			pass
 
-		for dict in self.call('list.host.alias'):
-			if (
-				alias == dict['alias'] and
-				interface == dict['interface'] and
-			 	host == dict['host']
+		for row in self.call('list.host.interface.alias'):
+			if alias == row['alias'] and (
+				host != row['host'] or interface == row['interface']
 			):
-				raise CommandError(self, 'alias "%s" exists' % alias)
-			
-			if alias == dict['alias'] and host != dict['host']:
-				raise CommandError(self, 'alias "%s" exists' % alias)
+				raise CommandError(self, f'alias "{alias}" exists')
 
 		rows = self.db.select("""
-			id from networks where
-			node = (select id from nodes where name=%s)
-			and device=%s
+			networks.id
+			FROM networks
+			LEFT JOIN nodes ON networks.node = nodes.id
+			WHERE nodes.name = %s AND networks.device = %s
 		""", (host, interface))
-		
+
 		if len(rows) == 0:
 			raise CommandError(self, 'interface does not exist')
 
 		self.db.execute(
-			'insert into aliases (network, name) values (%s, %s)',
+			'INSERT INTO aliases(network, name) VALUES (%s, %s)',
 			(rows[0][0], alias)
 		)

--- a/common/src/stack/command/stack/commands/dump/host/__init__.py
+++ b/common/src/stack/command/stack/commands/dump/host/__init__.py
@@ -21,7 +21,7 @@ class Command(stack.commands.dump.command):
 				groups[row['host']] = row['groups'].split()
 
 		aliases = defaultdict(lambda: defaultdict(list))
-		for row in self.call('list.host.alias'):
+		for row in self.call('list.host.interface.alias'):
 			aliases[row['host']][row['interface']].append(row['alias'])
 
 		interfaces = defaultdict(list)

--- a/common/src/stack/command/stack/commands/load/host/__init__.py
+++ b/common/src/stack/command/stack/commands/load/host/__init__.py
@@ -43,7 +43,7 @@ class Command(stack.commands.load.command):
 			self.stack('add.host.interface', name, **params)
 			
 			for alias in interface.get('alias'):
-				self.stack('add.host.alias', name, 
+				self.stack('add.host.interface.alias', name, 
 					   {'alias': alias},
 					   {'interface': interface['interface']})
 

--- a/common/src/stack/command/stack/commands/load/plugin_host.py
+++ b/common/src/stack/command/stack/commands/load/plugin_host.py
@@ -60,7 +60,7 @@ class Plugin(stack.commands.Plugin):
 				for a in aliases:
 					params = {'interface': i.get('interface'),
 						  'alias'    : a}
-					self.owner.stack('add.host.alias', host, **params)
+					self.owner.stack('add.host.interface.alias', host, **params)
 
 			self.owner.load_attr(h.get('attr'), host)
 			self.owner.load_controller(h.get('controller'), host)

--- a/common/src/stack/command/stack/commands/report/host/__init__.py
+++ b/common/src/stack/command/stack/commands/report/host/__init__.py
@@ -45,7 +45,7 @@ class Command(command):
 			zones[row['network']] = row['zone']
 
 		# Populate the host -> interface -> aliases map
-		for row in self.call('list.host.alias'):
+		for row in self.call('list.host.interface.alias'):
 			host = row['host']
 			interface = row['interface']
 			if host not in aliases:

--- a/common/src/stack/command/stack/commands/report/zones/__init__.py
+++ b/common/src/stack/command/stack/commands/report/zones/__init__.py
@@ -70,7 +70,7 @@ class Command(stack.commands.report.command,
 
 		networks = self.call('list.network', [ 'dns=true' ])
 		hosts = self.call("list.host.interface", ["expanded=true"])
-		aliases = self.call("list.host.alias")
+		aliases = self.call("list.host.interface.alias")
 
 		zones = []
 		for network in networks:

--- a/test-framework/test-suites/integration/tests/add/test_add_host_interface_alias.py
+++ b/test-framework/test-suites/integration/tests/add/test_add_host_interface_alias.py
@@ -4,32 +4,32 @@ import pytest
 import json
 
 
-class TestAddHostAlias:
+class TestAddHostInterfaceAlias:
 	# split possible?
 	def test_to_multiple_interfaces_across_multiple_hosts(self, host, revert_etc, test_file):
 		result = host.run(f'stack load hostfile file={test_file("add/add_host_alias_hostfile.csv")}')
 		assert result.rc == 0
 
-		result = host.run('stack add host alias backend-0-0 alias=test0-eth0 interface=eth0')
+		result = host.run('stack add host interface alias backend-0-0 alias=test0-eth0 interface=eth0')
 		assert result.rc == 0
 
 		# one alias in list
-		result = host.run('stack list host alias output-format=json')
+		result = host.run('stack list host interface alias output-format=json')
 		assert result.rc == 0
 
 		with open(test_file('add/add_host_alias_one_alias.json')) as output:
 			expected_output = output.read()
 		assert json.loads(result.stdout) == json.loads(expected_output)
 
-		result = host.run('stack add host alias backend-0-0 alias=test0-eth1 interface=eth1')
+		result = host.run('stack add host interface alias backend-0-0 alias=test0-eth1 interface=eth1')
 		assert result.rc == 0
-		result = host.run('stack add host alias backend-0-1 alias=test1-eth0 interface=eth0')
+		result = host.run('stack add host interface alias backend-0-1 alias=test1-eth0 interface=eth0')
 		assert result.rc == 0
-		result = host.run('stack add host alias backend-0-1 alias=test1-eth1 interface=eth1')
+		result = host.run('stack add host interface alias backend-0-1 alias=test1-eth1 interface=eth1')
 		assert result.rc == 0
 
 		# four aliases in list
-		result = host.run('stack list host alias output-format=json')
+		result = host.run('stack list host interface alias output-format=json')
 		assert result.rc == 0
 
 		with open(test_file('add/add_host_alias_four_aliases.json')) as output:
@@ -38,24 +38,24 @@ class TestAddHostAlias:
 
 	def test_add_numeric_alias(self, host, add_host_with_interface):
 		# add numeric alias (invalid)
-		result = host.run('stack add host alias backend-0-0 alias=42 interface=eth0')
+		result = host.run('stack add host interface alias backend-0-0 alias=42 interface=eth0')
 		assert result.rc != 0
 
 		# no aliases in list
-		result = host.run('stack list host alias output-format=json')
+		result = host.run('stack list host interface alias output-format=json')
 		assert result.rc == 0
 		assert result.stdout.strip() == ''
 
 	def test_add_duplicate_alias_same_host_interface(self, host, add_host_with_interface, test_file):
-		result = host.run('stack add host alias backend-0-0 alias=test0-eth0 interface=eth0')
+		result = host.run('stack add host interface alias backend-0-0 alias=test0-eth0 interface=eth0')
 		assert result.rc == 0
 
 		# add same alias again (invalid)
-		result = host.run('stack add host alias backend-0-0 alias=test0-eth0 interface=eth0')
+		result = host.run('stack add host interface alias backend-0-0 alias=test0-eth0 interface=eth0')
 		assert result.rc != 0
 
 		# one alias in list
-		result = host.run('stack list host alias output-format=json')
+		result = host.run('stack list host interface alias output-format=json')
 		assert result.rc == 0
 
 		with open(test_file('add/add_host_alias_one_alias.json')) as output:
@@ -65,13 +65,13 @@ class TestAddHostAlias:
 	def test_add_duplicate_alias_same_host(self, host, revert_etc, test_file):
 		result = host.run(f'stack load hostfile file={test_file("add/add_host_alias_hostfile.csv")}')
 		assert result.rc == 0
-		result = host.run('stack add host alias backend-0-0 alias=test interface=eth0')
+		result = host.run('stack add host interface alias backend-0-0 alias=test interface=eth0')
 		assert result.rc == 0
-		result = host.run('stack add host alias backend-0-0 alias=test interface=eth1')
+		result = host.run('stack add host interface alias backend-0-0 alias=test interface=eth1')
 		assert result.rc == 0
 
 		# both aliases in list
-		result = host.run('stack list host alias output-format=json')
+		result = host.run('stack list host interface alias output-format=json')
 		assert result.rc == 0
 
 		with open(test_file('add/add_host_alias_two_aliases_same_name.json')) as output:
@@ -82,15 +82,15 @@ class TestAddHostAlias:
 		result = host.run(f'stack load hostfile file={test_file("add/add_host_alias_hostfile.csv")}')
 		assert result.rc == 0
 
-		result = host.run('stack add host alias backend-0-0 alias=test0-eth0 interface=eth0')
+		result = host.run('stack add host interface alias backend-0-0 alias=test0-eth0 interface=eth0')
 		assert result.rc == 0
 
 		# add same alias to different host (invalid)
-		result = host.run('stack add host alias backend-0-1 alias=test0-eth0 interface=eth0')
+		result = host.run('stack add host interface alias backend-0-1 alias=test0-eth0 interface=eth0')
 		assert result.rc != 0
 
 		# one alias in list
-		result = host.run('stack list host alias output-format=json')
+		result = host.run('stack list host interface alias output-format=json')
 		assert result.rc == 0
 
 		with open(test_file('add/add_host_alias_one_alias.json')) as output:
@@ -98,13 +98,13 @@ class TestAddHostAlias:
 		assert json.loads(result.stdout) == json.loads(expected_output)
 
 	def test_add_multiple_aliases_same_host_interface(self, host, add_host_with_interface, test_file):
-		result = host.run('stack add host alias backend-0-0 alias=test0-eth0 interface=eth0')
+		result = host.run('stack add host interface alias backend-0-0 alias=test0-eth0 interface=eth0')
 		assert result.rc == 0
-		result = host.run('stack add host alias backend-0-0 alias=2-test0-eth0 interface=eth0')
+		result = host.run('stack add host interface alias backend-0-0 alias=2-test0-eth0 interface=eth0')
 		assert result.rc == 0
 
 		# both aliases in list
-		result = host.run('stack list host alias output-format=json')
+		result = host.run('stack list host interface alias output-format=json')
 		assert result.rc == 0
 
 		with open(test_file('add/add_host_alias_multiple_aliases_same_host_interface.json')) as output:
@@ -112,7 +112,7 @@ class TestAddHostAlias:
 		assert json.loads(result.stdout) == json.loads(expected_output)
 
 	def test_no_host(self, host):
-		result = host.run('stack add host alias')
+		result = host.run('stack add host interface alias')
 		assert result.rc == 255
 		assert result.stderr == dedent('''\
 			error - "host" argument is required
@@ -120,7 +120,7 @@ class TestAddHostAlias:
 		''')
 
 	def test_no_matching_hosts(self, host):
-		result = host.run('stack add host alias a:test')
+		result = host.run('stack add host interface alias a:test')
 		assert result.rc == 255
 		assert result.stderr == dedent('''\
 			error - "host" argument is required
@@ -128,7 +128,7 @@ class TestAddHostAlias:
 		''')
 
 	def test_multiple_hosts(self, host, add_host):
-		result = host.run('stack add host alias frontend-0-0 backend-0-0')
+		result = host.run('stack add host interface alias frontend-0-0 backend-0-0')
 		assert result.rc == 255
 		assert result.stderr == dedent('''\
 			error - "host" argument must be unique
@@ -136,16 +136,16 @@ class TestAddHostAlias:
 		''')
 
 	def test_hostname_in_use(self, host, add_host):
-		result = host.run('stack add host alias frontend-0-0 alias=backend-0-0 interface=eth0')
+		result = host.run('stack add host interface alias frontend-0-0 alias=backend-0-0 interface=eth0')
 		assert result.rc == 255
 		assert result.stderr == 'error - hostname already in use\n'
 
 	def test_invalid_alias(self, host, add_host):
-		result = host.run('stack add host alias frontend-0-0 alias=127.0.0.1 interface=eth0')
+		result = host.run('stack add host interface alias frontend-0-0 alias=127.0.0.1 interface=eth0')
 		assert result.rc == 255
 		assert result.stderr == 'error - aliases cannot be an IP address\n'
 
 	def test_invalid_interface(self, host, add_host):
-		result = host.run('stack add host alias frontend-0-0 alias=foo interface=eth7')
+		result = host.run('stack add host interface alias frontend-0-0 alias=foo interface=eth7')
 		assert result.rc == 255
 		assert result.stderr == 'error - interface does not exist\n'

--- a/test-framework/test-suites/integration/tests/list/test_list_host_interface_alias.py
+++ b/test-framework/test-suites/integration/tests/list/test_list_host_interface_alias.py
@@ -2,14 +2,14 @@ import json
 from textwrap import dedent
 
 
-class TestListHostAlias:
+class TestListHostInterfaceAlias:
 	def test_invalid(self, host, invalid_host):
-		result = host.run(f'stack list host alias {invalid_host}')
+		result = host.run(f'stack list host interface alias {invalid_host}')
 		assert result.rc == 255
 		assert result.stderr == f'error - cannot resolve host "{invalid_host}"\n'
 
 	def test_usage_error(self, host):
-		result = host.run('stack list host alias host=frontend-0-0')
+		result = host.run('stack list host interface alias host=frontend-0-0')
 		assert result.rc == 255
 		assert result.stderr == dedent('''\
 			error - Incorrect usage.
@@ -18,14 +18,14 @@ class TestListHostAlias:
 
 	def test_no_args(self, host, add_host_with_interface):
 		# Add a few aliases
-		result = host.run('stack add host alias frontend-0-0 alias=test-0 interface=eth1')
+		result = host.run('stack add host interface alias frontend-0-0 alias=test-0 interface=eth1')
 		assert result.rc == 0
 
-		result = host.run('stack add host alias backend-0-0 alias=test-1 interface=eth0')
+		result = host.run('stack add host interface alias backend-0-0 alias=test-1 interface=eth0')
 		assert result.rc == 0
 
 		# Make sure a list shows them
-		result = host.run('stack list host alias output-format=json')
+		result = host.run('stack list host interface alias output-format=json')
 		assert result.rc == 0
 		assert json.loads(result.stdout) == [
 			{
@@ -42,18 +42,18 @@ class TestListHostAlias:
 
 	def test_one_arg(self, host, add_host_with_interface):
 		# Add a few aliases for the frontend
-		result = host.run('stack add host alias frontend-0-0 alias=test-0 interface=eth1')
+		result = host.run('stack add host interface alias frontend-0-0 alias=test-0 interface=eth1')
 		assert result.rc == 0
 
-		result = host.run('stack add host alias frontend-0-0 alias=test-1 interface=eth1')
+		result = host.run('stack add host interface alias frontend-0-0 alias=test-1 interface=eth1')
 		assert result.rc == 0
 
 		# Add one for the backend so we can make sure the list doesn't include it
-		result = host.run('stack add host alias backend-0-0 alias=test-2 interface=eth0')
+		result = host.run('stack add host interface alias backend-0-0 alias=test-2 interface=eth0')
 		assert result.rc == 0
 
 		# Make sure only the frontend aliases are listed
-		result = host.run('stack list host alias frontend-0-0 output-format=json')
+		result = host.run('stack list host interface alias frontend-0-0 output-format=json')
 		assert result.rc == 0
 		assert json.loads(result.stdout) == [
 			{
@@ -70,31 +70,31 @@ class TestListHostAlias:
 
 	def test_multiple_args(self, host, add_host_with_interface):
 		# Add a few aliases for the frontend
-		result = host.run('stack add host alias frontend-0-0 alias=test-0 interface=eth1')
+		result = host.run('stack add host interface alias frontend-0-0 alias=test-0 interface=eth1')
 		assert result.rc == 0
 
-		result = host.run('stack add host alias frontend-0-0 alias=test-1 interface=eth1')
+		result = host.run('stack add host interface alias frontend-0-0 alias=test-1 interface=eth1')
 		assert result.rc == 0
 
 		# Add a few for backend-0-0
-		result = host.run('stack add host alias backend-0-0 alias=test-2 interface=eth0')
+		result = host.run('stack add host interface alias backend-0-0 alias=test-2 interface=eth0')
 		assert result.rc == 0
 
-		result = host.run('stack add host alias backend-0-0 alias=test-3 interface=eth0')
+		result = host.run('stack add host interface alias backend-0-0 alias=test-3 interface=eth0')
 		assert result.rc == 0
 
 		# Add another backend so we can make sure it is skipped in the listing
 		add_host_with_interface('backend-0-1', '0', '2', 'backend', 'eth0')
 
 		# Add a few for backend-0-1
-		result = host.run('stack add host alias backend-0-1 alias=test-4 interface=eth0')
+		result = host.run('stack add host interface alias backend-0-1 alias=test-4 interface=eth0')
 		assert result.rc == 0
 
-		result = host.run('stack add host alias backend-0-1 alias=test-5 interface=eth0')
+		result = host.run('stack add host interface alias backend-0-1 alias=test-5 interface=eth0')
 		assert result.rc == 0
 
 		# Now, make sure only the frontend and backend-0-0 aliases are listed
-		result = host.run('stack list host alias frontend-0-0 backend-0-0 output-format=json')
+		result = host.run('stack list host interface alias frontend-0-0 backend-0-0 output-format=json')
 		assert result.rc == 0
 		assert json.loads(result.stdout) == [
 			{
@@ -121,7 +121,7 @@ class TestListHostAlias:
 
 	def test_with_interface(self, host, add_host_with_interface):
 		# Add an alias for the frontend, which should be skipped
-		result = host.run('stack add host alias frontend-0-0 alias=test-0 interface=eth1')
+		result = host.run('stack add host interface alias frontend-0-0 alias=test-0 interface=eth1')
 		assert result.rc == 0
 
 		# Add another interface to the backend
@@ -129,15 +129,15 @@ class TestListHostAlias:
 		assert result.rc == 0
 
 		# Add an alias for the backend on interface eth0
-		result = host.run('stack add host alias backend-0-0 alias=test-1 interface=eth0')
+		result = host.run('stack add host interface alias backend-0-0 alias=test-1 interface=eth0')
 		assert result.rc == 0
 
 		# Add another for eth1
-		result = host.run('stack add host alias backend-0-0 alias=test-2 interface=eth1')
+		result = host.run('stack add host interface alias backend-0-0 alias=test-2 interface=eth1')
 		assert result.rc == 0
 
 		# Do a listing on eth1, making sure eth0 doesn't show up
-		result = host.run('stack list host alias backend-0-0 interface=eth1 output-format=json')
+		result = host.run('stack list host interface alias backend-0-0 interface=eth1 output-format=json')
 		assert result.rc == 0
 		assert json.loads(result.stdout) == [
 			{

--- a/test-framework/test-suites/integration/tests/remove/test_remove_host.py
+++ b/test-framework/test-suites/integration/tests/remove/test_remove_host.py
@@ -31,7 +31,7 @@ class TestRemoveHost:
 
 	def test_single_arg(self, host, add_host_with_interface, add_group, host_os, revert_etc):
 		# Attach a bunch of data to the backend
-		result = host.run('stack add host alias backend-0-0 alias=test interface=eth0')
+		result = host.run('stack add host interface alias backend-0-0 alias=test interface=eth0')
 		assert result.rc == 0
 
 		result = host.run('stack add host attr backend-0-0 attr=test value=true')
@@ -76,7 +76,7 @@ class TestRemoveHost:
 
 	def test_multiple_args(self, host, add_host_with_interface, add_group, host_os, revert_etc):
 		# Attach a bunch of data to the backend
-		result = host.run('stack add host alias backend-0-0 alias=test interface=eth0')
+		result = host.run('stack add host interface alias backend-0-0 alias=test interface=eth0')
 		assert result.rc == 0
 
 		result = host.run('stack add host attr backend-0-0 attr=test value=true')

--- a/test-framework/test-suites/integration/tests/remove/test_remove_host_interface_alias.py
+++ b/test-framework/test-suites/integration/tests/remove/test_remove_host_interface_alias.py
@@ -2,14 +2,14 @@ import json
 from textwrap import dedent
 
 
-class TestRemoveHostAlias:
+class TestRemoveHostInterfaceAlias:
 	def test_invalid_host(self, host):
-		result = host.run('stack remove host alias test')
+		result = host.run('stack remove host interface alias test')
 		assert result.rc == 255
 		assert result.stderr == 'error - cannot resolve host "test"\n'
 
 	def test_no_args(self, host):
-		result = host.run('stack remove host alias')
+		result = host.run('stack remove host interface alias')
 		assert result.rc == 255
 		assert result.stderr == dedent('''\
 			error - "host" argument is required
@@ -17,7 +17,7 @@ class TestRemoveHostAlias:
 		''')
 
 	def test_no_host_matches(self, host):
-		result = host.run('stack remove host alias a:test')
+		result = host.run('stack remove host interface alias a:test')
 		assert result.rc == 255
 		assert result.stderr == dedent('''\
 			error - "host" argument is required
@@ -25,7 +25,7 @@ class TestRemoveHostAlias:
 		''')
 
 	def test_multiple_args(self, host, add_host_with_interface):
-		result = host.run('stack remove host alias frontend-0-0 backend-0-0')
+		result = host.run('stack remove host interface alias frontend-0-0 backend-0-0')
 		assert result.rc == 255
 		assert result.stderr == dedent('''\
 			error - "host" argument must be unique
@@ -34,18 +34,18 @@ class TestRemoveHostAlias:
 
 	def test_no_parameters(self, host, add_host_with_interface):
 		# Add a few aliases for the frontend
-		result = host.run('stack add host alias frontend-0-0 alias=test-0 interface=eth1')
+		result = host.run('stack add host interface alias frontend-0-0 alias=test-0 interface=eth1')
 		assert result.rc == 0
 
-		result = host.run('stack add host alias frontend-0-0 alias=test-1 interface=eth1')
+		result = host.run('stack add host interface alias frontend-0-0 alias=test-1 interface=eth1')
 		assert result.rc == 0
 
 		# Add one for the backend so we can make sure remove leaves it alone
-		result = host.run('stack add host alias backend-0-0 alias=test-2 interface=eth0')
+		result = host.run('stack add host interface alias backend-0-0 alias=test-2 interface=eth0')
 		assert result.rc == 0
 
 		# Confirm all our aliases are in the DB
-		result = host.run('stack list host alias frontend-0-0 backend-0-0 output-format=json')
+		result = host.run('stack list host interface alias frontend-0-0 backend-0-0 output-format=json')
 		assert result.rc == 0
 		assert json.loads(result.stdout) == [
 			{
@@ -66,11 +66,11 @@ class TestRemoveHostAlias:
 		]
 
 		# Do a remove without specifying alias or interface
-		result = host.run('stack remove host alias frontend-0-0')
+		result = host.run('stack remove host interface alias frontend-0-0')
 		assert result.rc == 0
 
 		# Confirm only the backend alias remains
-		result = host.run('stack list host alias frontend-0-0 backend-0-0 output-format=json')
+		result = host.run('stack list host interface alias frontend-0-0 backend-0-0 output-format=json')
 		assert result.rc == 0
 		assert json.loads(result.stdout) == [
 			{
@@ -82,18 +82,18 @@ class TestRemoveHostAlias:
 
 	def test_with_alias(self, host, add_host_with_interface):
 		# Add a few aliases for the frontend
-		result = host.run('stack add host alias frontend-0-0 alias=test-0 interface=eth1')
+		result = host.run('stack add host interface alias frontend-0-0 alias=test-0 interface=eth1')
 		assert result.rc == 0
 
-		result = host.run('stack add host alias frontend-0-0 alias=test-1 interface=eth1')
+		result = host.run('stack add host interface alias frontend-0-0 alias=test-1 interface=eth1')
 		assert result.rc == 0
 
 		# Add one for the backend so we can make sure remove leaves it alone
-		result = host.run('stack add host alias backend-0-0 alias=test-2 interface=eth0')
+		result = host.run('stack add host interface alias backend-0-0 alias=test-2 interface=eth0')
 		assert result.rc == 0
 
 		# Confirm all our aliases are in the DB
-		result = host.run('stack list host alias frontend-0-0 backend-0-0 output-format=json')
+		result = host.run('stack list host interface alias frontend-0-0 backend-0-0 output-format=json')
 		assert result.rc == 0
 		assert json.loads(result.stdout) == [
 			{
@@ -114,11 +114,11 @@ class TestRemoveHostAlias:
 		]
 
 		# Do a remove specifying the alias
-		result = host.run('stack remove host alias frontend-0-0 alias=test-1')
+		result = host.run('stack remove host interface alias frontend-0-0 alias=test-1')
 		assert result.rc == 0
 
 		# Confirm only the test-1 alias was removed
-		result = host.run('stack list host alias frontend-0-0 backend-0-0 output-format=json')
+		result = host.run('stack list host interface alias frontend-0-0 backend-0-0 output-format=json')
 		assert result.rc == 0
 		assert json.loads(result.stdout) == [
 			{
@@ -135,11 +135,11 @@ class TestRemoveHostAlias:
 
 	def test_with_interface(self, host, add_host_with_interface):
 		# Add an alias for the frontend
-		result = host.run('stack add host alias frontend-0-0 alias=test-0 interface=eth1')
+		result = host.run('stack add host interface alias frontend-0-0 alias=test-0 interface=eth1')
 		assert result.rc == 0
 
 		# Add one for the backend so we can make sure remove leaves it alone
-		result = host.run('stack add host alias backend-0-0 alias=test-1 interface=eth0')
+		result = host.run('stack add host interface alias backend-0-0 alias=test-1 interface=eth0')
 		assert result.rc == 0
 
 		# Add a second interface to the backend
@@ -147,11 +147,11 @@ class TestRemoveHostAlias:
 		assert result.rc == 0
 
 		# Add an alias for the new backend interface, which we will be removeing
-		result = host.run('stack add host alias backend-0-0 alias=test-2 interface=eth1')
+		result = host.run('stack add host interface alias backend-0-0 alias=test-2 interface=eth1')
 		assert result.rc == 0
 
 		# Confirm all our aliases are in the DB
-		result = host.run('stack list host alias frontend-0-0 backend-0-0 output-format=json')
+		result = host.run('stack list host interface alias frontend-0-0 backend-0-0 output-format=json')
 		assert result.rc == 0
 		assert json.loads(result.stdout) == [
 			{
@@ -172,11 +172,11 @@ class TestRemoveHostAlias:
 		]
 
 		# Do a remove specifying the interface
-		result = host.run('stack remove host alias backend-0-0 interface=eth1')
+		result = host.run('stack remove host interface alias backend-0-0 interface=eth1')
 		assert result.rc == 0
 
 		# Confirm only the test-2 alias was removed
-		result = host.run('stack list host alias frontend-0-0 backend-0-0 output-format=json')
+		result = host.run('stack list host interface alias frontend-0-0 backend-0-0 output-format=json')
 		assert result.rc == 0
 		assert json.loads(result.stdout) == [
 			{
@@ -193,11 +193,11 @@ class TestRemoveHostAlias:
 
 	def test_with_alias_and_interface(self, host, add_host_with_interface):
 		# Add an alias for the frontend
-		result = host.run('stack add host alias frontend-0-0 alias=test-0 interface=eth1')
+		result = host.run('stack add host interface alias frontend-0-0 alias=test-0 interface=eth1')
 		assert result.rc == 0
 
 		# Add one for the backend so we can make sure remove leaves it alone
-		result = host.run('stack add host alias backend-0-0 alias=test-1 interface=eth0')
+		result = host.run('stack add host interface alias backend-0-0 alias=test-1 interface=eth0')
 		assert result.rc == 0
 
 		# Add a second interface to the backend
@@ -205,11 +205,11 @@ class TestRemoveHostAlias:
 		assert result.rc == 0
 
 		# Add an alias for the new backend interface, which we will be removeing
-		result = host.run('stack add host alias backend-0-0 alias=test-2 interface=eth1')
+		result = host.run('stack add host interface alias backend-0-0 alias=test-2 interface=eth1')
 		assert result.rc == 0
 
 		# Confirm all our aliases are in the DB
-		result = host.run('stack list host alias frontend-0-0 backend-0-0 output-format=json')
+		result = host.run('stack list host interface alias frontend-0-0 backend-0-0 output-format=json')
 		assert result.rc == 0
 		assert json.loads(result.stdout) == [
 			{
@@ -230,11 +230,11 @@ class TestRemoveHostAlias:
 		]
 
 		# Do a remove specifying the interface
-		result = host.run('stack remove host alias backend-0-0 alias=test-2 interface=eth1')
+		result = host.run('stack remove host interface alias backend-0-0 alias=test-2 interface=eth1')
 		assert result.rc == 0
 
 		# Confirm only the test-2 alias was removed
-		result = host.run('stack list host alias frontend-0-0 backend-0-0 output-format=json')
+		result = host.run('stack list host interface alias frontend-0-0 backend-0-0 output-format=json')
 		assert result.rc == 0
 		assert json.loads(result.stdout) == [
 			{

--- a/test-framework/test-suites/integration/tests/report/test_report_host.py
+++ b/test-framework/test-suites/integration/tests/report/test_report_host.py
@@ -122,7 +122,7 @@ class TestReportHost:
 		result = host.run('stack add host interface backend-4-4 interface=eth4 ip=10.10.11.15 network=test')
 		assert result.rc == 0
 
-		result = host.run('stack add host alias backend-4-4 alias=BACKEND4 interface=eth4')
+		result = host.run('stack add host interface alias backend-4-4 alias=BACKEND4 interface=eth4')
 		assert result.rc == 0
 
 		result = host.run('stack report host')

--- a/test-framework/test-suites/integration/tests/report/test_report_zones.py
+++ b/test-framework/test-suites/integration/tests/report/test_report_zones.py
@@ -41,7 +41,7 @@ class TestReportZones:
 		assert result.rc == 0
 
 		# Add an alias th generate a CNAME
-		result = host.run('stack add host alias backend-0-0 alias=foo interface=eth0')
+		result = host.run('stack add host interface alias backend-0-0 alias=foo interface=eth0')
 		assert result.rc == 0
 
 		# Report our zones
@@ -69,7 +69,7 @@ class TestReportZones:
 		assert result.rc == 0
 
 		# Add an alias th generate a CNAME
-		result = host.run('stack add host alias backend-0-0 alias=foo interface=eth0')
+		result = host.run('stack add host interface alias backend-0-0 alias=foo interface=eth0')
 		assert result.rc == 0
 
 		# Report our zones
@@ -93,7 +93,7 @@ class TestReportZones:
 		assert result.rc == 0
 
 		# Add an alias while we're at it
-		result = host.run('stack add host alias backend-0-0 alias=foo interface=eth0')
+		result = host.run('stack add host interface alias backend-0-0 alias=foo interface=eth0')
 		assert result.rc == 0
 
 		# Report our zones


### PR DESCRIPTION
The [add|list|remove] host alias commands are now located at
`[add|list|remove] host interface alias` to better reflect that the
command actually attaches the alias to a host interface.