### PR TITLE
INTERNAL: Also check for usefixtures marker before printing warning

### DIFF
--- a/redhat/nodes/ssh-client.xml
+++ b/redhat/nodes/ssh-client.xml
@@ -56,8 +56,8 @@ UseDNS no
 key="
 <stack:eval>
 /opt/stack/sbin/read-ssh-private-key RSA1 2> /dev/null | python -c '
-import base64 
-import sys 
+import base64
+import sys
 base64.encode(sys.stdin, sys.stdout)'
 </stack:eval>"
 
@@ -70,7 +70,7 @@ chmod 0400 /etc/ssh/ssh_host_key
 
 <stack:file stack:name="/etc/ssh/ssh_host_key.pub" stack:perms="0444">
 <stack:eval>
-cat /etc/ssh/ssh_host_key.pub 2> /dev/null
+cat /etc/ssh/ssh_host_key.pub
 </stack:eval>
 </stack:file>
 

--- a/test-framework/test-suites/integration/tests/fixtures/reverts.py
+++ b/test-framework/test-suites/integration/tests/fixtures/reverts.py
@@ -68,8 +68,12 @@ def _remove_overlay(target, request):
 				f.write('{}\n\n'.format('\n'.join(sorted(mods))))
 
 				# Check if the fixture is part of the function parameters
+				# or if it was specified via a usefixtures marker.
 				parameters = inspect.signature(request.function).parameters
-				if request.fixturename not in parameters:
+				usefixtures_marker = request.node.get_closest_marker("usefixtures")
+				if request.fixturename not in parameters and (
+					usefixtures_marker is None or request.fixturename not in usefixtures_marker.args
+				):
 					request.node.warn(pytest.PytestWarning(
 						f"'{request.fixturename}' fixture is missing"
 					))


### PR DESCRIPTION
This fixes the audit logic to take into account the use of the [usefixtures marker](https://docs.pytest.org/en/latest/fixture.html#using-fixtures-from-classes-modules-or-projects).