### PR TITLE
Bugfix/fix stackios limited pallets

### DIFF
--- a/common/src/stack/command/stack/commands/add/pallet/plugin_remote_path.py
+++ b/common/src/stack/command/stack/commands/add/pallet/plugin_remote_path.py
@@ -56,7 +56,6 @@ class Plugin(stack.commands.Plugin):
 			wget_cmd = [
 				'wget',
 				*creds,
-				'--quiet',
 				'--recursive', # recursive download
 				'--no-host-directories', # Don't create host directory
 				'--no-parent',  # Don't create parent directories
@@ -68,8 +67,8 @@ class Plugin(stack.commands.Plugin):
 			]
 
 			try:
-				result = self.owner._exec(wget_cmd, check=True)
+				result = self.owner._exec(wget_cmd, stderr=subprocess.STDOUT, check=True)
 			except subprocess.CalledProcessError as e:
-				raise CommandError(self, f'remote fetch failed, tried:\n{" ".join(wget_cmd)}: {e.stderr}')
+				raise CommandError(self, f'remote fetch failed, tried:\n{" ".join(wget_cmd)}\n{e.stdout}')
 
 			args[arg]['exploded_path'] = tempdir

--- a/common/src/stack/command/stack/commands/add/pallet/plugin_remote_path.py
+++ b/common/src/stack/command/stack/commands/add/pallet/plugin_remote_path.py
@@ -63,7 +63,7 @@ class Plugin(stack.commands.Plugin):
 				f'--cut-dirs={cut_dirs}',
 				'--reject=TBL,index.html*',
 				f'--directory-prefix={tempdir}', # directory to save files to
-				canon_arg,
+				norm_loc,
 			]
 
 			try:

--- a/common/src/stack/report-system/command/report/system/tests/test_stacki.py
+++ b/common/src/stack/report-system/command/report/system/tests/test_stacki.py
@@ -1,8 +1,28 @@
 import pytest
-
+import json
 
 @pytest.mark.parametrize("command", ["box", "pallet", "cart", "network", "host", "host interface"])
 def test_stack_list(command, host, report_output):
 	result = host.run(f"stack list {command}")
 	assert result.rc == 0
 	report_output(f"list {command}", result.stdout)
+
+def test_stacki_pallets_sane(host):
+	palletdir = '/export/stack/pallets/'
+
+	result = host.run(f'probepal {palletdir}')
+	assert result.rc == 0
+	palinfo = json.loads(result.stdout)
+	# it shouldn't be empty
+	assert palinfo[palletdir]
+
+	stacki_pallets = []
+	important_dirs = ['graph', 'nodes', 'RPMS', 'repodata']
+	for pallet in palinfo[palletdir]:
+		if pallet['name'] == 'stacki':
+			for subdir in important_dirs:
+				assert host.file(f"{pallet['pallet_root']}/{subdir}").is_directory
+			stacki_pallets.append(pallet)
+
+	# there should be at least one stacki pallet
+	assert stacki_pallets

--- a/test-framework/test-suites/integration/tests/add/test_add_pallet.py
+++ b/test-framework/test-suites/integration/tests/add/test_add_pallet.py
@@ -298,6 +298,26 @@ class TestAddPallet:
 			}
 		]
 
+	def test_network_directory_with_extra_slash(self, host, run_file_server, revert_export_stack_pallets):
+		''' add pallet should clean up the extra slash - this was a bug we found in stackios :( '''
+		# Add the minimal pallet directory from the network
+		result = host.run('stack add pallet http://127.0.0.1:8000/pallets//minimal/1.0/sles12/sles/x86_64')
+		assert result.rc == 0
+
+		# Check it made it in as expected
+		result = host.run('stack list pallet minimal output-format=json')
+		assert result.rc == 0
+		assert json.loads(result.stdout) == [
+			{
+				'name': 'minimal',
+				'version': '1.0',
+				'release': 'sles12',
+				'arch': 'x86_64',
+				'os': 'sles',
+				'boxes': ''
+			}
+		]
+
 	def test_failed_download(self, host, run_file_server):
 		result = host.run('stack add pallet http://127.0.0.1:8000/test.iso')
 		assert result.rc == 255


### PR DESCRIPTION
BUGFIX: For stackios, don't use the webserver to fetch pallets that are stored on the boot dvd.

Instead, mount the dvd in the chroot and add it directly there.  This works around a bug I wish I had better understanding of where the recent add pallet refactor fetches directory listings from ludicrous as html, instead of recursively fetching them, but this only appears to happen during stackios installation.