### PR TITLE
Bugfix/uefi denied

### DIFF
--- a/redhat/nodes/uefi-server.xml
+++ b/redhat/nodes/uefi-server.xml
@@ -13,7 +13,9 @@ https://github.com/Teradata/stacki/blob/master/LICENSE.txt
 <stack:script stack:stage="install-post">
 mkdir -p /tftpboot/pxelinux/uefi/
 cp /boot/efi/EFI/centos/grubx64.efi /tftpboot/pxelinux/uefi/
+chmod 0644 /tftpboot/pxelinux/uefi/grubx64.efi
 cp /boot/efi/EFI/centos/shim.efi /tftpboot/pxelinux/uefi/
+chmod 0644 /tftpboot/pxelinux/uefi/shim.efi
 
 <stack:file stack:name="/tftpboot/pxelinux/uefi/grub.cfg" stack:perms="0644">
 configfile ($root)/uefi/grub.cfg-$net_default_ip


### PR DESCRIPTION
When setting up a frontend to serve uefi based hosts on CentOS, the previous
behavior was to just copy shim.efi and grubx64.efi from /boot/EFI/centos
without changing their file permissions. These files had permissions of 0700,
resulting in tftp permission denied errors when trying to retrive files from
the host, causing boot errors. This commit changes these files to be readable
by anyone (0644) after being copied so they can be served to hosts via tftp.