### PR TITLE
BUGFIX: Allow cluster-up to use the local `frontend-install.py`

### DIFF
--- a/tools/cluster-up/cluster-up.sh
+++ b/tools/cluster-up/cluster-up.sh
@@ -259,6 +259,12 @@ then
     fi
 fi
 
+# Pull frontend-install.py from the local machine if we are running from a full repo checkout
+if [[ -f ../fab/frontend-install.py ]]
+then
+    cp ../fab/frontend-install.py .
+fi
+
 # Make sure the boxes are up-to-date
 echo
 echo -e "\033[34mChecking the vagrant boxes for updates ...\033[0m"

--- a/tools/cluster-up/provision-frontend.sh
+++ b/tools/cluster-up/provision-frontend.sh
@@ -43,11 +43,16 @@ then
     echo "nameserver ${DNS//,/ /}" >> /etc/resolv.conf
 fi
 
-# Fetch the barnacle script
-curl -sfSLO --retry 3 https://raw.githubusercontent.com/Teradata/stacki/develop/tools/fab/frontend-install.py
-chmod u+x frontend-install.py
+# Fetch the barnacle script, if needed
+if [[ -f /vagrant/frontend-install.py ]]
+then
+    mv /vagrant/frontend-install.py .
+else
+    curl -sfSLO --retry 3 https://raw.githubusercontent.com/Teradata/stacki/$(echo $ISO_FILENAME | cut -d '-' -f -2 | cut -d '_' -f 1)/tools/fab/frontend-install.py
+fi
 
 # Barnacle myself, choosing the second interface
+chmod u+x frontend-install.py
 ./frontend-install.py --use-existing --stacki-iso="/export/stacki-iso/$ISO_FILENAME" <<< "2"
 
 # Allow port forwards to talk on eth0


### PR DESCRIPTION
If it can't find a local copy, then try to pull it from Github using a branch which matches the version embedded in the ISO name.