### PR TITLE
INTERNAL: iso builder docs say the OS_PALLET var needs to be a file i…

### DIFF
--- a/tools/iso-builder/build.sh
+++ b/tools/iso-builder/build.sh
@@ -75,7 +75,7 @@ cp build-*/stacki-*.iso /vagrant/
 if [[ $PLATFORM = "redhat7" && -n $OS_PALLET ]]
 then
     cd /export/src
-    stack create pallet stacki/build-*/stacki-*.iso /export/isos/$OS_PALLET name=stackios
+    stack create pallet stacki/build-*/stacki-*.iso /export/isos/$(basename $OS_PALLET) name=stackios
     cp stackios-*.iso /vagrant/
 fi
 


### PR DESCRIPTION
…n ISOS, so just get the filename from that variable