### PR TITLE
FEATURE: replace xinetd tftp-service management with systemd

### DIFF
--- a/common/nodes/pxe.xml
+++ b/common/nodes/pxe.xml
@@ -27,24 +27,19 @@ stack-pxeboot
 
 <stack:script stack:stage="install-post">
 
-/usr/bin/systemctl enable xinetd
+<!-- pxe needs a tftp server - unit files in /etc override system defaults -->
+<stack:file stack:name="/etc/systemd/system/tftp.service">
+[Unit]
+Description=Tftp Server
+Requires=tftp.socket
+Documentation=man:in.tftpd
 
-<!-- pxe needs a tftp server -->
-<stack:file stack:name="/etc/xinetd.d/tftp">
-service tftp
-{
-        socket_type             = dgram
-        protocol                = udp
-        wait                    = yes
-        user                    = root
-        server                  = /usr/sbin/in.tftpd
-        server_args             = --verbose --secure /tftpboot/pxelinux
-        instances               = 1
-	per_source		= 11
-	cps			= 1000 2
-	flags			= IPv4
-        disable                 = no
-}
+[Service]
+ExecStart=/usr/sbin/in.tftpd --user root --verbose --secure /tftpboot/pxelinux
+StandardInput=socket
+
+[Install]
+Also=tftp.socket
 </stack:file>
 
 
@@ -57,6 +52,9 @@ cp /opt/stack/images/initrd* /tftpboot/pxelinux/
 
 <!-- copy all the syslinux programs to the pxelinux directory -->
 cp -R /usr/share/syslinux/* /tftpboot/pxelinux/
+
+systemctl enable tftp.socket
+systemctl start tftp.socket
 
 </stack:script>
 

--- a/common/src/stack/report-system/command/report/system/tests/test_services.py
+++ b/common/src/stack/report-system/command/report/system/tests/test_services.py
@@ -44,8 +44,9 @@ def test_service_enabled_and_running(host, service):
 def test_tftpd_enabled_and_running(host):
 	xinetd = host.service('xinetd')
 	fbtftpd = host.service('fbtftpd')
-	assert xinetd.is_enabled or fbtftpd.is_enabled, "No tftp server is enabled."
-	assert xinetd.is_running or fbtftpd.is_running, "No tftp server is running."
+	tftpsocket = host.service('tftp.socket')
+	assert tftpsocket.is_enabled or xinetd.is_enabled or fbtftpd.is_enabled, "No tftp server is enabled."
+	assert tftpsocket.is_running or xinetd.is_running or fbtftpd.is_running, "No tftp server is running."
 
 def test_logrotate_service_enabled(host):
 	"""Test that the logrotate service is enabled."""


### PR DESCRIPTION
Turns out all the OSes we currently use as frontends (SLES12/EL7) ship with systemd unit files for the daemon and the socket (so the daemon isn't always listening) for tftpd.  The impetus here is that SLES15 does not ship xinetd (how we currently conditionally manage tftpd), so we definitely needed to change it there anyway.