### PR TITLE
Feature/all the partitions

### DIFF
--- a/common/src/stack/kickstart/profile.py
+++ b/common/src/stack/kickstart/profile.py
@@ -222,7 +222,10 @@ if output:
 if profile_update_macs:
 	#
 	# add all the detected network interfaces to the database
-	#
+	# For ib interfaces there is a known bug where ifconfig will
+	# wrongly output the GID. The man page for newer ifconfigs
+	# lists it as a bug, this will probably never be fixed as
+	# ifconfig was deprecated.
 	ifaces = []
 	macs = []
 	modules = []

--- a/common/src/stack/switch/command/list/switch/partition/__init__.py
+++ b/common/src/stack/switch/command/list/switch/partition/__init__.py
@@ -29,15 +29,21 @@ class Command(
 	If a switch is not an infiniband subnet manager an error will be raised.
 	</param>
 
+	<param type='boolean' name='expanded' optional='1'>
+	All partitions currently defined on the infiniband switch
+	</param>
+
+
 	"""
 
 	def run(self, params, args):
 		if not len(args):
 			raise ArgRequired(self, 'switch')
 
-		name, enforce_sm = self.fillParams([
+		name, enforce_sm, expanded = self.fillParams([
 			('name', None),
 			('enforce_sm', False),
+			('expanded', False)
 		])
 
 		if name:
@@ -75,6 +81,11 @@ class Command(
 		sw_select += ' ORDER BY nodes.name'
 
 		self.beginOutput()
-		for line in self.db.select(sw_select, vals):
-			self.addOutput(line[0], (line[1], '0x{0:04x}'.format(line[2]), line[3]))
+		if self.str2bool(expanded):
+			for switch_name in switches:
+				model = self.getHostAttr(switch_name, 'component.model')
+				self.runImplementation(model, [switch_name])
+		else:
+			for line in self.db.select(sw_select, vals):
+				self.addOutput(line[0], (line[1], '0x{0:04x}'.format(line[2]), line[3]))
 		self.endOutput(header=['switch', 'partition', 'partition key', 'options'])

--- a/common/src/stack/switch/command/list/switch/partition/__init__.py
+++ b/common/src/stack/switch/command/list/switch/partition/__init__.py
@@ -84,7 +84,9 @@ class Command(
 		if self.str2bool(expanded):
 			for switch_name in switches:
 				model = self.getHostAttr(switch_name, 'component.model')
-				self.runImplementation(model, [switch_name])
+				partitions = self.runImplementation(model, [switch_name])
+				for part in partitions:
+					self.addOutput(switch_name, [part.partition, part.pkey, part.options])
 		else:
 			for line in self.db.select(sw_select, vals):
 				self.addOutput(line[0], (line[1], '0x{0:04x}'.format(line[2]), line[3]))

--- a/common/src/stack/switch/command/list/switch/partition/imp_m7800.py
+++ b/common/src/stack/switch/command/list/switch/partition/imp_m7800.py
@@ -17,7 +17,7 @@ class Implementation(stack.commands.Implementation):
 			'username': switch_attrs[switch].get('switch_username'),
 			'password': switch_attrs[switch].get('switch_password'),
 		}
-		part_info = namedtuple('ib_part', 'part pkey options')
+		part_info = namedtuple('ib_part', 'partition pkey options')
 		part_list = []
 
 		# remove username and pass attrs (aka use any pylib defaults) if they aren't host attrs
@@ -30,11 +30,11 @@ class Implementation(stack.commands.Implementation):
 		partitions = ib_switch.partitions
 
 		for partition, part_values in partitions.items():
-			options = [f'ipoib=part_values["ipoib"]']
+			options = [f'ipoib={part_values["ipoib"]}']
 			pkey = part_values['pkey']
 
-			if defmember:
-				options.append(f'defmember=part_values["defmember"]')
+			if part_values['defmember']:
+				options.append(f'defmember={part_values["defmember"]}')
 
 			if pkey:
 				pkey = '0x{0:04x}'.format(pkey)

--- a/common/src/stack/switch/command/list/switch/partition/imp_m7800.py
+++ b/common/src/stack/switch/command/list/switch/partition/imp_m7800.py
@@ -1,0 +1,42 @@
+# @copyright@
+# Copyright (c) 2006 - 2019 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+import stack.commands
+from stack.switch.m7800 import SwitchMellanoxM7800
+
+class Implementation(stack.commands.Implementation):
+	def run(self, args):
+
+		# switch hostname
+		switch, = args
+
+		switch_attrs = self.owner.getHostAttrDict(switch)
+
+		kwargs = {
+			'username': switch_attrs[switch].get('switch_username'),
+			'password': switch_attrs[switch].get('switch_password'),
+		}
+
+		# remove username and pass attrs (aka use any pylib defaults) if they aren't host attrs
+		kwargs = {k:v for k, v in kwargs.items() if v is not None}
+
+		ib_switch = SwitchMellanoxM7800(switch, **kwargs)
+		ib_switch.connect()
+
+		# Get all partitions on ib switch
+		partitions = ib_switch.partitions
+
+		for partition, part_values in partitions.items():
+			ipoib = part_values['ipoib']
+			defmember = part_values['defmember']
+
+			if part_values['pkey']:
+				pkey = '0x{0:04x}'.format(part_values['pkey'])
+			else:
+				pkey = part_values['pkey']
+			if part_values['defmember']:
+				self.owner.addOutput(switch, [partition, pkey, f'ipoib={ipoib},defmember={defmember}'])
+			else:
+				self.owner.addOutput(switch, [partition, pkey, f'ipoib={ipoib}'])

--- a/common/src/stack/switch/command/list/switch/partition/imp_m7800.py
+++ b/common/src/stack/switch/command/list/switch/partition/imp_m7800.py
@@ -5,19 +5,20 @@
 # @copyright@
 import stack.commands
 from stack.switch.m7800 import SwitchMellanoxM7800
+from collections import namedtuple
 
 class Implementation(stack.commands.Implementation):
 	def run(self, args):
 
 		# switch hostname
 		switch, = args
-
 		switch_attrs = self.owner.getHostAttrDict(switch)
-
 		kwargs = {
 			'username': switch_attrs[switch].get('switch_username'),
 			'password': switch_attrs[switch].get('switch_password'),
 		}
+		part_info = namedtuple('ib_part', 'part pkey options')
+		part_list = []
 
 		# remove username and pass attrs (aka use any pylib defaults) if they aren't host attrs
 		kwargs = {k:v for k, v in kwargs.items() if v is not None}
@@ -29,14 +30,16 @@ class Implementation(stack.commands.Implementation):
 		partitions = ib_switch.partitions
 
 		for partition, part_values in partitions.items():
-			ipoib = part_values['ipoib']
-			defmember = part_values['defmember']
+			options = [f'ipoib=part_values["ipoib"]']
+			pkey = part_values['pkey']
 
-			if part_values['pkey']:
-				pkey = '0x{0:04x}'.format(part_values['pkey'])
-			else:
-				pkey = part_values['pkey']
-			if part_values['defmember']:
-				self.owner.addOutput(switch, [partition, pkey, f'ipoib={ipoib},defmember={defmember}'])
-			else:
-				self.owner.addOutput(switch, [partition, pkey, f'ipoib={ipoib}'])
+			if defmember:
+				options.append(f'defmember=part_values["defmember"]')
+
+			if pkey:
+				pkey = '0x{0:04x}'.format(pkey)
+
+			partition = part_info(partition, pkey, ','.join(options))
+			part_list.append(partition)
+
+		return part_list

--- a/common/src/stack/switch/command/list/switch/partition/member/__init__.py
+++ b/common/src/stack/switch/command/list/switch/partition/member/__init__.py
@@ -112,5 +112,25 @@ class Command(
 		elif source == 'switch':
 			for switch_name in switches:
 				model = self.getHostAttr(switch_name, 'component.model')
-				self.runImplementation(model, [switch_name, expanded])
+				partitions = self.runImplementation(model, [switch_name])
+				for partition, members in partitions.items():
+					for member in members:
+						output = []
+						if expanded:
+							output = [
+								member.host,
+								member.interface,
+								member.guid,
+								member.partition,
+								member.pkey,
+								member.options
+							]
+						else:
+							output = [
+								member.host,
+								member.interface,
+								member.guid,
+								member.partition
+							]
+						self.addOutput(switch_name, options)
 		self.endOutput(header=table_headers)

--- a/common/src/stack/switch/command/list/switch/partition/member/__init__.py
+++ b/common/src/stack/switch/command/list/switch/partition/member/__init__.py
@@ -122,6 +122,7 @@ class Command(
 								member.interface,
 								member.guid,
 								member.partition,
+								member.membership,
 								member.pkey,
 								member.options
 							]
@@ -130,7 +131,8 @@ class Command(
 								member.host,
 								member.interface,
 								member.guid,
-								member.partition
+								member.partition,
+								member.membership
 							]
-						self.addOutput(switch_name, options)
+						self.addOutput(switch_name, output)
 		self.endOutput(header=table_headers)

--- a/common/src/stack/switch/command/list/switch/partition/member/imp_m7800.py
+++ b/common/src/stack/switch/command/list/switch/partition/member/imp_m7800.py
@@ -1,0 +1,72 @@
+# @copyright@
+# Copyright (c) 2006 - 2019 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+import stack.commands
+from stack import api
+from stack.switch.m7800 import SwitchMellanoxM7800
+
+class Implementation(stack.commands.Implementation):
+	def get_host_interface_by_mac(self, mac):
+		# Return the host name, interface name, and address
+		# if a given mac belongs to a host in the database
+		host = ''
+		interface_name = ''
+		address = ''
+		for interface in api.Call('list host interface'):
+			# If a mac addresses matches what's in the database
+			# Get it's host name and interface name
+			if interface['mac'] and mac.lower() in interface['mac'].lower():
+				found_mac = interface['mac']
+				if 'host' in interface:
+					host = interface['host']
+				if 'ip' in interface:
+					address = interface['ip']
+				if 'interface' in interface:
+					interface_name = interface['interface']
+		return {'host_name': host, 'interface_name': interface_name}
+
+	def run(self, args):
+
+		# switch hostname
+		switch, expanded = args
+
+		switch_attrs = self.owner.getHostAttrDict(switch)
+
+		kwargs = {
+			'username': switch_attrs[switch].get('switch_username'),
+			'password': switch_attrs[switch].get('switch_password'),
+		}
+
+		# remove username and pass attrs (aka use any pylib defaults) if they aren't host attrs
+		kwargs = {k:v for k, v in kwargs.items() if v is not None}
+
+		ib_switch = SwitchMellanoxM7800(switch, **kwargs)
+		ib_switch.connect()
+
+		# Get all partitions on ib switch
+		partitions = ib_switch.partitions
+
+		for partition, part_values in partitions.items():
+			ipoib = part_values['ipoib']
+			members = part_values['guids']
+			defmember = part_values['defmember']
+
+			# Go through each partition member and output it
+			for guid, membership in members.items():
+				host = self.get_host_interface_by_mac(guid)
+
+				# Format partition key
+				if part_values['pkey']:
+					pkey = '0x{0:04x}'.format(part_values['pkey'])
+				else:
+					pkey = part_values['pkey']
+
+				# Only show default member type if it's set
+				if expanded and defmember:
+					self.owner.addOutput(switch, [host['host_name'], host['interface_name'], guid, partition, membership, pkey, f'ipoib={ipoib},defmember={defmember}'])
+				elif expanded:
+					self.owner.addOutput(switch, [host['host_name'], host['interface_name'], guid, partition, membership, pkey, f'ipoib={ipoib}'])
+				else:
+					self.owner.addOutput(switch, [host['host_name'], host['interface_name'], guid, partition, membership])

--- a/common/src/stack/switch/command/list/switch/partition/member/imp_m7800.py
+++ b/common/src/stack/switch/command/list/switch/partition/member/imp_m7800.py
@@ -28,7 +28,7 @@ class Implementation(stack.commands.Implementation):
 	def run(self, args):
 
 		# switch hostname
-		switch = args
+		switch, = args
 
 		switch_attrs = self.owner.getHostAttrDict(switch)
 
@@ -71,7 +71,7 @@ class Implementation(stack.commands.Implementation):
 				if defmember:
 					options.append(f'defmember={defmember}')
 
-				member = part_member(host['host_name'], host['interface_name'], guid, partition, membership, pkey, options)
+				member = part_member(host['host_name'], host['interface_name'], guid, partition, membership, pkey, ','.join(options))
 				member_list.append(member)
 
 			partition_info[partition] = member_list

--- a/common/src/stack/switch/pylib/switch/m7800.py
+++ b/common/src/stack/switch/pylib/switch/m7800.py
@@ -212,7 +212,7 @@ class SwitchMellanoxM7800(Switch):
 	def partitions(self):
 		"""
 		Return a dictionary of the partitions.
-		partition['partition_name'] = {'pkey': int, 'ipoib': bool, 'guids': [list, of, member, guids]}
+		partition['partition_name'] = {'pkey': int, 'ipoib': bool, 'guids': [list, of, member, guids], 'defmember': str}
 		"""
 
 		partitions = {}
@@ -243,6 +243,7 @@ class SwitchMellanoxM7800(Switch):
 					'pkey': '',
 					'ipoib': False,
 					'guids': {},
+					'defmember': ''
 				}
 				continue
 
@@ -253,6 +254,9 @@ class SwitchMellanoxM7800(Switch):
 			elif line.startswith('ipoib'):
 				_, ipoib = line.split(':' if new_console_format else '=')
 				partitions[cur_partition]['ipoib'] = str2bool(ipoib.strip())
+			elif line.startswith('defmember'):
+				_, defmember = line.split(':' if new_console_format else '=')
+				partitions[cur_partition]['defmember'] = defmember.strip()
 			elif line.startswith('GUID'):
 				m = re.search(guid_member_format, line)
 				guid, membership = m.groups()[0].lower(), m.groups()[2]

--- a/test-framework/test-suites/unit/files/switch/m7800_parse_partitions_output.json
+++ b/test-framework/test-suites/unit/files/switch/m7800_parse_partitions_output.json
@@ -1,1 +1,1 @@
-{"Default": {"guids": {"all": "full", "e4:1d:2d:03:00:15:6e:80": "limited"}, "ipoib": true, "pkey": 32767}}
+{"Default": {"guids": {"all": "full", "e4:1d:2d:03:00:15:6e:80": "limited"}, "ipoib": true, "pkey": 32767, "defmember": ""}}

--- a/test-framework/test-suites/unit/files/switch/m7800_parse_partitions_with_member_named_all_output.json
+++ b/test-framework/test-suites/unit/files/switch/m7800_parse_partitions_with_member_named_all_output.json
@@ -1,1 +1,1 @@
-{"0x0123": {"guids": {"e4:1d:2d:03:00:15:6e:80": "limited", "e4:1d:aa:00:00:11:22:80": "limited", "e4:1d:b1:26:99:34:aa:80": "limited", "e4:aa:2d:bb:cd:cd:ee:80": "full"}, "ipoib": true, "pkey": 291}}
+{"0x0123": {"guids": {"e4:1d:2d:03:00:15:6e:80": "limited", "e4:1d:aa:00:00:11:22:80": "limited", "e4:1d:b1:26:99:34:aa:80": "limited", "e4:aa:2d:bb:cd:cd:ee:80": "full"}, "ipoib": true, "pkey": 291, "defmember": ""}}


### PR DESCRIPTION
This adds two new bits of functionality to the list switch commands. When `list switch partition $IBSWITCH expanded=true` and `list switch partition member $IBSWITCH source=switch` is done, the actual switch partition tables will be queried and displayed vs what's in the database without those flags.

There is also a branch called feature/check-ib-partitions that adds report system tests that depend on this functionality.