### PR TITLE
FEATURE: Add example partition spreadsheets for uefi based hosts

### DIFF
--- a/common/src/stack/examples/spreadsheets/partition/redhat-uefi.csv
+++ b/common/src/stack/examples/spreadsheets/partition/redhat-uefi.csv
@@ -1,0 +1,7 @@
+NAME,DEVICE,MOUNTPOINT,SIZE,TYPE,OPTIONS
+backend-0-0,sda,/boot/efi,512,efi,
+,sda,swap,8192,swap,
+,sda,/export,15360,xfs,
+,sda,/boot,1024,xfs,
+,sda,/,16000,xfs,
+,sda,/var,26000,xfs,

--- a/common/src/stack/examples/spreadsheets/partition/sles-uefi.csv
+++ b/common/src/stack/examples/spreadsheets/partition/sles-uefi.csv
@@ -1,0 +1,6 @@
+NAME,DEVICE,MOUNTPOINT,SIZE,TYPE,OPTIONS
+backend-0-0,sda,/boot/efi,512,vfat,
+,sda,swap,8192,swap,
+,sda,/export,15360,xfs,
+,sda,/,17000,xfs,
+,sda,/var,26000,xfs,


### PR DESCRIPTION
I've been doing some uefi testing and noticed we didn't have any example spreadsheets. There is a seperate one for SLES as unlike Redhat, it doesn't seem to like having a separate /boot partition (dumps to a grub rescue shell). I have tested both of these on uefi based SLES and Redhat backends and they come up successfully. 