### PR TITLE
BUGFIX: Ensure pip and setuptools are always available on the frontend

### DIFF
--- a/redhat/nodes/frontend.xml
+++ b/redhat/nodes/frontend.xml
@@ -15,6 +15,10 @@ https://github.com/Teradata/stacki/blob/master/LICENSE.txt
 
 <stack:package>stack-command</stack:package>
 
+<!-- Make sure pip is installed. This also installs setuptools. -->
+<stack:script stack:stage="install-post">
+/opt/stack/bin/python3 -m ensurepip
+</stack:script>
 
-</stack:stack> 
+</stack:stack>
 

--- a/sles/nodes/install.xml
+++ b/sles/nodes/install.xml
@@ -24,9 +24,14 @@ https://github.com/Teradata/stacki/blob/master/LICENSE.txt
 	ln -s /export/stack install;
 	cd install/sbin ;
 	ln -s . public ;
-) 
+)
 
 </stack:script>
 
-</stack:stack> 
+<!-- Make sure pip is installed. This also installs setuptools. -->
+<stack:script stack:stage="install-post">
+/opt/stack/bin/python3 -m ensurepip
+</stack:script>
+
+</stack:stack>
 


### PR DESCRIPTION
Functionally identical to #674, except the graph has evolved in that PR so I had to shove the post-install script into the old graph structure on the support branch.

This now allows the tdc-infrastructure pallet to build, as netappy can now run `setup.py build`.