### PR TITLE
INTERNAL: Added django to dumped databases

### DIFF
--- a/test-framework/test-suites/integration/tests/conftest.py
+++ b/test-framework/test-suites/integration/tests/conftest.py
@@ -76,6 +76,7 @@ def dump_mysql(worker_id):
 	# Put drop database commands at the front of the SQL restore file
 	file_obj.write("DROP DATABASE IF EXISTS `shadow`;\n")
 	file_obj.write("DROP DATABASE IF EXISTS `cluster`;\n\n")
+	file_obj.write("DROP DATABASE IF EXISTS `django`;\n\n")
 	file_obj.flush()
 	os.fsync(file_fd)
 

--- a/test-framework/test-suites/integration/tests/conftest.py
+++ b/test-framework/test-suites/integration/tests/conftest.py
@@ -81,7 +81,7 @@ def dump_mysql(worker_id):
 
 	# Dump the initial Stacki DB into an SQL file, to restore from after each test
 	subprocess.run([
-		"mysqldump", "--opt", "--databases", "cluster", "shadow"
+		"mysqldump", "--opt", "--databases", "cluster", "shadow", "django"
 	], stdout=file_obj, check=True)
 
 	# Close the file


### PR DESCRIPTION
## Solves Issue #382 

I've added "django" to the list to databases. Since it's integration test, there is no need to verify the database name from `/opt/stack/etc/django.my.cnf`, right?