### PR TITLE
Feature/solve resolv

### DIFF
--- a/common/nodes/database-data.xml
+++ b/common/nodes/database-data.xml
@@ -53,7 +53,7 @@ rm /tmp/my.cnf
 </stack:script>
 
 <stack:script stack:cond="platform != 'docker'">
-/opt/stack/bin/stack report host > /etc/hosts
+<stack:report stack:name="host"></stack:report>
 
 <!-- Firmware support -->
 <!-- Mellanox m7800 and m6036 -->

--- a/common/src/stack/command/stack/commands/__init__.py
+++ b/common/src/stack/command/stack/commands/__init__.py
@@ -1335,13 +1335,6 @@ class DatabaseConnection:
 
 		result = None
 
-		###
-		# CLADD (11/5/2018): I'm 99% sure this code below is unreachable
-		# in our current code base. Tracing though the code, I couldn't
-		# find a path to get coverage on this chunk of code, where subnet
-		# would be anything besides None. However, I'm hesitent to delete
-		# the chunk of code until test coverage is higher.
-		###
 		for (netname, zone) in self.select("""
 			net.name, s.zone from nodes n, networks net, subnets s
 			where n.name like %s and s.name like %s
@@ -1352,11 +1345,10 @@ class DatabaseConnection:
 			# dns zone
 			if not netname:
 				netname = hostname
-
-			result = '%s.%s' % (netname, zone)
-		###
-		# End possible dead code chunk
-		###
+			if zone:
+				result = '%s.%s' % (netname, zone)
+			else:
+				result = netname
 
 		return result
 

--- a/common/src/stack/command/stack/commands/report/host/__init__.py
+++ b/common/src/stack/command/stack/commands/report/host/__init__.py
@@ -33,10 +33,12 @@ class Command(command):
 	"""
 
 	def run(self, param, args):
+		text = []
 		self.beginOutput()
-		self.addOutput(None, stack.text.DoNotEdit())
-		self.addOutput(None, '#  Site additions go in /etc/hosts.local\n')
-		self.addOutput(None, '127.0.0.1\tlocalhost.localdomain\tlocalhost\n')
+		text.append('<stack:file stack:name="/etc/hosts">')
+		text.append(stack.text.DoNotEdit())
+		text.append('#  Site additions go in /etc/hosts.local\n')
+		text.append('127.0.0.1\tlocalhost.localdomain\tlocalhost\n')
 		zones = {}
 		aliases = {}
 
@@ -151,7 +153,7 @@ class Command(command):
 						continue
 
 				# Write it all
-				self.addOutput(None, '%s\t%s' % (ip, ' '.join(names)))
+				text.append('%s\t%s' % (ip, ' '.join(names)))
 
 				if ip not in processed:
 					processed[ip] = {}
@@ -161,11 +163,13 @@ class Command(command):
 		hostlocal = '/etc/hosts.local'
 		if os.path.exists(hostlocal):
 			f = open(hostlocal, 'r')
-			self.addOutput(None, '\n# Imported from /etc/hosts.local\n')
+			text.append('\n# Imported from /etc/hosts.local\n')
 			h = f.read()
-			self.addOutput(None, h)
+			text.append(h)
 			f.close()
 
+		text.append('</stack:file>')
+		self.addOutput(None, '\n'.join(text))
 		self.endOutput(padChar='', trimOwner=True)
 
 
@@ -188,4 +192,3 @@ class Command(command):
 		if hostinfo['default']:
 			return True
 		return False
-                

--- a/common/src/stack/command/stack/commands/sync/host/__init__.py
+++ b/common/src/stack/command/stack/commands/sync/host/__init__.py
@@ -65,20 +65,7 @@ class Command(command):
 	"""
 
 	def run(self, params, args):
-
-		self.notify('Sync Host')
-
-		output = self.command('report.host')
-		f = open('/etc/hosts', 'w')
-		f.write("%s\n" % output)
-		f.close()
-
-		if os.path.exists('/srv/salt/rocks'):
-			f = open('/srv/salt/rocks/hosts', 'w')
-			f.write("%s\n" % output)
-			f.close()
-
-
-
-
-
+		synchosts = self.str2bool(self.getHostAttr('localhost', 'sync.hosts'))
+		if synchosts:
+			self.notify('Sync Host')
+			self.report('report.host')

--- a/common/src/stack/command/stack/commands/sync/host/network/__init__.py
+++ b/common/src/stack/command/stack/commands/sync/host/network/__init__.py
@@ -69,6 +69,7 @@ class Command(stack.commands.sync.host.command):
 		hosts = self.getHostnames(args, managed_only=1)
 		run_hosts = self.getRunHosts(hosts)
 
+		host_attrs = self.getHostAttrDict(hosts)
 		me = self.db.getHostname('localhost')
 
 		threads = []
@@ -80,9 +81,13 @@ class Command(stack.commands.sync.host.command):
 			if host == me:
 				self.cleanup()
 
+			sync_hosts = self.str2bool(host_attrs[host].get('sync.hosts', False))
 
 			cmd = '( /opt/stack/bin/stack report host interface %s && ' % host
 			cmd += '/opt/stack/bin/stack report host network %s && ' % host
+			if sync_hosts:
+				# we only conditionally sync /etc/hosts
+				cmd += '/opt/stack/bin/stack report host && '
 			cmd += '/opt/stack/bin/stack report host resolv %s && ' % host
 			cmd += '/opt/stack/bin/stack report host route %s ) | ' % host
 			cmd += '/opt/stack/bin/stack report script | '

--- a/common/src/stack/command/stack/commands/sync/host/network/__init__.py
+++ b/common/src/stack/command/stack/commands/sync/host/network/__init__.py
@@ -80,24 +80,17 @@ class Command(stack.commands.sync.host.command):
 			if host == me:
 				self.cleanup()
 
-			# Sometimes these return None, in that case, make them an empty string
-			c = str(self.command('report.host.interface',[host]) or '') + \
-				str(self.command('report.host.network',[host]) or '') + \
-				str(self.command('report.host.route',[host]) or '')
-
-			s = subprocess.Popen(['/opt/stack/bin/stack','report','script'],
-				stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-			o, e = s.communicate(input=c.encode())
 
 			cmd = '( /opt/stack/bin/stack report host interface %s && ' % host
 			cmd += '/opt/stack/bin/stack report host network %s && ' % host
+			cmd += '/opt/stack/bin/stack report host resolv %s && ' % host
 			cmd += '/opt/stack/bin/stack report host route %s ) | ' % host
 			cmd += '/opt/stack/bin/stack report script | '
 			if host != me:
 				cmd += 'ssh -T -x %s ' % hostname
 			cmd += 'bash > /dev/null 2>&1'
 
-			p = Parallel(cmd, stdin=o.decode())
+			p = Parallel(cmd)
 			threads.append(p)
 			p.start()
 
@@ -149,4 +142,3 @@ class Command(stack.commands.sync.host.command):
 		#
 		if me in hosts and os.path.exists('/etc/ganglia/gmond.conf'):
 			os.system('service gmond restart > /dev/null 2>&1')
-

--- a/redhat/nodes/resolv.xml
+++ b/redhat/nodes/resolv.xml
@@ -22,8 +22,12 @@ https://github.com/Teradata/stacki/blob/master/LICENSE.txt
 127.0.0.1	localhost.localdomain localhost
 </stack:file>
 
-<stack:file stack:name="/etc/hosts" stack:cond="hostaddr" stack:mode="append">
+<stack:file stack:name="/etc/hosts" stack:cond="hostaddr and domainname" stack:mode="append">
 &hostaddr;	&hostname;.&domainname; &hostname;
+</stack:file>
+
+<stack:file stack:name="/etc/hosts" stack:cond="hostaddr and not domainname" stack:mode="append">
+&hostaddr;	&hostname;
 </stack:file>
 
 </stack:script>

--- a/sles/nodes/backend.xml
+++ b/sles/nodes/backend.xml
@@ -35,7 +35,11 @@ export LD_LIBRARY_PATH=/opt/stack/lib
 
 <stack:script stack:stage="install-post">
 
-echo "&hostname;.&domainname;" > /etc/HOSTNAME
+echo "&hostname;" > /etc/HOSTNAME
+if [ x"" == x&domainname; ]
+then
+	echo -n ".&domainname;" >> /etc/HOSTNAME
+fi
 
 SERVER=&yumserver;
 if [ x"" == x$SERVER ]

--- a/test-framework/Vagrantfile
+++ b/test-framework/Vagrantfile
@@ -76,7 +76,7 @@ Vagrant.configure("2") do |config|
 
     config.vm.synced_folder '.', '/vagrant', disabled: true
 
-    config.vm.hostname = "frontend-0-0.localdomain"
+    config.vm.hostname = "frontend-0-0"
     config.vm.network "private_network",
       ip: "192.168.0.2",
       virtualbox__intnet: NAME,

--- a/test-framework/provisioning/roles/barnacle/tasks/main.yml
+++ b/test-framework/provisioning/roles/barnacle/tasks/main.yml
@@ -25,8 +25,8 @@
     copy:
       dest: /etc/hosts
       content: |
-        127.0.0.1       localhost     localhost.localdomain
-        192.168.0.2     frontend-0-0  frontend-0-0.localdomain
+        127.0.0.1       localhost
+        192.168.0.2     frontend-0-0  frontend-0-0
       mode: 0644
 
   - name: Download frontend-install.py

--- a/test-framework/provisioning/roles/barnacle/tasks/main.yml
+++ b/test-framework/provisioning/roles/barnacle/tasks/main.yml
@@ -19,7 +19,7 @@
     until: get_url_result is succeeded
     retries: 6
     delay: 10
-    when: lookup('env','GIT_BRANCH') is match("(feature|bugfix)/.*")
+    when: lookup('pipe','git symbolic-ref --short HEAD') is match("(feature|bugfix)/.*")
 
   - name: Setup /etc/host to a known good state
     copy:
@@ -31,7 +31,7 @@
 
   - name: Download frontend-install.py
     get_url:
-      url: https://raw.githubusercontent.com/Teradata/stacki/develop/tools/fab/frontend-install.py
+      url: https://raw.githubusercontent.com/Teradata/stacki/{{ lookup('pipe','git symbolic-ref --short HEAD') }}/tools/fab/frontend-install.py
       dest: /root/
       mode: 0744
     register: get_url_result

--- a/test-framework/test-suites/integration/tests/report/test_report_networkfile.py
+++ b/test-framework/test-suites/integration/tests/report/test_report_networkfile.py
@@ -17,7 +17,7 @@ class TestReportNetworkfile:
 		assert result.rc == 0
 		assert result.stdout == textwrap.dedent(f"""\
 			NETWORK,ADDRESS,MASK,GATEWAY,MTU,ZONE,DNS,PXE\r
-			private,{network[0]['address']},255.255.255.0,{network[0]['gateway']},1500,localdomain,False,True
+			private,{network[0]['address']},255.255.255.0,{network[0]['gateway']},1500,,False,True
 			"""
 		)
 

--- a/test-framework/test-suites/integration/tests/sync/test_sync_host_network.py
+++ b/test-framework/test-suites/integration/tests/sync/test_sync_host_network.py
@@ -1,4 +1,5 @@
-def test_sync_host_network_backend(host, add_host, revert_etc):
+def test_sync_host_network_backend_without_ifaces(host, add_host, revert_etc):
+	# test should pass as sync host network ignores backends without networking
 	result = host.run('stack sync host network')
 	assert result.rc == 0
 

--- a/test-framework/test-suites/integration/tests/sync/test_sync_host_network.py
+++ b/test-framework/test-suites/integration/tests/sync/test_sync_host_network.py
@@ -24,3 +24,78 @@ def test_sync_host_network_resolv(host, revert_etc):
 	# verify we actually do rewrite resolv.conf
 	with open('/etc/resolv.conf') as fi:
 		assert og_resolv_data == fi.read()
+
+def test_ensure_hostfile_matches_database(host, revert_etc):
+	# ensure starting hostfile is what the FE would write
+	# get the og hostfile
+	with open('/etc/hosts') as fi:
+		og_hostsfiledata = fi.read()
+
+	# this command will always overwrite /etc/hosts
+	result = host.run('stack report host | stack report script | bash')
+	assert result.rc == 0
+
+	with open('/etc/hosts') as fi:
+		hostsfiledata = fi.read()
+		assert og_hostsfiledata == hostsfiledata
+
+
+def test_sync_host_network_hosts(host, revert_etc):
+	''' sync host network should also sync /etc/hosts '''
+	with open('/etc/hosts') as fi:
+		hostsfiledata = fi.read()
+
+	# write garbage to it
+	with open('/etc/hosts', 'a+') as fi:
+		fi.write('# curatorial nonsense garbage')
+		fi.seek(0)
+		garbagehostsdata = fi.read()
+		assert garbagehostsdata != hostsfiledata
+
+	# run sync host network without sync.hosts (defaults to False)
+	result = host.run('stack sync host network localhost')
+	assert result.rc == 0
+	# verify hostfile same
+	with open('/etc/hosts') as fi:
+		assert garbagehostsdata == fi.read()
+
+	# enable syncing hostfile and call sync host network
+	result = host.run('stack set host attr localhost attr=sync.hosts value=True')
+	assert result.rc == 0
+	result = host.run('stack sync host network localhost')
+	assert result.rc == 0
+
+	# verify hostfile clobber
+	with open('/etc/hosts') as fi:
+		assert hostsfiledata == fi.read()
+
+def test_sync_host_network_hosts_with_synchosts(host, revert_etc):
+	''' sync host network should sync /etc/hosts only if sync.hosts==True '''
+	with open('/etc/hosts') as fi:
+		hostsfiledata = fi.read()
+
+	# write garbage to it
+	with open('/etc/hosts', 'a+') as fi:
+		fi.write('# curatorial nonsense garbage')
+		fi.seek(0)
+		garbagehostsdata = fi.read()
+		assert garbagehostsdata != hostsfiledata
+
+	# disable syncing hostfile and sync
+	result = host.run('stack set host attr localhost attr=sync.hosts value=False')
+	assert result.rc == 0
+	result = host.run('stack sync host')
+	assert result.rc == 0
+	# verify hostfile same
+	with open('/etc/hosts') as fi:
+		assert garbagehostsdata == fi.read()
+
+	# enable syncing hostfile and sync
+	result = host.run('stack set host attr localhost attr=sync.hosts value=True')
+	assert result.rc == 0
+	result = host.run('stack sync host')
+	assert result.rc == 0
+
+	# verify hostfile clobber
+	with open('/etc/hosts') as fi:
+		assert hostsfiledata == fi.read()

--- a/test-framework/test-suites/integration/tests/sync/test_sync_host_network.py
+++ b/test-framework/test-suites/integration/tests/sync/test_sync_host_network.py
@@ -3,5 +3,24 @@ def test_sync_host_network_backend(host, add_host, revert_etc):
 	assert result.rc == 0
 
 def test_sync_host_network_frontend_only(host, revert_etc):
-	result = host.run('stack sync host network')
+	result = host.run('stack sync host network localhost')
 	assert result.rc == 0
+
+def test_sync_host_network_resolv(host, revert_etc):
+	''' sync host network should also sync resolv.conf '''
+	# write garbage to it
+	with open('/etc/resolv.conf', 'a+') as fi:
+		fi.seek(0)
+		og_resolv_data = fi.read()
+		fi.write('# curatorial nonsense garbage')
+		fi.seek(0)
+		garbagedata = fi.read()
+		assert garbagedata != og_resolv_data
+
+	# call sync host network
+	result = host.run('stack sync host network localhost')
+	assert result.rc == 0
+
+	# verify we actually do rewrite resolv.conf
+	with open('/etc/resolv.conf') as fi:
+		assert og_resolv_data == fi.read()

--- a/tools/fab/frontend-install.py
+++ b/tools/fab/frontend-install.py
@@ -578,6 +578,7 @@ for iso in extra_isos:
 subprocess.call([stackpath, 'enable', 'pallet', '%'])
 subprocess.call([stackpath, 'enable', 'pallet', '%', 'box=frontend'])
 
+subprocess.call([stackpath, 'sync', 'config'])
 # all done
 banner("Done")
 


### PR DESCRIPTION
This is a series of commits.

First commit handles resolv.conf syncing and a partial cleanup of the `sync host network` command.

Second commit handles /etc/hosts syncing and a port of the `report host` command to SUX.

Third allows the above `sync host network` to run against a host that doesn't have a domainname attribute or an interface with a network on a zone.

Fourth adds a sync config to frontend-install.py

Final changes test-framework to always pull frontend-install.py from the same branch.