### PR TITLE
BUGFIX: Fully XML entity encode attrs in node xml

### DIFF
--- a/common/src/stack/command/stack/commands/list/node/xml/__init__.py
+++ b/common/src/stack/command/stack/commands/list/node/xml/__init__.py
@@ -323,7 +323,7 @@ class Command(stack.commands.list.command,
 
 		self.addText('<stack:profile stack:os="%s"' % attrs['os'])
 		self.addText(' %s' % handler.nsAttrs())
-		self.addText(' stack:attrs="%s">\n' % saxutils.escape('%s' % attrs))
+		self.addText(' stack:attrs=%s>\n' % saxutils.quoteattr('%s' % attrs))
 
 		self.runPlugins(attrs)
 

--- a/test-framework/test-suites/integration/tests/list/test_list_host_profile.py
+++ b/test-framework/test-suites/integration/tests/list/test_list_host_profile.py
@@ -1,19 +1,29 @@
 import xml.etree.ElementTree as ET
 
 
-def test_list_host_profile(host, add_host_with_net, revert_export_stack_carts, revert_etc):
-	result = host.run('stack list host profile backend-0-0')
-	assert result.rc == 0
+class TestListHostProfile:
+	def test_generation(self, host, add_host_with_net, revert_export_stack_carts, revert_etc):
+		# List the host profile
+		result = host.run('stack list host profile backend-0-0')
+		assert result.rc == 0
 
-	# Check if this is an actual XML output that can be parsed
-	root = ET.fromstring(result.stdout)
+		# Check if this is an actual XML output that can be parsed
+		root = ET.fromstring(result.stdout)
 
-	# Check for a few expected tags and attributes
-	# This could be more and more variable as we go deeper, so I don't check a lot.
-	assert root.tag == "profile"
-	assert root.attrib == {'type': 'native'}
-	for child in root:
-		assert child.tag == "chapter"
-		for grandchild in child:
-			assert grandchild.tag == "section"
+		# Check for a few expected tags and attributes
+		# This could be more and more variable as we go deeper, so I don't check a lot.
+		assert root.tag == "profile"
+		assert root.attrib == {'type': 'native'}
+		for child in root:
+			assert child.tag == "chapter"
+			for grandchild in child:
+				assert grandchild.tag == "section"
 
+	def test_xml_entity_encoding(self, host, add_host_with_net, revert_export_stack_carts, revert_etc):
+		# Add an attr with values XML doesn't like
+		result = host.run('stack set host attr backend-0-0 attr=test value=foo\\&\\<\\>\\\'\\\"')
+		assert result.rc == 0
+
+		# List the host profile
+		result = host.run('stack list host profile backend-0-0')
+		assert result.rc == 0


### PR DESCRIPTION
When the attrs were inserted into the `stacki:profile` tag as an XML attribute, the single and double quotes weren't being encoded in the attr values, which causes non-valid XML to be output.