### PR TITLE
BUGFIX: Fix regression in load storage partition

### DIFF
--- a/common/src/stack/command/stack/commands/load/__init__.py
+++ b/common/src/stack/command/stack/commands/load/__init__.py
@@ -284,7 +284,11 @@ class command(stack.commands.Command):
 			self.validate_partition(partitions = partitions)
 
 		# Remove all existing entries based on which scope we are operating in.
-		self.stack(f'remove.{scope}.storage.partition' if scope != 'global' else 'remove.storage.partition', device='*')
+		self.stack(
+			f'remove.{scope}.storage.partition' if scope != 'global' else 'remove.storage.partition',
+			target,
+			device='*',
+		)
 
 		cmd = f'add.{scope}.storage.partition' if scope != 'global' else 'add.storage.partition'
 

--- a/test-framework/test-suites/integration/files/load/json/partition2.json
+++ b/test-framework/test-suites/integration/files/load/json/partition2.json
@@ -1,0 +1,95 @@
+{
+	"version": "05.03.00.00",
+	"partition": [
+		{
+			"device": "vda",
+			"partid": 1,
+			"mountpoint": "/foo",
+			"size": 200,
+			"fstype": null,
+			"options": "--asprimary --partition_id=18"
+		}
+	],
+	"host": [
+		{
+			"name": "test-host",
+			"rack": "0",
+			"rank": "0",
+			"appliance": "test_appliance",
+			"box": "default",
+			"environment": null,
+			"osaction": "default",
+			"installaction": "default",
+			"comment": null,
+			"metadata": null,
+			"group": [],
+			"interface": [
+				{
+					"interface": "eth0",
+					"default": null,
+					"network": "private",
+					"mac": "52:54:00:ad:a7:c5",
+					"ip": "10.1.1.1",
+					"name": "test-host",
+					"module": null,
+					"vlan": null,
+					"options": null,
+					"channel": null,
+					"alias": []
+				}
+			],
+			"partition": [
+				{
+					"device": "vdb",
+					"mountpoint": "/bar",
+					"size": 0,
+					"fstype": "ext4",
+					"options": "--asprimary --label=HOST"
+				}
+			]
+		}
+	],
+	"environment": [
+		{
+			"name": "test_environment",
+			"partition": [
+				{
+					"device": "vdc",
+					"mountpoint": "/baz",
+					"size": 34567,
+					"fstype": "ext4",
+					"options": ""
+				}
+			]
+		}
+	],
+	"os": [
+		{
+			"name": "redhat",
+			"partition": [
+				{
+					"device": "vdd",
+					"mountpoint": "/bag",
+					"size": 23456,
+					"fstype": "ext4",
+					"options": ""
+				}
+			]
+		}
+	],
+	"appliance": [
+		{
+			"name": "test_appliance",
+			"public": true,
+			"partition": [
+				{
+					"device": "vde",
+					"mountpoint": "/bam",
+					"size": 12345,
+					"fstype": "ext4",
+					"options": ""
+				}
+			]
+		}
+	]
+}

--- a/test-framework/test-suites/integration/files/load/storage_partition_appliance_scope2.csv
+++ b/test-framework/test-suites/integration/files/load/storage_partition_appliance_scope2.csv
@@ -1,0 +1,5 @@
+NAME,DEVICE,MOUNTPOINT,SIZE,TYPE,OPTIONS
+backend,sda,/,0,ext4,
+,sdb,/var,0,ext4,
+,sdc,/opt,0,ext4,
+,sdd,/export,0,ext4,

--- a/test-framework/test-suites/integration/files/load/storage_partition_global_scope2.csv
+++ b/test-framework/test-suites/integration/files/load/storage_partition_global_scope2.csv
@@ -1,0 +1,5 @@
+NAME,DEVICE,PARTID,MOUNTPOINT,SIZE,TYPE,OPTIONS
+global,sda,1,/,0,ext4,
+,sdb,2,/var,0,ext4,
+,sdc,3,/opt,0,ext4,
+,sdd,4,/export,0,ext4,

--- a/test-framework/test-suites/integration/files/load/storage_partition_host_scope2.csv
+++ b/test-framework/test-suites/integration/files/load/storage_partition_host_scope2.csv
@@ -1,0 +1,5 @@
+NAME,DEVICE,MOUNTPOINT,SIZE,TYPE
+backend-0-0,sda,/,0,ext4
+,sdb,/var,0,ext4,
+,sdc,/opt,0,ext4,
+,sdd,/export,0,ext4,

--- a/test-framework/test-suites/integration/files/load/storage_partition_os_scope2.csv
+++ b/test-framework/test-suites/integration/files/load/storage_partition_os_scope2.csv
@@ -1,0 +1,5 @@
+NAME,DEVICE,MOUNTPOINT,SIZE,TYPE,OPTIONS
+sles,sda,/,0,ext4,
+,sdb,/var,0,ext4,
+,sdc,/opt,0,ext4,
+,sdd,/export,0,ext4,

--- a/test-framework/test-suites/integration/tests/load/test_load_storage_partition.py
+++ b/test-framework/test-suites/integration/tests/load/test_load_storage_partition.py
@@ -162,9 +162,84 @@ class TestLoadStoragePartition:
 			}
 		]
 
+	def test_global_scope_overwrite(self, host, test_file):
+		"""Test that loading another storage partition in the same scope unloads the previous partitioning information."""
+		actual_partition_config = test_file('load/storage_partition_global_scope.csv')
+		secondary_partition_config = test_file('load/storage_partition_global_scope2.csv')
+		# Load the secondary partition config and then load the actual one.
+		result = host.run(f'stack load storage partition file={secondary_partition_config}')
+		assert result.rc == 0
+		result = host.run(f'stack load storage partition file={actual_partition_config}')
+		assert result.rc == 0
+
+		result = host.run('stack list storage partition output-format=json')
+
+		assert result.rc == 0
+		assert json.loads(result.stdout) == [
+			{
+				"device": "sda",
+				"partid": 1,
+				"mountpoint": None,
+				"size": 40,
+				"fstype": None,
+				"options": "--asprimary --partition_id=18"
+			},
+			{
+				"device": "sda",
+				"partid": 2,
+				"mountpoint": "/",
+				"size": 30720,
+				"fstype": "ext4",
+				"options": "--asprimary --label=ROOT-BE1"
+			},
+			{
+				"device": "sda",
+				"partid": 3,
+				"mountpoint": None,
+				"size": 30720,
+				"fstype": "ext4",
+				"options": "--asprimary --label=ROOT-BE2"
+			}
+		]
+
 	def test_appliance_scope(self, host, test_file):
 		path = test_file('load/storage_partition_appliance_scope.csv')
 		result = host.run(f'stack load storage partition file={path}')
+		assert result.rc == 0
+
+		result = host.run(
+			'stack list appliance storage partition backend output-format=json'
+		)
+		assert result.rc == 0
+		assert json.loads(result.stdout) == [
+			{
+				"appliance": "backend",
+				"device": "sda",
+				"partid": 1,
+				"mountpoint": "/",
+				"size": 0,
+				"fstype": "ext4",
+				"options": ""
+			},
+			{
+				"appliance": "backend",
+				"device": "sdb",
+				"partid": 2,
+				"mountpoint": "/home",
+				"size": 0,
+				"fstype": "ext4",
+				"options": "--label=HOME"
+			}
+		]
+
+	def test_appliance_scope_overwrite(self, host, test_file):
+		"""Test that loading another storage partition in the same scope unloads the previous partitioning information."""
+		actual_partition_config = test_file('load/storage_partition_appliance_scope.csv')
+		secondary_partition_config = test_file('load/storage_partition_appliance_scope2.csv')
+		# Load the secondary partition config and then load the actual one.
+		result = host.run(f'stack load storage partition file={secondary_partition_config}')
+		assert result.rc == 0
+		result = host.run(f'stack load storage partition file={actual_partition_config}')
 		assert result.rc == 0
 
 		result = host.run(
@@ -223,9 +298,70 @@ class TestLoadStoragePartition:
 			}
 		]
 
+	def test_os_scope_overwrite(self, host, test_file):
+		"""Test that loading another storage partition in the same scope unloads the previous partitioning information."""
+		actual_partition_config = test_file('load/storage_partition_os_scope.csv')
+		secondary_partition_config = test_file('load/storage_partition_os_scope2.csv')
+		# Load the secondary partition config and then load the actual one.
+		result = host.run(f'stack load storage partition file={secondary_partition_config}')
+		assert result.rc == 0
+		result = host.run(f'stack load storage partition file={actual_partition_config}')
+		assert result.rc == 0
+
+		result = host.run(
+			'stack list os storage partition sles output-format=json'
+		)
+
+		assert result.rc == 0
+		assert json.loads(result.stdout) == [
+			{
+				"os": "sles",
+				"device": "sda",
+				"partid": 1,
+				"mountpoint": "/",
+				"size": 0,
+				"fstype": "ext4",
+				"options": ""
+			},
+			{
+				"os": "sles",
+				"device": "sdb",
+				"partid": 2,
+				"mountpoint": "/home",
+				"size": 0,
+				"fstype": "ext4",
+				"options": "--label=HOME"
+			}
+		]
+
 	def test_host_scope(self, host, add_host, test_file):
 		path = test_file('load/storage_partition_host_scope.csv')
 		result = host.run(f'stack load storage partition file={path}')
+		assert result.rc == 0
+
+		result = host.run(
+			'stack list host storage partition backend-0-0 output-format=json'
+		)
+		assert result.rc == 0
+		assert json.loads(result.stdout) == [{
+			"host": "backend-0-0",
+			"device": "sda",
+			"partid": 1,
+			"mountpoint": "/",
+			"size": 0,
+			"fstype": "ext4",
+			"options": "",
+			"source": "H"
+		}]
+
+	def test_host_scope_overwrite(self, host, add_host, test_file):
+		"""Test that loading another storage partition in the same scope unloads the previous partitioning information."""
+		actual_partition_config = test_file('load/storage_partition_host_scope.csv')
+		secondary_partition_config = test_file('load/storage_partition_host_scope2.csv')
+		# Load the secondary partition config and then load the actual one.
+		result = host.run(f'stack load storage partition file={secondary_partition_config}')
+		assert result.rc == 0
+		result = host.run(f'stack load storage partition file={actual_partition_config}')
 		assert result.rc == 0
 
 		result = host.run(


### PR DESCRIPTION
INTERNAL:

This was not properly removing the old storage partition information for
scopes other than global.