### PR TITLE
INTERNAL: Fix docstring to use correct Mellanox model number

### DIFF
--- a/common/src/stack/command/stack/commands/add/firmware/__init__.py
+++ b/common/src/stack/command/stack/commands/add/firmware/__init__.py
@@ -54,20 +54,20 @@ class Command(command, stack.commands.HostArgumentProcessor):
 	The optional hash algorithm to use to verify the integrity of the fetched image. If not specified this defaults to MD5.
 	</param>
 
-	<example cmd="add firmware 3.6.5002 source=/export/some/path/img-3.6.5002.img make=Mellanox model=7800 imp=mellanox_m7800">
+	<example cmd="add firmware 3.6.5002 source=/export/some/path/img-3.6.5002.img make=Mellanox model=m7800 imp=mellanox_m7800">
 	Fetches the firmware file from the source (a local file on the front end in /export/some/path), associates it with the
 	Mellanox make and 7800 model, and sets the version to 3.6.5002, and adds it to be tracked in the stacki database.
 	</example>
 
-	<example cmd="add firmware 3.6.5002 source=http://www.your-sweet-site.com/firmware/mellanox/img-3.6.5002.img make=Mellanox model=7800 imp=mellanox_m7800">
+	<example cmd="add firmware 3.6.5002 source=http://www.your-sweet-site.com/firmware/mellanox/img-3.6.5002.img make=Mellanox model=m7800 imp=mellanox_m7800">
 	This performs the same steps as the previous example except the image is fetched via HTTP.
 	</example>
 
-	<example cmd="add firmware 3.6.5002 source=http://www.your-sweet-site.com/firmware/mellanox/img-3.6.5002.img make=Mellanox model=7800 hosts=switch-0-1,switch-0-2">
+	<example cmd="add firmware 3.6.5002 source=http://www.your-sweet-site.com/firmware/mellanox/img-3.6.5002.img make=Mellanox model=m7800 hosts=switch-0-1,switch-0-2">
 	This performs the same steps as the previous example except the firmware gets associated with the hosts named switch-0-1 and switch-0-2.
 	</example>
 
-	<example cmd="add firmware 3.6.5002 source=http://www.your-sweet-site.com/firmware/mellanox/img-3.6.5002.img make=Mellanox model=7800 hosts=a:switch">
+	<example cmd="add firmware 3.6.5002 source=http://www.your-sweet-site.com/firmware/mellanox/img-3.6.5002.img make=Mellanox model=m7800 hosts=a:switch">
 	This performs the same steps as the previous example except the firmware gets associated with all hosts that are of the appliance switch type.
 	</example>
 


### PR DESCRIPTION
This makes it match what the database is seeded with.