### PR TITLE
FEATURE: Add port forwarding to `cluster-up`

### DIFF
--- a/tools/cluster-up/README.md
+++ b/tools/cluster-up/README.md
@@ -23,23 +23,23 @@ the download directory before bringing up the cluster.
 
 There are some optional arguments you can pass to the command:
 
-    --backends=[0-253]          The number backends to create. Default: 0
-    --fqdn=FQDN                 The FQDN of the frontend. Default: cluster-up-frontend.localdomain
-    --name=NAME                 The name to uniquely identify this cluster. Default: cluster-up-RRRRRRRR
-    --download-dir=DIRECTORY    The directory to store installer ISOs. Default: '.'
-    --use-the-src-dir=DIRECTORY The directory will be mounted and symlinked into the frontend.
-    --export-frontend           Export the frontend as a vagrant box with the same name as the STACK_ISO
-
+    --backends=[0-253]            The number backends to create. Default: 0
+    --fqdn=FQDN                   The FQDN of the frontend. Default: cluster-up-frontend.localdomain
+    --name=NAME                   The name to uniquely identify this cluster. Default: cluster-up-RRRRRRRR
+    --download-dir=DIRECTORY      The directory to store installer ISOs. Default: '.'
+    --use-the-src-dir=DIRECTORY   The directory will be mounted and symlinked into the frontend.
+    --export-frontend             Export the frontend as a vagrant box with the same name as the STACK_ISO
+    --forward-ports=SRC:DST[,...] Comma separated list of ports to forward.
 You can also specify the following flags, which will switch cluster-up to create
 the second interface to a bridge interface on the VM host. If you specify a bridged
 interface, then no backends will be automatically created, as they rely on host only
 networking. Instead, you can create your own backends over the bridged interface.
 
-    --bridge=INTERFACE          Bridge interface on the host. Default: Use host only networking
-    --ip=IP_ADDRESS             IP Address for the bridge network. Default: Use DHCP
-    --netmask=NETMASK           The netmask for the bridge network. Default: 255.255.255.0
-    --gateway=GATEWAY_ADDRESS   Gateway address for the bridged interface.
-    --dns=DNS_ADDRESS[,DNS2]    Comma seperated list of DNS servers.
+    --bridge=INTERFACE            Bridge interface on the host. Default: Use host only networking
+    --ip=IP_ADDRESS               IP Address for the bridge network. Default: Use DHCP
+    --netmask=NETMASK             The netmask for the bridge network. Default: 255.255.255.0
+    --gateway=GATEWAY_ADDRESS     Gateway address for the bridged interface.
+    --dns=DNS_ADDRESS[,DNS2]      Comma separated list of DNS servers.
 
 The script will create a generic OS frontend box in Virtualbox or KVM, install
 Stacki on it, then pxe-boot the number of backends requested (None by default) and

--- a/tools/cluster-up/Vagrantfile
+++ b/tools/cluster-up/Vagrantfile
@@ -25,6 +25,7 @@ if File.file?('.vagrant/cluster-up.json')
   NETMASK = settings['NETMASK']
   GATEWAY = settings['GATEWAY']
   DNS = settings['DNS']
+  FORWARD_PORTS = settings['FORWARD_PORTS']
 
   Vagrant.configure("2") do |config|
     config.vm.define "frontend", autostart: false do |config|
@@ -91,6 +92,11 @@ if File.file?('.vagrant/cluster-up.json')
             dev: BRIDGE,
             libvirt__adapter: 1
         end
+      end
+
+      FORWARD_PORTS.split(",").each do |pair|
+        host, guest = pair.split(":")
+        config.vm.network "forwarded_port", host: host.to_i, guest: guest.to_i
       end
 
       config.vm.provision "shell", path: "provision-frontend.sh", env: settings

--- a/tools/cluster-up/cluster-up.sh
+++ b/tools/cluster-up/cluster-up.sh
@@ -31,6 +31,7 @@ IP=""
 NETMASK="255.255.255.0"
 GATEWAY=""
 DNS=""
+FORWARD_PORTS=""
 
 while [[ "$#" -gt 0 ]]
 do
@@ -79,6 +80,14 @@ do
             DNS="${1#*=}"
             shift 1
             ;;
+        --forward-ports=*)
+            FORWARD_PORTS="${1#*=}"
+            shift 1
+            ;;
+        --*)
+            echo -e "\033[31mError: unrecognized flag \"$1\"\033[0m"
+            exit 1
+            ;;
         *)
             ISO="$1"
             shift 1
@@ -90,17 +99,18 @@ if [[ -z "$ISO" ]]
 then
     echo "Usage: ./cluster-up.sh [options...] STACKI_ISO"
     echo "Options:"
-    echo -e "  --backends=[0-253]\t\tThe number backends to create. Default: 1"
+    echo -e "  --backends=[0-253]\t\tThe number backends to create. Default: 0"
     echo -e "  --fqdn=FQDN\t\t\tThe FQDN of the frontend. Default: cluster-up-frontend.localdomain"
     echo -e "  --name=NAME\t\t\tThe name to uniquely identify this cluster. Default: YYYYMMDD_HHMMSS_RRRR"
     echo -e "  --download-dir=DIRECTORY\tThe directory to store installer ISOs. Default: '.'"
     echo -e "  --use-the-src-dir=DIRECTORY\tThe directory will be mounted and symlinked into the frontend."
     echo -e "  --export-frontend\t\tExport the frontend as a vagrant box."
+    echo -e "  --forward-ports=SRC:DST[,...]\tComma separated list of ports to forward."
     echo -e "  --bridge=INTERFACE\t\tBridge interface on the host. Default: Use host only networking"
     echo -e "  --ip=IP_ADDRESS\t\tIP Address for the bridge network. Default: Use DHCP"
     echo -e "  --netmask=NETMASK\t\tThe netmask for the bridge network. Default: 255.255.255.0"
     echo -e "  --gateway=GATEWAY_ADDRESS\tGateway address for the bridged interface."
-    echo -e "  --dns=DNS_ADDRESS[,DNS2]\tComma seperated list of DNS servers."
+    echo -e "  --dns=DNS_ADDRESS[,DNS2]\tComma separated list of DNS servers."
     exit 1
 fi
 
@@ -212,7 +222,8 @@ cat > ".vagrant/cluster-up.json" <<-EOF
     "IP": "$IP",
     "NETMASK": "$NETMASK",
     "GATEWAY": "$GATEWAY",
-    "DNS": "$DNS"
+    "DNS": "$DNS",
+    "FORWARD_PORTS": "$FORWARD_PORTS"
 }
 EOF
 


### PR DESCRIPTION
You can now pass a new `--forward-ports=SRC:DST[,...]` flag to the `cluster-up.sh` command to forward ports from the host (SRC) to the guest VM (DST). Multiple comma separated SRC:DST pairs can be passed in the flag.