### PR TITLE
BUGFIX: Properly set the file system type when loading partitions

### DIFF
--- a/common/src/stack/command/stack/commands/load/__init__.py
+++ b/common/src/stack/command/stack/commands/load/__init__.py
@@ -149,7 +149,7 @@ class command(stack.commands.Command):
 				  'partid'    : p.get('partid'),
 				  'mountpoint': p.get('mountpoint'),
 				  'size'      : p.get('size'),
-				  'fstype'    : p.get('fstype'),
+				  'type'    : p.get('fstype'),
 				  'options'   : p.get('options')}
 
 			self.stack('add.storage.partition', target, **params)


### PR DESCRIPTION
This was split out into its own commit so it can be cherry-picked onto the support branch easily. I made this command scope aware in #588 and added tests there, but I don't think the scoped stuff is wanted in the support branch.

This change makes it so that `stack load` actually sets the filesystem type of storage partitions that are loaded. `stack add storage partition` expects the parameter to be named `type` not `fstype`.