### PR TITLE
INTERNAL: Decorator to map resolver kwargs. Useful for having `id` in the SPEC and `_id` as the  resolver kwarg.

### DIFF
--- a/common/src/stack/graph_ql/app/resolvers/HostResolver.py
+++ b/common/src/stack/graph_ql/app/resolvers/HostResolver.py
@@ -7,13 +7,15 @@
 
 from ariadne import ObjectType, QueryType, MutationType
 import app.db as db
+from app.utils import map_kwargs
 
 query = QueryType()
 mutation = MutationType()
 interface = ObjectType("Interface")
 
 @query.field("hosts")
-def resolve_hosts(_, info, id=None):
+@map_kwargs({"id": "id_"})
+def resolve_hosts(_, info, id_=None):
     # TODO: Add nested environment
     # TODO: Add nested osaction
     # TODO: Add nested installaction
@@ -31,16 +33,16 @@ def resolve_hosts(_, info, id=None):
         """
     args = ()
 
-    if id:
+    if id_:
         cmd += " WHERE id=%s"
-        args += (id, )
+        args += (id_, )
 
     results, _ = db.run_sql(cmd, args)
     return results
 
 @interface.field("host")
 def resolve_host_by_id(parent, info):
-    return resolve_hosts(parent, info, id=parent.get(id))[0]
+    return resolve_hosts(parent, info, id_=parent.get("id"))[0]
 
 
 object_types = [interface]

--- a/common/src/stack/graph_ql/app/resolvers/InterfaceResolver.py
+++ b/common/src/stack/graph_ql/app/resolvers/InterfaceResolver.py
@@ -7,6 +7,8 @@
 
 from ariadne import ObjectType, QueryType, MutationType
 import app.db as db
+from app.utils import map_kwargs
+
 
 query = QueryType()
 mutation = MutationType()
@@ -30,7 +32,8 @@ def resolve_interfaces_from_node_id(parent, info):
     return results
 
 @query.field("interfaces")
-def resolve_interfaces(_, info, id=None, host_id=None, device=None):
+@map_kwargs({"id": "id_"})
+def resolve_interfaces(_, info, id_=None, host_id=None, device=None):
     cmd = '''SELECT
         id,
         node AS host_id,
@@ -49,9 +52,9 @@ def resolve_interfaces(_, info, id=None, host_id=None, device=None):
 '''
 
     args = ()
-    if id:
+    if id_:
         cmd += ' AND id=%s '
-        args += (id, )
+        args += (id_, )
     # TODO error check -- node id and device must go together?  or maybe that's ok here?
     if host_id:
         cmd += ' AND node=%s '

--- a/common/src/stack/graph_ql/app/schema/Host.graphql
+++ b/common/src/stack/graph_ql/app/schema/Host.graphql
@@ -20,7 +20,7 @@ type Host {
 }
 
 extend type Query {
-  hosts: [Host]
+  hosts(id: Int): [Host]
 }
 
 extend type Mutation {

--- a/common/src/stack/graph_ql/app/utils.py
+++ b/common/src/stack/graph_ql/app/utils.py
@@ -1,0 +1,29 @@
+import asyncio
+from functools import wraps
+from typing import Callable, Dict, Any
+
+
+def map_kwargs(mappings: Dict) -> Callable:
+	def inner(func: Callable) -> Callable:
+		def do_mapping(kwargs: Dict) -> Dict:
+			mapped_kwargs = {}
+			for key, value in kwargs.items():
+				if key in mappings:
+					mapped_kwargs[mappings[key]] = value
+				else:
+					mapped_kwargs[key] = value
+			return mapped_kwargs
+
+		if asyncio.iscoroutinefunction(func):
+			@wraps(func)
+			async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+				return await func(*args, **do_mapping(kwargs))
+
+			return async_wrapper
+
+		@wraps(func)
+		def wrapper(*args: Any, **kwargs: Any) -> Any:
+			return func(*args, **do_mapping(kwargs))
+
+		return wrapper
+	return inner


### PR DESCRIPTION
I hope to get this decorator pushed upstream to Ariadne, unless I have to to fill out a lot of TD paperwork to do so.