### PR TITLE
BUGFIX: Only allow valid hostname labels

### DIFF
--- a/common/src/stack/command/stack/commands/add/host/__init__.py
+++ b/common/src/stack/command/stack/commands/add/host/__init__.py
@@ -19,7 +19,7 @@ from stack.exception import (
 	ArgRequired,
 	ArgValue,
 )
-from stack.util import is_hostname_label
+from stack.util import is_valid_hostname
 
 
 class command(
@@ -88,7 +88,7 @@ class Command(command):
 
 		host = args[0].lower()
 
-		if not is_hostname_label(host):
+		if not is_valid_hostname(host):
 			raise ArgValue(self, 'host', 'a valid hostname label')
 
 		if self.db.count('(ID) from nodes where name=%s', (host,)) > 0:

--- a/common/src/stack/command/stack/commands/add/host/__init__.py
+++ b/common/src/stack/command/stack/commands/add/host/__init__.py
@@ -12,7 +12,14 @@
 
 
 import stack.commands
-from stack.exception import CommandError, ParamRequired, ArgUnique, ArgRequired
+from stack.exception import (
+	CommandError,
+	ParamRequired,
+	ArgUnique,
+	ArgRequired,
+	ArgValue,
+)
+from stack.util import is_hostname_label
 
 
 class command(
@@ -80,6 +87,9 @@ class Command(command):
 			raise ArgUnique(self, 'host')
 
 		host = args[0].lower()
+
+		if not is_hostname_label(host):
+			raise ArgValue(self, 'host', 'a valid hostname label')
 
 		if self.db.count('(ID) from nodes where name=%s', (host,)) > 0:
 			raise CommandError(self, 'host "%s" already exists in the database' % host)

--- a/common/src/stack/command/stack/commands/set/host/name/__init__.py
+++ b/common/src/stack/command/stack/commands/set/host/name/__init__.py
@@ -12,7 +12,8 @@
 
 
 import stack.commands
-from stack.exception import CommandError
+from stack.exception import CommandError, ParamValue
+from stack.util import is_hostname_label
 
 
 class Command(stack.commands.set.host.command):
@@ -38,6 +39,9 @@ class Command(stack.commands.set.host.command):
 		(name, ) = self.fillParams([
 			('name', None, True)
 		])
+
+		if not is_hostname_label(name):
+			raise ParamValue(self, 'name', 'a valid hostname label')
 
 		if name in self.getHostnames():
 			raise CommandError(self, 'name already exists')

--- a/common/src/stack/command/stack/commands/set/host/name/__init__.py
+++ b/common/src/stack/command/stack/commands/set/host/name/__init__.py
@@ -13,7 +13,7 @@
 
 import stack.commands
 from stack.exception import CommandError, ParamValue
-from stack.util import is_hostname_label
+from stack.util import is_valid_hostname
 
 
 class Command(stack.commands.set.host.command):
@@ -40,7 +40,7 @@ class Command(stack.commands.set.host.command):
 			('name', None, True)
 		])
 
-		if not is_hostname_label(name):
+		if not is_valid_hostname(name):
 			raise ParamValue(self, 'name', 'a valid hostname label')
 
 		if name in self.getHostnames():

--- a/common/src/stack/pylib/stack/util.py
+++ b/common/src/stack/pylib/stack/util.py
@@ -177,7 +177,19 @@ def is_valid_hostname(name):
 	"""Check if a given name is a valid hostname.
 
 	For our purposes, a valid hostname is a single hostname label (or "name")
-	as defined by RFCs 952 and 1123.
+	as defined by RFCs 952 and 1123. That is, a name of 1 to 63 characters
+	starting and ending with a letter or digit and having letters, digits,
+	and/or hyphens in between.
 	"""
-	pattern = r"^[a-zA-Z0-9]$|^[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]$"
-	return bool(re.match(pattern, name))
+	return bool(
+		re.match(
+			r"""
+			# <let-or-digit>
+			^[a-z0-9]$
+			# / <let-or-digit> 0*61<let-or-digit-or-hyphen> <let-or-digit>
+			|^[a-z0-9][a-z0-9\-]{0,61}[a-z0-9]$
+			""",
+			name,
+			flags=re.IGNORECASE | re.VERBOSE
+		)
+	)

--- a/common/src/stack/pylib/stack/util.py
+++ b/common/src/stack/pylib/stack/util.py
@@ -173,10 +173,11 @@ def lowered(iterable):
 	"""Return a generator that lowercases all strings in the provided iterable."""
 	return (string.lower() for string in iterable)
 
-def is_hostname_label(name):
-	"""Check if a given name is a valid hostname label.
+def is_valid_hostname(name):
+	"""Check if a given name is a valid hostname.
 
-	Validity is defined by RFCs 952 and 1123.
+	For our purposes, a valid hostname is a single hostname label (or "name")
+	as defined by RFCs 952 and 1123.
 	"""
 	pattern = r"^[a-zA-Z0-9]$|^[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]$"
 	return bool(re.match(pattern, name))

--- a/common/src/stack/pylib/stack/util.py
+++ b/common/src/stack/pylib/stack/util.py
@@ -17,6 +17,7 @@ import subprocess
 import shlex
 import itertools
 from xml.sax import handler
+import re
 
 # An exception for Kickstart builder trinity: kcgi, kgen, kpp
 
@@ -171,3 +172,11 @@ def unique_everseen(iterable, key=None):
 def lowered(iterable):
 	"""Return a generator that lowercases all strings in the provided iterable."""
 	return (string.lower() for string in iterable)
+
+def is_hostname_label(name):
+	"""Check if a given name is a valid hostname label.
+
+	Validity is defined by RFCs 952 and 1123.
+	"""
+	pattern = r"^[a-zA-Z0-9]$|^[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]$"
+	return bool(re.match(pattern, name))

--- a/test-framework/test-suites/integration/tests/add/test_add_host.py
+++ b/test-framework/test-suites/integration/tests/add/test_add_host.py
@@ -82,6 +82,12 @@ class TestAddHost:
 		assert result.rc == 255
 		assert result.stderr == f'error - "test" os boot action for "{host_os}" is missing\n'
 
+	def test_invalid_hostname(self, host):
+		result = host.run('stack add host -bad-backend appliance=backend rack=0 rank=0')
+		assert result.rc == 255
+		errmsg = result.stderr.split('\n')[0]
+		assert errmsg == 'error - "host" argument must be a valid hostname label'
+
 	def test_with_environment(self, host, host_os):
 		# Create our environment
 		result = host.run('stack add environment test')

--- a/test-framework/test-suites/integration/tests/set/test_set_host_name.py
+++ b/test-framework/test-suites/integration/tests/set/test_set_host_name.py
@@ -32,6 +32,12 @@ class TestSetHostName:
 		assert result.rc == 255
 		assert result.stderr == 'error - name already exists\n'
 
+	def test_invalid_name(self, host, add_host):
+		result = host.run('stack set host name backend-0-0 name=-bad-backend')
+		assert result.rc == 255
+		errmsg = result.stderr.split('\n')[0]
+		assert errmsg == 'error - "name" parameter must be a valid hostname label'
+
 	def test_single_host(self, host, add_host, host_os):
 		# Set the host name
 		result = host.run('stack set host name backend-0-0 name=test')

--- a/test-framework/test-suites/unit/tests/pylib/stack/test_pylib_stack_util.py
+++ b/test-framework/test-suites/unit/tests/pylib/stack/test_pylib_stack_util.py
@@ -96,8 +96,8 @@ class TestUtil:
 		"""Expect lowered to lowercase all strings in an interable."""
 		assert ["foo", "bar", "baz"] == list(stack.util.lowered(["FOO", "BAR", "BAZ"]))
 
-	def test_is_hostname_label(self):
-		assert stack.util.is_hostname_label("backend-0-0")
-		assert not stack.util.is_hostname_label("-no-leading-minus")
-		assert not stack.util.is_hostname_label("no-trailing-minus-")
-		assert not stack.util.is_hostname_label("no.other_chars")
+	def test_is_valid_hostname(self):
+		assert stack.util.is_valid_hostname("backend-0-0")
+		assert not stack.util.is_valid_hostname("-no-leading-minus")
+		assert not stack.util.is_valid_hostname("no-trailing-minus-")
+		assert not stack.util.is_valid_hostname("no.other_chars")

--- a/test-framework/test-suites/unit/tests/pylib/stack/test_pylib_stack_util.py
+++ b/test-framework/test-suites/unit/tests/pylib/stack/test_pylib_stack_util.py
@@ -95,3 +95,9 @@ class TestUtil:
 	def test_lowered(self):
 		"""Expect lowered to lowercase all strings in an interable."""
 		assert ["foo", "bar", "baz"] == list(stack.util.lowered(["FOO", "BAR", "BAZ"]))
+
+	def test_is_hostname_label(self):
+		assert stack.util.is_hostname_label("backend-0-0")
+		assert not stack.util.is_hostname_label("-no-leading-minus")
+		assert not stack.util.is_hostname_label("no-trailing-minus-")
+		assert not stack.util.is_hostname_label("no.other_chars")

--- a/test-framework/test-suites/unit/tests/pylib/stack/test_pylib_stack_util.py
+++ b/test-framework/test-suites/unit/tests/pylib/stack/test_pylib_stack_util.py
@@ -98,6 +98,14 @@ class TestUtil:
 
 	def test_is_valid_hostname(self):
 		assert stack.util.is_valid_hostname("backend-0-0")
+		assert stack.util.is_valid_hostname("a")
+		assert not stack.util.is_valid_hostname("")
+
 		assert not stack.util.is_valid_hostname("-no-leading-minus")
 		assert not stack.util.is_valid_hostname("no-trailing-minus-")
 		assert not stack.util.is_valid_hostname("no.other_chars")
+
+		max_len_name = "63---------------------------------------------------------long"
+		assert stack.util.is_valid_hostname(max_len_name)
+		longer_name = "64----------------------------------------------------------long"
+		assert not stack.util.is_valid_hostname(longer_name)


### PR DESCRIPTION
Validity is defined by RFCs 952 and 1123.
Hostnames in `add/set host` are validated as one label.