### PR TITLE
FEATURE: add 'prefix' attribute to 'stack:report' SUX tags.

### DIFF
--- a/common/src/stack/pylib/stack/profile.py
+++ b/common/src/stack/pylib/stack/profile.py
@@ -623,9 +623,13 @@ class Pass1NodeHandler(NodeHandler):
 		if not self.doEval or not self.rcl:
 			return
 		# still allow non-namespace xml attributes (deprecated)
+		prefix = self.getAttr(attrs, 'prefix')
 		command = self.getAttr(attrs, 'stack:name') or self.getAttr(attrs, 'name')
 
-		self.rclCommand = 'report.%s' % command
+		if prefix:
+			self.rclCommand = '%s.report.%s' % (prefix, command)
+		else:
+			self.rclCommand = 'report.%s' % command
 
 
 	def endTag_stack_report(self, ns, tag):


### PR DESCRIPTION
This allows 'report' commands outside of 'stack report more stuff', like `stack tdc report bynet foo bar baz` to be used in SUX.

```
<stack:report stack:prefix="tdc" stack:name="host.bynet.foo.bar">&hostname;</stack:report>

instead of:

<stack:eval>/opt/stack/bin/stack tdc report host bynet foo bar &hostname;</stack:eval>
```

This is allows for the same syntax for all report commands, but it also allows errors in the report command to actually bubble up to the `list host profile` command instead of being silently ignored.