### PR TITLE
INTERNAL: create a symlink 'any_python' that points to whichever vers…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,18 @@ endif
 	cd sles   && $(ROLLSBUILD)/bin/get3rdparty.py
 
 bootstrap-make:
+	# setup any_python
+	# this lets some of our build scripts be written in a python2 and python3
+	# and scripts can use /usr/bin/env any_python for the shebang
+	# note `then :;` is the bash equivalent of `pass`. skip linking if link exists
+	(									\
+		if [ "$(shell which any_python)" != "" ]; then :;		\
+		elif [ "$(shell which python)" != "" ]; then			\
+			ln -s $(shell which python) /usr/bin/any_python;	\
+		elif [ "$(shell which python3)" != "" ]; then			\
+			ln -s $(shell which python3) /usr/bin/any_python;	\
+		fi;								\
+	)
 	$(MAKE) -C $(OS) -f bootstrap.mk RELEASE=$(RELEASE) bootstrap
 	$(MAKE) -C common/src/stack/build bootstrap
 

--- a/common/src/Makefile
+++ b/common/src/Makefile
@@ -11,7 +11,7 @@ endif
 include order-$(ROLL).mk
 
 order-$(ROLL).mk: Makefile ../../version.mk $(shell find . -name version.mk)
-	python stack/build/build/bin/gen-order > $@
+	stack/build/build/bin/gen-order > $@
 
 -include order-$(ROLL)-$(RELEASE).mk
 

--- a/common/src/stack/build/build/bin/gen-order
+++ b/common/src/stack/build/build/bin/gen-order
@@ -1,11 +1,14 @@
-#! /usr/bin/python
+#! /usr/bin/env any_python
+#
+# NOTE: THIS FILE MUST WORK IN PYTHON2 and PYTHON3
 #
 # @copyright@
 # Copyright (c) 2006 - 2019 Teradata
 # All rights reserved. Stacki(r) v5.x stacki.com
 # https://github.com/Teradata/stacki/blob/master/LICENSE.txt
 # @copyright@
-
+from __future__ import print_function
+import sys
 import os
 import string
 from subprocess import *
@@ -18,8 +21,13 @@ for entry in os.listdir('.'):
 	if os.path.isdir(entry):
 #		print '+', entry
 		os.chdir(entry)
-		stdout, stderr = Popen(['make', 'dump-info'], 
-				       stderr=PIPE, stdout=PIPE).communicate()
+		cmd = ['make', 'dump-info']
+		kwargs = {'stderr': PIPE, 'stdout': PIPE}
+		# python3 wants an encoding, python2's Popen doesn't support one
+		# check the version here.
+		if sys.version_info[0] == 3:
+			kwargs['encoding'] = 'utf-8'
+		stdout, stderr = Popen(cmd, **kwargs).communicate()
 
 		for line in stdout.split('\n'):
 #			print line
@@ -38,7 +46,7 @@ for entry in os.listdir('.'):
 					curr = {}
 			except:
 				continue
-        
+
 			curr[key.lower()] = value
 
 		try:
@@ -48,18 +56,17 @@ for entry in os.listdir('.'):
 
 		os.chdir(cwd)
 
-
 list = []
 for src in dirs.keys():
-        order = dirs[src]['order']
-        if order:
-                order = int(order)
-        else:
-                order = 50
-        list.append((order, dirs[src]['dir']))
+	order = dirs[src]['order']
+	if order:
+		order = int(order)
+	else:
+		order = 50
+	list.append((order, dirs[src]['dir']))
 
 list.sort()
 
-print 'SRCDIRS = ',
+print('SRCDIRS = ', end='')
 for order, src in list:
-        print '\\\n\t%s ' % src,
+	print('\\\n\t%s ' % src, end='')

--- a/common/src/stack/build/build/bin/genfilelist
+++ b/common/src/stack/build/build/bin/genfilelist
@@ -1,16 +1,15 @@
-#!/usr/bin/env python
+#! /bin/bash
 
-import os, sys
+# this script was re-written from the original version to support environments which do not have python2
 
-pkg = sys.argv[1]
-buildroot = sys.argv[2]
-for r, d, f in os.walk(buildroot,topdown=True):
-	for n in d:
-		dn = os.path.join(r,n)
-		if os.listdir(dn) == []:
-			fname = dn.replace(buildroot,'', 1)
-			print "\"%s\"" % fname
-	for n in f:
-		fn = os.path.join(r, n)
-		fname = fn.replace(buildroot,'',1)
-		print "\"%s\"" % fname
+# $1 is the package name - not used?
+# $2 is the source directory
+
+# find all empty directories in the source dir
+# find all files (symlinks too) in the source dir
+# print each on a newline, relative to the source directory ($2), and wrapped in quotes
+pushd $2 > /dev/null
+find . -empty -type d -printf '"/%P"\n'
+find . -type f -printf '"/%P"\n'
+find . -type l -printf '"/%P"\n'
+popd > /dev/null

--- a/common/src/stack/build/build/src/pallet/bin/get3rdparty.py
+++ b/common/src/stack/build/build/src/pallet/bin/get3rdparty.py
@@ -1,4 +1,6 @@
-#!/usr/bin/python
+#!/usr/bin/env any_python
+#
+# NOTE: THIS FILE MUST WORK IN PYTHON2 and PYTHON3
 #
 # @copyright@
 # Copyright (c) 2006 - 2019 Teradata
@@ -6,6 +8,7 @@
 # https://github.com/Teradata/stacki/blob/master/LICENSE.txt
 # @copyright@
 
+from __future__ import print_function
 import os
 import sys
 import json
@@ -70,7 +73,8 @@ def download_url(source, target, curl_args):
 	while retry:
 		p = subprocess.Popen(curl_cmd,
 			stdout=subprocess.PIPE,
-			stderr=subprocess.PIPE)
+			stderr=subprocess.PIPE,
+                )
 		rc = p.wait()
 		o, e = p.communicate()
 		if rc:
@@ -78,7 +82,8 @@ def download_url(source, target, curl_args):
 			print(e)
 			time.sleep(1)
 		else:
-			if o.strip() == '200':
+			# note the byte literal makes this line py2/3 compatible
+			if o.strip() == b'200':
 				retry = 0
 				success = True
 			else:

--- a/sles/src/Makefile
+++ b/sles/src/Makefile
@@ -11,7 +11,7 @@ endif
 include order-$(ROLL).mk
 
 order-$(ROLL).mk: Makefile ../../version.mk $(shell find . -name version.mk)
-	python ../../common/src/stack/build/build/bin/gen-order > $@
+	../../common/src/stack/build/build/bin/gen-order > $@
 
 -include order-$(ROLL)-$(RELEASE).mk
 


### PR DESCRIPTION
…ion of python is the system default.  Also convert bootstrap utilities to be python2/3 compatible.

This is only intended to be used in a build environment.  At some future point, it might make more sense to replace the python scripts we have with bash.