### PR TITLE
FEATURE: Add parameter to `stack load` to have it run the commands

### DIFF
--- a/test-framework/test-suites/integration/tests/fixtures/add_data.py
+++ b/test-framework/test-suites/integration/tests/fixtures/add_data.py
@@ -195,3 +195,18 @@ def add_host_with_net(host):
 	host.run("stack add host interface a:frontend interface=eth2 network=test ip=192.168.0.2")
 	host.run("stack add host backend-0-0 appliance=backend rack=0 rank=0")
 	host.run("stack add host interface backend-0-0 interface=eth0 network=test ip=192.168.0.3")
+
+@pytest.fixture(params = (True, False))
+def stack_load(request, host):
+	if request.param:
+		def _load_using_exec(dump_file, **kwargs):
+			kwargs_string = " ".join(f"{key}={value}" for key, value in kwargs.items())
+			return host.run(f"stack load {dump_file} exec=True {kwargs_string}")
+
+		return _load_using_exec
+
+	def _load_using_bash(dump_file, **kwargs):
+		kwargs_string = " ".join(f"{key}={value}" for key, value in kwargs.items() if key != "exec")
+		return host.run(f"stack load {dump_file} {kwargs_string} | bash -x")
+
+	return _load_using_bash

--- a/test-framework/test-suites/integration/tests/load/test_load.py
+++ b/test-framework/test-suites/integration/tests/load/test_load.py
@@ -17,13 +17,13 @@ class TestLoad:
 			("load/json/route.json", "load/json/expected_route.json", "stack list {} route output-format=json", "route"),
 		),
 	)
-	def test_load_processing(self, host, test_file, dump_json, expected_results_json, list_command_template, object_name):
+	def test_load_processing(self, host, stack_load, test_file, dump_json, expected_results_json, list_command_template, object_name):
 		"""Test that loading information at the various scopes works as expected."""
 		# get the file path to use in load.
 		file_path = Path(test_file(dump_json)).resolve(strict = True)
 
 		# Load all of the test data into the database. We use -e to ensure we fail if a command output by load fails.
-		result = host.run(f"stack load {file_path} | bash -x -e")
+		result = stack_load(file_path)
 		assert result.rc == 0
 
 		# Now ensure the objects were added as expected at each scope.


### PR DESCRIPTION
INTERNAL:
This allows other commands to dogfood `stack load` via the normal
`self.call` machinery.