### PR TITLE
BUGFIX: Fail to get scope mappings if arguments are provided at the global scope

### DIFF
--- a/common/src/stack/command/stack/commands/__init__.py
+++ b/common/src/stack/command/stack/commands/__init__.py
@@ -811,6 +811,12 @@ class ScopeArgumentProcessor(
 		# Validate the different scopes and get the keys to the targets
 		if scope == 'global':
 			# Global scope has no friends
+			if args:
+				raise CommandError(
+					cmd = self,
+					msg = "Arguments are not allowed at the global scope.",
+				)
+
 			scope_mappings.append(
 				ScopeMapping(scope, None, None, None, None)
 			)

--- a/test-framework/test-suites/integration/tests/dump/test_dump_appliance.py
+++ b/test-framework/test-suites/integration/tests/dump/test_dump_appliance.py
@@ -17,7 +17,7 @@ class TestDumpAppliance:
 		assert results.rc == 0
 		results = host.run('stack add appliance firewall backend action=accept chain=input protocol=udp service=www network=private output-network=private rulename=appliancetest table=filter comment="test" flags="-m set"')
 		assert results.rc == 0
-		results = host.run('stack add storage partition backend device=test options="test option" size=1 mountpoint=test partid=1 type=ext4')
+		results = host.run('stack add appliance storage partition backend device=test options="test option" size=1 mountpoint=test partid=1 type=ext4')
 		assert results.rc == 0
 		results = host.run('stack add appliance storage controller backend adapter=1 arrayid=2 enclosure=3 raidlevel=4 slot=5 options=test')
 		assert results.rc == 0

--- a/test-framework/test-suites/integration/tests/dump/test_dump_host.py
+++ b/test-framework/test-suites/integration/tests/dump/test_dump_host.py
@@ -31,7 +31,7 @@ class TestDumpHost:
 		assert results.rc == 0
 		results = host.run('stack add host storage controller backend-test adapter=1 arrayid=2 enclosure=3 raidlevel=4 slot=5')
 		assert results.rc == 0
-		results = host.run('stack add storage partition backend-test device=test options="test option" size=1 mountpoint=test partid=1 type=ext4')
+		results = host.run('stack add host storage partition backend-test device=test options="test option" size=1 mountpoint=test partid=1 type=ext4')
 		assert results.rc == 0
 		results = host.run('stack add host firewall backend-test action=accept chain=input protocol=udp service=www comment=test flags="-m state" network=private output-network=private rulename=test table=filter')
 		assert results.rc == 0

--- a/test-framework/test-suites/integration/tests/dump/test_dump_os.py
+++ b/test-framework/test-suites/integration/tests/dump/test_dump_os.py
@@ -17,7 +17,7 @@ class TestDumpOs:
 		assert results.rc == 0
 		results = host.run('stack add os firewall redhat action=accept chain=input protocol=udp service=www network=private output-network=private rulename=ostest table=filter comment="test" flags="-m set"')
 		assert results.rc == 0
-		results = host.run('stack add storage partition redhat device=test options="test option" size=1 mountpoint=test partid=1 type=ext4')
+		results = host.run('stack add os storage partition redhat device=test options="test option" size=1 mountpoint=test partid=1 type=ext4')
 		assert results.rc == 0
 		results = host.run('stack add os storage controller redhat adapter=1 arrayid=2 enclosure=3 raidlevel=4 slot=5 options=test')
 		assert results.rc == 0

--- a/test-framework/test-suites/integration/tests/list/test_list_host_firewall.py
+++ b/test-framework/test-suites/integration/tests/list/test_list_host_firewall.py
@@ -49,7 +49,7 @@ class TestListHostFirewall:
 
 		# Add a bunch of rules to get applied to the host
 		result = host.run(
-			'stack add firewall backend service=1 chain=INPUT '
+			'stack add firewall service=1 chain=INPUT '
 			'action=ACCEPT protocol=TCP rulename=global_rule'
 		)
 		assert result.rc == 0

--- a/test-framework/test-suites/unit/tests/command/stack/commands/test_command_stack_commands___init__.py
+++ b/test-framework/test-suites/unit/tests/command/stack/commands/test_command_stack_commands___init__.py
@@ -1,8 +1,10 @@
-from stack.commands import Command, Implementation
+from stack.commands import Command, Implementation, ScopeArgumentProcessor
+from stack.exception import CommandError
 from unittest.mock import patch, create_autospec, ANY
 from concurrent.futures import Future
 from collections import namedtuple
 import time
+import pytest
 
 class CommandUnderTest(Command):
 	"""A subclass of Command that replaces __init__ to remove the database dependency."""
@@ -260,3 +262,20 @@ class TestCommand:
 			)
 			for key in test_implementation_mapping
 		}
+
+class TestScopeArgumentProcessor:
+	"""Test case for the ScopeArgumentProcessor"""
+
+	def test_getScopeMappings_global_scope(self):
+		"""Test that getting the scope mappings works as expected for the global scope."""
+		test_scope = "global"
+		result = ScopeArgumentProcessor().getScopeMappings(scope = test_scope)
+		assert [(test_scope, None, None, None, None)] == result
+
+	def test_getScopeMappings_global_scope_with_args(self):
+		"""Test that getting the scope mappings for the global scope fails when additional args are passed."""
+		test_scope = "global"
+		test_args = ["foo", "bar"]
+
+		with pytest.raises(CommandError):
+			ScopeArgumentProcessor().getScopeMappings(args = test_args, scope = test_scope)


### PR DESCRIPTION
INTERNAL:

Fix broken tests that were using the wrongly scoped versions of commands.
Add new unit tests to check global scope behavior.