### PR TITLE
Feature/implement the power

### DIFF
--- a/common/src/stack/command/stack/commands/set/host/power/__init__.py
+++ b/common/src/stack/command/stack/commands/set/host/power/__init__.py
@@ -8,96 +8,132 @@ import stack.commands
 import stack.mq
 import socket
 import json
-from stack.exception import ArgRequired, ParamError
-
+from stack.exception import ArgRequired, ParamError, CommandError
+from collections import namedtuple
 
 class Command(stack.commands.set.host.command):
 	"""
-	Sends a "power" command to a host. Valid power commands are: on, off and reset. This
-	command uses IPMI to change the power setting on a host.
-	
+	Sends a "power" command to a host. Valid power commands are: on, off, reset, and status. This
+	command uses IPMI for hardware based hosts to change the power setting.
+
 	<arg type='string' name='host' repeat='1'>
 	One or more host names.
 	</arg>
 
 	<param type='string' name='command' optional='0'>
-	The power command to execute. Valid power commands are: "on", "off" and "reset".
+	The power command to execute. Valid power commands are: "on", "off", "reset", and "status".
 	</param>
 
 	<param type='boolean' name='debug' optional='1'>
-	Print debug output from the ipmitool command.
+	Print debug output from the command. For ipmi capable hosts, prints
+	the output from ipmitool.
+	</param>
+
+	<param type='string' name='method' optional='1'>
+	Set a desired method for communicating to hosts, possible methods
+	include but are not limited to ipmi and ssh.
 	</param>
 
 	<example cmd='set host power stacki-1-1 command=reset'>
 	Performs a hard power reset on host stacki-1-1.
 	</example>
+
+	<example cmd='set host power stacki-1-1 command=off method=ssh'>
+	Turns off host stacki-1-1 using ssh.
+	</example>
 	"""
-
-	def doPower(self, host, ipmi_ip, cmd):
-		import subprocess
-		import shlex
-
-		if not ipmi_ip:
-			return
-
-		username = self.getHostAttr(host, 'ipmi_username')
-		if not username:
-			username = 'root'
-
-		password = self.getHostAttr(host, 'ipmi_password')
-		if not password:
-			password = 'admin'
-
-		ipmi = 'ipmitool -I lanplus -H %s -U %s -P %s chassis power %s' \
-			% (ipmi_ip, username, password, cmd)
-
-		p = subprocess.Popen(shlex.split(ipmi), stdout = subprocess.PIPE,
-			stderr = subprocess.STDOUT)
-		out, err = p.communicate()
-
-		if self.debug:
-			self.beginOutput()
-			self.addOutput(host, out.decode())
-			self.endOutput(padChar='', trimOwner=True)
+	def mq_publish(self, host, cmd):
+		"""
+		Publish the power status to the
+		message queue
+		"""
 
 		ttl = 60*10
 		if cmd == 'off':
 			ttl = -1
 
-		msg = { 'source' : host, 
-			'channel': 'health', 
+		msg = { 'source' : host,
+			'channel': 'health',
 			'ttl'    : ttl,
 			'payload': '{"state": "power %s"}' % cmd }
 
 		tx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-		tx.sendto(json.dumps(msg).encode(), 
+		tx.sendto(json.dumps(msg).encode(),
 			  ('127.0.0.1', stack.mq.ports.publish))
 		tx.close()
-
-
 
 	def run(self, params, args):
 		if not len(args):
 			raise ArgRequired(self, 'host')
 
-		cmd, debug = self.fillParams([ ('command', None, True), ('debug', False) ])
-
-		if cmd == 'status':
-			#
-			# used by "stack list host power" -- this is an easy way in which to
-			# share code between the two commands
-			#
-			# set 'debug' to True in order to get output from the status command
-			#
-			debug = True
-		elif cmd not in [ 'on', 'off', 'reset' ]:
-			raise ParamError(self, 'command', 'must be "on", "off" or "reset"')
-		
+		cmd, debug, force_imp = self.fillParams([
+			('command', None, True),
+			('debug', False),
+			('method', None)
+		])
+		host_errors = []
 		self.debug = self.str2bool(debug)
-		
-		for host in self.getHostnames(args):
-			for o in self.call('list.host.interface', [ host ]):
-				if o['interface'] == 'ipmi':
-					self.doPower(host, o['ip'], cmd)
-					break
+		impl_output = namedtuple('output', 'out debug success')
 
+		self.loadImplementation()
+
+		# The first implementation is ipmi by default
+		# but can be forced by the method parameter
+		# If this is set, only that implementation will be run
+		if force_imp:
+			if force_imp not in self.impl_list:
+				raise ParamError(self, 'method', f'{force_imp} not found as a valid implementation')
+			imp_names = [force_imp]
+
+		# Otherwise use all the implementations
+		else:
+
+			# Gather all set power implmentations besides ipmi and ssh
+			imp_names  = [imp for imp in self.impl_list if imp not in ['ssh', 'ipmi']]
+
+			# Add ipmi to be the first implementation used
+			if 'ipmi' in self.impl_list:
+				imp_names.insert(0, 'ipmi')
+
+			# Add ssh to be the last implementation used
+			if 'ssh' in self.impl_list:
+				imp_names.append('ssh')
+
+		if cmd not in ['on', 'off', 'reset', 'status']:
+			raise ParamError(self, 'command', 'must be "on", "off", "reset", or "status"')
+
+		for host in self.getHostnames(args):
+
+			# Flag for if an implementation has
+			# successfully run. Set to true if an
+			# implementation returns success in its output
+			imp_success = False
+			self.beginOutput()
+
+			# Iterate through each implementation
+			# if one succeeds, we are done with the command
+			for imp in imp_names:
+				imp_msg = self.runImplementation(imp, [host, cmd, impl_output])
+				if imp_msg.out:
+					self.addOutput(host, imp_msg.out)
+				if self.debug:
+
+					# Output debug information if the parameter was set
+					if not imp_msg.success and imp_msg.debug:
+						self.addOutput(host, f'Failed to set power via {imp}: "{imp_msg.debug}"')
+
+					# Handle if an implementation fails but has no debug information
+					elif not imp_msg.success:
+						self.addOutput(host, f'Failed to set power via {imp}')
+					elif imp_msg.success:
+						self.addOutput(host, f'Successfully set power via {imp}')
+
+				# We don't need to run anymore implementations
+				# now that one has succeeded for this host
+				if imp_msg.success:
+					imp_success = True
+					self.mq_publish(host, cmd)
+					break
+			if self.debug and not imp_success:
+				self.addOutput(host, f'Could not set power cmd {cmd} on host {host}')
+			self.endOutput(padChar='', trimOwner=True)

--- a/common/src/stack/command/stack/commands/set/host/power/imp_ipmi.py
+++ b/common/src/stack/command/stack/commands/set/host/power/imp_ipmi.py
@@ -1,0 +1,34 @@
+# @copyright@
+# Copyright (c) 2006 - 2019 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+
+import stack.commands
+
+class Implementation(stack.commands.Implementation):
+	def run(self, args):
+		host = args[0]
+		cmd = args[1]
+		impl_output = args[2]
+		ipmi_ip = ''
+
+		# See if the host has an ipmi interface, raise an error if not
+		for interface in self.owner.call('list.host.interface', args = [host]):
+			if interface['interface'] == 'ipmi':
+				ipmi_ip = interface['ip']
+				break
+		if not ipmi_ip:
+			return impl_output('', f'{host} missing ipmi interface', False)
+
+		# Try to get ipmi username/passwords, otherwise try defaults
+		username = self.owner.getHostAttrDict(host)[host].get('ipmi_username', 'root')
+		password = self.owner.getHostAttrDict(host)[host].get('ipmi_password', 'admin')
+
+		# Run the actual ipmitool command
+		ipmi = f'ipmitool -I lanplus -H {ipmi_ip} -U {username} -P {password} chassis power {cmd}'
+
+		cmd_output = self.owner._exec(ipmi, shlexsplit=True)
+		if cmd_output.returncode != 0:
+			return impl_output('' , cmd_output.stderr, False)
+		return impl_output(cmd_output.stdout, '', True)

--- a/common/src/stack/command/stack/commands/set/host/power/imp_ssh.py
+++ b/common/src/stack/command/stack/commands/set/host/power/imp_ssh.py
@@ -1,0 +1,47 @@
+# @copyright@
+# Copyright (c) 2006 - 2019 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+
+import stack.commands
+
+class Implementation(stack.commands.Implementation):
+	def run(self, args):
+		host = args[0]
+		cmd = args[1]
+		impl_output = args[2]
+
+		# Unlike ipmi, ssh has no way to start a host that is off
+		# We still have to handle the command however
+		if cmd == 'on':
+			return impl_output('', f'Cannot use ssh to start host {host}', False)
+
+		elif cmd == 'off':
+			cmd_output = self.owner._exec(f'ssh {host} "shutdown -h now"', shlexsplit=True)
+			err = cmd_output.stderr
+			if cmd_output.returncode != 0 and f'Connection to {host} closed by remote host' not in err:
+				return impl_output('', err.strip(), False)
+			return impl_output('', cmd_output.stdout, True)
+
+		elif cmd == 'reset':
+			cmd_output = self.owner._exec(f'ssh {host} "reboot"',shlexsplit=True)
+			err = cmd_output.stderr
+
+			# After issueing a reboot, ssh will send a Connection closed message in stderr
+			# We shouldn't raise an error because of this
+			if cmd_output.returncode != 0 and f'Connection to {host} closed by remote host' not in err:
+				return impl_output('', err.strip(), False)
+
+			# Return stderr here as stdout is blank
+			return impl_output('', err.strip(), True)
+
+		elif cmd == 'status':
+
+			# If we can run a command on the remote host, it's up
+			cmd_output = self.owner._exec(f'ssh {host} "hostname"', shlexsplit=True)
+			out = cmd_output.stdout
+			err = cmd_output.stderr
+			if cmd_output.returncode != 0:
+				return impl_output('', f'Chassis Power is unreachable via ssh: {err.strip()}', False)
+			return impl_output(f'Chassis Power is on\n', '', True)

--- a/test-framework/test-suites/system/tests/stacki/test_set_host_power.py
+++ b/test-framework/test-suites/system/tests/stacki/test_set_host_power.py
@@ -1,0 +1,37 @@
+from textwrap import dedent
+
+class TestSetHostPower:
+	def test_single_host(self, host):
+		result = host.run('stack set host power backend-0-0 command="status"')
+		assert result.rc == 0
+		assert result.stdout.strip() == 'Chassis Power is on'
+
+	def test_multiple_hosts(self, host):
+		result = host.run('stack set host power backend-0-0 backend-0-1 command="status"')
+		assert result.rc == 0
+		power_count = 0
+		for line in result.stdout.splitlines():
+			if "Chassis Power is on" in line:
+				power_count += 1
+		assert power_count == 2
+
+	def test_invalid_command(self, host):
+		result = host.run('stack set host power backend-0-0 command="invalid_command"')
+		assert result.rc == 255
+
+	def test_invalid_host(self, host):
+		result = host.run('stack set host power invalid_host command="status"')
+		assert result.rc == 255
+		assert result.stderr.strip() == 'error - cannot resolve host "invalid_host"'
+
+	def test_invalid_method(self, host):
+		result = host.run('stack set host power backend-0-0 command="status" method=invalid_method')
+		assert result.rc == 255
+
+	def test_invalid_ipmi(self, host):
+		result = host.run('stack set host power backend-0-0 command="status" debug=y method=ipmi')
+		assert result.rc == 0
+		assert result.stdout == dedent('''\
+		Failed to set power via ipmi: "backend-0-0 missing ipmi interface"
+		Could not set power cmd status on host backend-0-0
+		''')


### PR DESCRIPTION
This refactors `set host power` to be more modular by being able to use other implementations for setting power on hosts that lack ipmi. Included is an implementation for ipmi and ssh. In addition a new command flag is added to force a specific implementation. For instance `set host power $HOST command=reset force=ssh` will use the ssh implementation for the command only. Without the force flag, the normal order is to try ipmi first, then any additional implementations before falling back to ssh.  