### PR TITLE
INTERNAL: Add testing of backend partitioning to system tests

### DIFF
--- a/test-framework/Vagrantfile
+++ b/test-framework/Vagrantfile
@@ -103,7 +103,7 @@ Vagrant.configure("2") do |config|
     config.vm.provision :reload
   end
 
-  (0..1).each do |i|
+  (0..2).each do |i|
     config.vm.define "backend-0-#{i}", autostart: false do |config|
       config.vm.box = "stacki/pxe-boot"
       config.vm.box_url = "http://stacki-builds.labs.teradata.com/vagrant-boxes/pxe-boot.json"

--- a/test-framework/test-suites/system/files/hosts.csv
+++ b/test-framework/test-suites/system/files/hosts.csv
@@ -1,0 +1,5 @@
+NAME,INTERFACE HOSTNAME,DEFAULT,APPLIANCE,RACK,RANK,IP,MAC,INTERFACE,NETWORK,CHANNEL,OPTIONS,VLAN,INSTALLACTION,OSACTION,GROUPS,BOX,COMMENT
+backend-0-0,,,backend,0,0,,,eth0,,,noreport,,,,,,
+backend-0-0,,TRUE,,,,192.168.0.1,52:54:00:00:00:03,eth1,private,,,,,,,,
+backend-0-1,,,backend,0,1,,,eth0,,,noreport,,,,,,
+backend-0-1,,TRUE,,,,192.168.0.3,52:54:00:00:00:04,eth1,private,,,,,,,,

--- a/test-framework/test-suites/system/files/lvm-complex.csv
+++ b/test-framework/test-suites/system/files/lvm-complex.csv
@@ -1,0 +1,13 @@
+NAME,DEVICE,MOUNTPOINT,SIZE,TYPE,OPTIONS
+backend-0-0,sda,biosboot,1,biosboot,
+,sda,/boot,500,xfs,
+,sda,pv.01,25000,lvm,
+,pv.01,vg_sys,0,volgroup,
+,vg_sys,/,2048,xfs,--name=lv_root
+,vg_sys,swap,1024,xfs,--name=lv_swap
+,vg_sys,/usr,6144,xfs,--name=lv_usr
+,vg_sys,/var,4096,xfs,"--name=lv_var --fsoptions=defaults,nodev"
+,vg_sys,/var/log,2048,xfs,"--name=lv_var_log --fsoptions=defaults,nodev,noexec,nosuid"
+,vg_sys,/home,500,xfs,"--name=lv_home --fsoptions=defaults,nodev,nosuid"
+,vg_sys,/opt,2560,xfs,"--name=lv_opt --fsoptions=defaults,nodev,nosuid"
+,vg_sys,/tmp,2048,xfs,"--name=lv_tmp --fsoptions=defaults,nodev,noexec,nosuid"

--- a/test-framework/test-suites/system/files/monitor-backends.py
+++ b/test-framework/test-suites/system/files/monitor-backends.py
@@ -65,10 +65,16 @@ async def monitor_install(backend):
 
 async def main(timeout):
 	# Create our monitoring tasks...
+	# backend-0-0 will end up with the .1, the frontend will have the .2,
+	# backend-0-1 will end up with the .3, and backend-0-2 will have the .4
+	backend_ips = {
+		"backend-0-0": "192.168.0.1",
+		"backend-0-1": "192.168.0.3",
+		"backend-0-2": "192.168.0.4",
+	}
 	tasks = asyncio.gather(
-		monitor_install("192.168.0.1"),
-		monitor_install("192.168.0.3"),
-		return_exceptions=True
+		*(monitor_install(ip) for ip in backend_ips.values()),
+		return_exceptions=True,
 	)
 
 	# ...and run them with a timeout
@@ -85,14 +91,11 @@ async def main(timeout):
 		# vagrant output for the backends
 		await asyncio.sleep(10)
 
-		print()
-		print("*** Last status for backend-0-0 ***")
-		print(STATUSES["192.168.0.1"])
-		print()
-
-		print("*** Last status for backend-0-1 ***")
-		print(STATUSES["192.168.0.3"])
-		print()
+		for backend, ip in backend_ips.items():
+			print()
+			print(f"*** Last status for {backend} ***")
+			print(STATUSES[ip])
+			print()
 
 	# Return if our tasks finished successfully or not
 	return not any(isinstance(result, Exception) for result in results)

--- a/test-framework/test-suites/system/files/quoted-options.csv
+++ b/test-framework/test-suites/system/files/quoted-options.csv
@@ -1,0 +1,7 @@
+NAME,DEVICE,MOUNTPOINT,SIZE,TYPE,OPTIONS
+backend-0-1,sda,biosboot,1,biosboot,
+,sda,swap,8192,swap,
+,sda,/var/lib/docker,0,xfs,"--mkfsoptions=""-n ftype=1"""
+,sda,/boot,1024,xfs,
+,sda,/,16000,xfs,
+,sda,/var,26000,xfs,

--- a/test-framework/test-suites/system/files/set-redhat-host-partitions.sh
+++ b/test-framework/test-suites/system/files/set-redhat-host-partitions.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Bail on script errors
+set -e
+
+# Add hosts which are going to get specific partitioning setups for testing
+stack load hostfile file=/export/test-suites/system/files/hosts.csv
+
+# Load partitioning information for backend-0-0 and backend-0-1
+stack load storage partition file=/export/test-suites/system/files/lvm-complex.csv
+stack load storage partition file=/export/test-suites/system/files/quoted-options.csv
+
+# Set the installer to use the graphical installer
+stack set host bootaction a:backend type=install action="default"
+
+# Set our backends to install next boot
+stack set host boot a:backend action=install nukedisks=true nukecontroller=true

--- a/test-framework/test-suites/system/set-up.d/_common.sh
+++ b/test-framework/test-suites/system/set-up.d/_common.sh
@@ -6,6 +6,8 @@ vagrant up backend-0-0 &
 sleep 10
 vagrant up backend-0-1 &
 sleep 10
+vagrant up backend-0-2 &
+sleep 10
 
 # Monitor the backend installs
 vagrant ssh frontend -c "sudo -i /export/test-suites/system/files/monitor-backends.py --timeout=$1"

--- a/test-framework/test-suites/system/set-up.d/stacki-redhat7.sh
+++ b/test-framework/test-suites/system/set-up.d/stacki-redhat7.sh
@@ -6,6 +6,9 @@ set -e
 # The standard stacki Redhat 7 system test-suite gets a single ISO
 if [[ "$#" -eq 1 && $1 =~ stacki-.*-redhat7\.x86_64\.disk1\.iso ]]
 then
+    # Load hostfile and set partitioning for backend-0-0 and backend-0-1
+    vagrant ssh frontend -c "sudo -i /export/test-suites/system/files/set-redhat-host-partitions.sh"
+
     # Start discovery
     vagrant ssh frontend -c "sudo -i stack enable discovery"
 


### PR DESCRIPTION
This uses the reworked report system test that checks backend
partitioning. This currently is only set up for redhat as for some
reason the example partitioning schemes are not working on SLES 12 KVM
hosts. Yes, it works on SLES 11 and SLES 12 if you use virtualbox. No,
I don't know why.