### PR TITLE
INTERNAL: Clean up some remaining tech debt in firmware code

### DIFF
--- a/common/src/stack/command/stack/commands/list/host/firmware/mapping/plugin_basic.py
+++ b/common/src/stack/command/stack/commands/list/host/firmware/mapping/plugin_basic.py
@@ -12,7 +12,7 @@
 
 import stack.commands
 from stack.util import unique_everseen
-from stack.exception import ArgError, ParamError, ParamRequired, CommandError
+from stack.exception import ParamError
 
 class Plugin(stack.commands.Plugin):
 	"""Lists firmware mappings and filters the results on any provided arguments."""
@@ -22,174 +22,49 @@ class Plugin(stack.commands.Plugin):
 
 	def get_firmware_mappings(self, hosts, versions, make, model, sort):
 		"""Gets the mappings using the provided arguments as a filter."""
-		# If versions and hosts are specified, get the specific mappings for the hosts
-		if versions and hosts:
-			mappings = [
-				(row[0], row[1:]) for row in self.owner.db.select(
-					f"""
-					nodes.Name, firmware.version, firmware_make.name, firmware_model.name
-					FROM firmware_mapping
-						INNER JOIN nodes
-							ON firmware_mapping.node_id = nodes.ID
-						INNER JOIN firmware
-							ON firmware_mapping.firmware_id = firmware.id
-						INNER JOIN firmware_model
-							ON firmware.model_id = firmware_model.id
-						INNER JOIN firmware_make
-							ON firmware_model.make_id = firmware_make.id
-					WHERE nodes.Name IN %s AND firmware.version IN %s AND firmware_make.name=%s AND firmware_model.name=%s
-					ORDER BY {sort}
-					""",
-					(hosts, versions, make, model)
-				)
-			]
-		# Else if make, model, and hosts are specified, get all mappings for that make and model for the specified hosts
-		elif make and model and hosts:
-			mappings = [
-				(row[0], row[1:]) for row in self.owner.db.select(
-					f"""
-					nodes.Name, firmware.version, firmware_make.name, firmware_model.name
-					FROM firmware_mapping
-						INNER JOIN nodes
-							ON firmware_mapping.node_id = nodes.ID
-						INNER JOIN firmware
-							ON firmware_mapping.firmware_id = firmware.id
-						INNER JOIN firmware_model
-							ON firmware.model_id = firmware_model.id
-						INNER JOIN firmware_make
-							ON firmware_model.make_id = firmware_make.id
-					WHERE nodes.Name IN %s AND firmware_make.name=%s AND firmware_model.name=%s
-					ORDER BY {sort}
-					""",
-					(hosts, make, model)
-				)
-			]
-		# Else if make and hosts are specified, get all mappings for that make for the specified hosts.
-		elif make and hosts:
-			mappings = [
-				(row[0], row[1:]) for row in self.owner.db.select(
-					f"""
-					nodes.Name, firmware.version, firmware_make.name, firmware_model.name
-					FROM firmware_mapping
-						INNER JOIN nodes
-							ON firmware_mapping.node_id = nodes.ID
-						INNER JOIN firmware
-							ON firmware_mapping.firmware_id = firmware.id
-						INNER JOIN firmware_model
-							ON firmware.model_id = firmware_model.id
-						INNER JOIN firmware_make
-							ON firmware_model.make_id = firmware_make.id
-					WHERE nodes.Name IN %s AND firmware_make.name=%s
-					ORDER BY {sort}
-					""",
-					(hosts, make)
-				)
-			]
-		# Else only hosts are specified, so get all firmware mappings from the specified hosts
-		elif hosts:
-			mappings = [
-				(row[0], row[1:]) for row in self.owner.db.select(
-					f"""
-					nodes.Name, firmware.version, firmware_make.name, firmware_model.name
-					FROM firmware_mapping
-						INNER JOIN nodes
-							ON firmware_mapping.node_id = nodes.ID
-						INNER JOIN firmware
-							ON firmware_mapping.firmware_id = firmware.id
-						INNER JOIN firmware_model
-							ON firmware.model_id = firmware_model.id
-						INNER JOIN firmware_make
-							ON firmware_model.make_id = firmware_make.id
-					WHERE nodes.Name IN %s
-					ORDER BY {sort}
-					""",
-					(hosts,)
-				)
-			]
-		# Else if versions are specified, get all mappings for the specified firmware versions.
-		elif versions:
-			mappings = [
-				(row[0], row[1:]) for row in self.owner.db.select(
-					f"""
-					nodes.Name, firmware.version, firmware_make.name, firmware_model.name
-					FROM firmware_mapping
-						INNER JOIN nodes
-							ON firmware_mapping.node_id = nodes.ID
-						INNER JOIN firmware
-							ON firmware_mapping.firmware_id = firmware.id
-						INNER JOIN firmware_model
-							ON firmware.model_id = firmware_model.id
-						INNER JOIN firmware_make
-							ON firmware_model.make_id = firmware_make.id
-					WHERE nodes.Name IN %s AND firmware.version IN %s AND firmware_make.name=%s AND firmware_model.name=%s
-					ORDER BY {sort}
-					""",
-					(versions, make, model)
-				)
-			]
-		# Else if make and model are specified, get all mappings for that make and model for all hosts
-		elif make and model:
-			mappings = [
-				(row[0], row[1:]) for row in self.owner.db.select(
-					f"""
-					nodes.Name, firmware.version, firmware_make.name, firmware_model.name
-					FROM firmware_mapping
-						INNER JOIN nodes
-							ON firmware_mapping.node_id = nodes.ID
-						INNER JOIN firmware
-							ON firmware_mapping.firmware_id = firmware.id
-						INNER JOIN firmware_model
-							ON firmware.model_id = firmware_model.id
-						INNER JOIN firmware_make
-							ON firmware_model.make_id = firmware_make.id
-					WHERE firmware_make.name=%s AND firmware_model.name=%s
-					ORDER BY {sort}
-					""",
-					(make, model)
-				)
-			]
-		# Else if make is specified, get all mappings for that make for all hosts.
-		elif make:
-			mappings = [
-				(row[0], row[1:]) for row in self.owner.db.select(
-					f"""
-					nodes.Name, firmware.version, firmware_make.name, firmware_model.name
-					FROM firmware_mapping
-						INNER JOIN nodes
-							ON firmware_mapping.node_id = nodes.ID
-						INNER JOIN firmware
-							ON firmware_mapping.firmware_id = firmware.id
-						INNER JOIN firmware_model
-							ON firmware.model_id = firmware_model.id
-						INNER JOIN firmware_make
-							ON firmware_model.make_id = firmware_make.id
-					WHERE firmware_make.name=%s
-					ORDER BY {sort}
-					""",
-					(make,)
-				)
-			]
-		# otherwise get all mappings
-		else:
-			mappings = [
-				(row[0], row[1:]) for row in self.owner.db.select(
-					f"""
-					nodes.Name, firmware.version, firmware_make.name, firmware_model.name
-					FROM firmware_mapping
-						INNER JOIN nodes
-							ON firmware_mapping.node_id = nodes.ID
-						INNER JOIN firmware
-							ON firmware_mapping.firmware_id = firmware.id
-						INNER JOIN firmware_model
-							ON firmware.model_id = firmware_model.id
-						INNER JOIN firmware_make
-							ON firmware_model.make_id = firmware_make.id
-					ORDER BY {sort}
-					"""
-				)
-			]
+		where_clause = []
+		query_args = []
 
-		return mappings
+		if hosts:
+			where_clause.append("nodes.Name IN %s")
+			query_args.append(hosts)
+
+		if make:
+			where_clause.append("firmware_make.name=%s")
+			query_args.append(make)
+
+		if model:
+			where_clause.append("firmware_model.name=%s")
+			query_args.append(model)
+
+		if versions:
+			where_clause.append("firmware.version IN %s")
+			query_args.append(versions)
+
+		if where_clause:
+			where_clause = f"WHERE {' AND '.join(where_clause)}"
+		else:
+			where_clause = ""
+
+		return [
+			(row[0], row[1:]) for row in self.owner.db.select(
+				f"""
+				nodes.Name, firmware.version, firmware_make.name, firmware_model.name
+				FROM firmware_mapping
+					INNER JOIN nodes
+						ON firmware_mapping.node_id = nodes.ID
+					INNER JOIN firmware
+						ON firmware_mapping.firmware_id = firmware.id
+					INNER JOIN firmware_model
+						ON firmware.model_id = firmware_model.id
+					INNER JOIN firmware_make
+						ON firmware_model.make_id = firmware_make.id
+				{where_clause}
+				ORDER BY {sort}
+				""",
+				query_args,
+			)
+		]
 
 	def run(self, args):
 		params, hosts = args
@@ -198,9 +73,9 @@ class Plugin(stack.commands.Plugin):
 				("make", ""),
 				("model", ""),
 				("versions", ""),
-				("sort", "host")
+				("sort", "host"),
 			],
-			params = params
+			params = params,
 		)
 
 		sort_map = {
@@ -217,40 +92,16 @@ class Plugin(stack.commands.Plugin):
 			raise ParamError(
 				cmd = self.owner,
 				param = "sort",
-				msg = f"Sort must be one of: {list(sort_map.keys())}"
+				msg = f"Sort must be one of: {list(sort_map.keys())}",
 			)
 		# process hosts if present
 		if hosts:
 			# hosts must exist
 			hosts = self.owner.getHosts(args = hosts)
-		# process make if present
-		if make:
-			# ensure the make exists
-			if not self.owner.make_exists(make = make):
-				raise ParamError(
-					cmd = self.owner,
-					param = "make",
-					msg = f"The make {make} doesn't exist."
-				)
-		# process model if present
-		if model:
-			# make is now required
-			if not make:
-				raise ParamRequired(cmd = self.owner, param = "make")
-			# ensure the model exists
-			if not self.owner.model_exists(make = make, model = model):
-				raise ParamError(
-					cmd = self.owner,
-					param = "model",
-					msg = f"The model {model} doesn't exist for make {make}."
-				)
-		# Process versions if present
+
+		# Process versions if present. This will check the make and model as well since those are
+		# now required.
 		if versions:
-			# make and model are now required
-			if not make:
-				raise ParamRequired(cmd = self.owner, param = "make")
-			if not model:
-				raise ParamRequired(cmd = self.owner, param = "model")
 			# turn a comma separated string into a list of versions and
 			# get rid of any duplicate names
 			versions = tuple(
@@ -258,15 +109,13 @@ class Plugin(stack.commands.Plugin):
 					(version.strip() for version in versions.split(",") if version.strip())
 				)
 			)
-			# ensure the versions exist
-			try:
-				self.owner.ensure_firmwares_exist(make = make, model = model, versions = versions)
-			except CommandError as exception:
-				raise ArgError(
-					cmd = self.owner,
-					arg = "version",
-					msg = exception.message()
-				)
+			self.owner.ensure_firmwares_exist(make = make, model = model, versions = versions)
+		# Process model if present. This will check the make as well since that is now required.
+		elif model:
+			self.owner.ensure_model_exists(make = make, model = model)
+		# Process make if present.
+		elif make:
+			self.owner.ensure_make_exists(make = make)
 
 		results = self.get_firmware_mappings(
 			hosts = hosts,

--- a/common/src/stack/command/stack/commands/list/host/firmware/plugin_basic.py
+++ b/common/src/stack/command/stack/commands/list/host/firmware/plugin_basic.py
@@ -6,7 +6,6 @@
 
 import re
 import stack.commands
-import stack.firmware
 
 class Plugin(stack.commands.Plugin):
 
@@ -15,52 +14,34 @@ class Plugin(stack.commands.Plugin):
 
 	def run(self, args):
 		# Unpack args.
-		CommonKey, CommonResult, hosts_makes_models, expanded, hashit = args
+		CommonResult, database_values_dict = args
 
 		# This plugin gets the desired firmware version, so add that column to the header.
 		header = ["desired_firmware_version"]
-		values = {host_make_model: [] for host_make_model in hosts_makes_models}
+		results = {host_make_model: [] for host_make_model in database_values_dict}
 
-		# We may be called with an empty list of hosts_makes_models in the case where there are no firmware mappings.
-		# If so, skip trying to get the firmware version and just return the header to append.
-		if values:
-			for row in self.owner.db.select(
-				"""
-				nodes.Name, firmware_make.name, firmware_model.name, firmware.version
-				FROM firmware_mapping
-					INNER JOIN nodes
-						ON firmware_mapping.node_id = nodes.ID
-					INNER JOIN firmware
-						ON firmware_mapping.firmware_id = firmware.id
-					INNER JOIN firmware_model
-						ON firmware.model_id = firmware_model.id
-					INNER JOIN firmware_make
-						ON firmware_model.make_id = firmware_make.id
-				WHERE nodes.Name IN %s
-				""",
-				([host_make_model.host for host_make_model in values],)
-			):
-				host, make, model, version = row
-				# Ensure that if a version regex exists, that we check the version in the database matches.
-				# Since they are optional, it could have been set after the fact and a bad version number was
-				# snuck in.
-				regex_obj = self.owner.try_get_version_regex(
-					make = make,
-					model = model,
+		# For each host_make_model + firmware_version, firmware_imp combination, get the desired firmware version and validate it.
+		for host_make_model, firmware_info in database_values_dict.items():
+			# Ensure that if a version regex exists, that we check the version in the database matches.
+			# Since they are optional, it could have been set after the fact and a bad version number was
+			# snuck in.
+			regex_obj = self.owner.try_get_version_regex(
+				make = host_make_model.make,
+				model = host_make_model.model,
+			)
+			if regex_obj and not re.search(regex_obj.regex, firmware_info.firmware_version, re.IGNORECASE):
+				results[host_make_model].append(
+					f"{firmware_info.firmware_version} (Invalid format per the version_regex named {regex_obj.name} and will be ignored by sync unless forced)"
 				)
-				if regex_obj and not re.search(regex_obj.regex, version, re.IGNORECASE):
-					values[CommonKey(host, make, model)].append(
-						f"{version} (Invalid format per the version_regex named {regex_obj.name} and will be ignored by sync unless forced)"
-					)
-				else:
-					values[CommonKey(host, make, model)].append(version)
+			else:
+				results[host_make_model].append(firmware_info.firmware_version)
 
 		# add empty values for host + make + model combos that have no results and
 		# join together mutiple version results into one string for host + make + model combos with multiple results.
-		for host_make_model, value in values.items():
+		for host_make_model, value in results.items():
 			if not value:
-				values[host_make_model].append(None)
+				results[host_make_model].append(None)
 			elif len(value) > 1:
-				values[host_make_model] = ["(ambiguous, sync will ignore unless forced) " + ", ".join(value)]
+				results[host_make_model] = [f"(ambiguous, sync will ignore unless forced) {', '.join(value)}"]
 
-		return CommonResult(header, values)
+		return CommonResult(header, results)

--- a/common/src/stack/command/stack/commands/sync/host/firmware/__init__.py
+++ b/common/src/stack/command/stack/commands/sync/host/firmware/__init__.py
@@ -7,6 +7,8 @@
 import re
 from pathlib import Path
 from collections import namedtuple
+from dataclasses import make_dataclass
+import itertools
 import stack.commands
 import stack.firmware
 from stack.argument_processors.firmware import FirmwareArgumentProcessor
@@ -32,76 +34,13 @@ class Command(stack.commands.sync.host.command, FirmwareArgumentProcessor):
 	</example>
 	"""
 
-	def get_host_firmwares(self, common_key, hosts, host_attrs, host_current_firmwares, force):
-		results = {}
-		# The firmware information for a given host + make + model combination.
-		FirmwareInfo = namedtuple(
-			"FirmwareInfo", (
-				# Can potentially support multiple firmware files
-				"firmware_files",
-				"current_version",
-				"imp",
-				"host_attrs",
-				"force",
-				"frontend_ip",
-			)
-		)
-		# The information for the firmware file to be applied.
-		FirmwareFile = namedtuple(
-			"FirmwareFile", (
-				"file",
-				"version",
-				"url",
-			)
-		)
-		for row in self.db.select(
-				"""
-				nodes.Name, firmware_make.name, firmware_model.name, firmware.version, firmware.file, firmware_imp.name
-				FROM firmware_mapping
-					INNER JOIN nodes
-						ON firmware_mapping.node_id = nodes.ID
-					INNER JOIN firmware
-						ON firmware_mapping.firmware_id = firmware.id
-					INNER JOIN firmware_model
-						ON firmware.model_id = firmware_model.id
-					INNER JOIN firmware_make
-						ON firmware_model.make_id = firmware_make.id
-					INNER JOIN firmware_imp
-						ON firmware_model.imp_id = firmware_imp.id
-				WHERE nodes.Name IN %s
-				""",
-				(hosts,)
-		):
-			host_make_model = common_key(*row[:3])
-			version, firmware_file, imp = row[3:]
-			# Use resolve(strict = True) to force a exception if the file path doesn't exist.
-			path = Path(firmware_file).resolve(strict = True)
-			# If the key does not already exist in the map, add it. Otherwise, update the existing information.
-			if host_make_model in results:
-				results[host_make_model].firmware_files.add(
-					FirmwareFile(
-						file = path,
-						version = version,
-						url = self.get_firmware_url(hostname = host_make_model.host, firmware_file = path),
-					)
-				)
-			else:
-				results[host_make_model] = FirmwareInfo(
-					current_version = host_current_firmwares[host_make_model],
-					imp = imp,
-					host_attrs = host_attrs[host_make_model.host],
-					force = force,
-					frontend_ip = self.get_common_frontend_ip(hostname = host_make_model.host),
-					firmware_files = {
-						FirmwareFile(
-							file = path,
-							version = version,
-							url = self.get_firmware_url(hostname = host_make_model.host, firmware_file = path),
-						)
-					}
-				)
+	def _get_invalid_mappings(self, results, force, host_current_firmwares):
+		"""Processes the result set and excludes any invalid mappings.
 
-		# Perform post processing and validation now that we have all the info from the DB
+		This is where, if force is not set, multiple firmware versions for the same host + make + model
+		are rejected and already up to date hosts are skipped. This will also perform the version regex
+		validation if one is found.
+		"""
 		invalid_mappings = set()
 		for host_make_model, firmware_info in results.items():
 			# don't allow multiple firmware versions for a host + make + model combo unless force is specified.
@@ -140,6 +79,109 @@ class Command(stack.commands.sync.host.command, FirmwareArgumentProcessor):
 					)
 					break
 
+		return invalid_mappings
+
+	def _sync_required_firmware_files(self, results):
+		"""Ensures the required firmware files are on disk based on the resulting firmware information to sync."""
+		# build a dictionary of make + model mapped to versions
+		keyfunc = lambda items: (items[0].make, items[0].model)
+		firmware_files_to_sync = {
+			make_model: [
+				firmware_file.version
+				for _, firmware_info in values
+				for firmware_file in firmware_info.firmware_files
+			]
+			for make_model, values in itertools.groupby(
+				sorted(results.items(), key = keyfunc),
+				key = keyfunc,
+			)
+		}
+		# sync all firmware we need first to ensure the local filesystem
+		# is consistent with what the DB
+		for make_model, versions in firmware_files_to_sync.items():
+			self.call(command = 'sync.firmware', args = [*versions, f"make={make_model[0]}", f"model={make_model[1]}"])
+
+	def _get_host_firmwares(self, common_key, hosts, host_attrs, host_current_firmwares, force):
+		"""Get all the firmware information from the database needed to perform the sync operation."""
+		results = {}
+		# The firmware information for a given host + make + model combination.
+		FirmwareInfo = make_dataclass(
+			"FirmwareInfo", (
+				# Can potentially support multiple firmware files
+				"firmware_files",
+				"current_version",
+				"imp",
+				"host_attrs",
+				"force",
+				"frontend_ip",
+			)
+		)
+		# The information for the firmware file to be applied.
+		FirmwareFile = make_dataclass(
+			"FirmwareFile", (
+				"file",
+				"version",
+				"url",
+			)
+		)
+		for row in self.db.select(
+				"""
+				nodes.Name, firmware_make.name, firmware_model.name, firmware.version, firmware.file, firmware_imp.name
+				FROM firmware_mapping
+					INNER JOIN nodes
+						ON firmware_mapping.node_id = nodes.ID
+					INNER JOIN firmware
+						ON firmware_mapping.firmware_id = firmware.id
+					INNER JOIN firmware_model
+						ON firmware.model_id = firmware_model.id
+					INNER JOIN firmware_make
+						ON firmware_model.make_id = firmware_make.id
+					INNER JOIN firmware_imp
+						ON firmware_model.imp_id = firmware_imp.id
+				WHERE nodes.Name IN %s
+				""",
+				(hosts,)
+		):
+			host_make_model = common_key(*row[:3])
+			version, firmware_file, imp = row[3:]
+			path = Path(firmware_file).resolve()
+			# If the key does not already exist in the map, add it. Otherwise, update the existing information.
+			if host_make_model in results:
+				results[host_make_model].firmware_files.append(
+					FirmwareFile(
+						file = path,
+						version = version,
+						# This will be resolved later after pruning invalid mappings.
+						url = None,
+					)
+				)
+			else:
+				results[host_make_model] = FirmwareInfo(
+					current_version = host_current_firmwares[host_make_model],
+					imp = imp,
+					host_attrs = host_attrs[host_make_model.host],
+					force = force,
+					frontend_ip = self.get_common_frontend_ip(hostname = host_make_model.host),
+					firmware_files = [
+						FirmwareFile(
+							file = path,
+							version = version,
+							# This will be resolved later after pruning invalid mappings.
+							url = None,
+						)
+					]
+				)
+
+		# Perform validation now that we have all the info from the DB
+		invalid_mappings = self._get_invalid_mappings(
+			results = results,
+			force = force,
+			host_current_firmwares = host_current_firmwares,
+		)
+		# Drop the invalid mappings.
+		for host_make_model in invalid_mappings:
+			results.pop(host_make_model)
+
 		# Notify about the hosts being skipped because of no mapped firmware.
 		hosts_with_mapped_firmware = [host_make_model.host for host_make_model in results]
 		for host in hosts:
@@ -148,9 +190,20 @@ class Command(stack.commands.sync.host.command, FirmwareArgumentProcessor):
 					f"Skipping {host} because no firmware is mapped to it."
 				)
 
-		# Drop the invalid mappings before returning the results.
-		for host_make_model in invalid_mappings:
-			results.pop(host_make_model)
+		# Make sure the files we need exist on disk based on the results.
+		# We do this after the results are pruned because we don't want to run a bunch of
+		# potentially long file fetch operations on files we aren't going to use.
+		self._sync_required_firmware_files(results)
+
+		# Finally, post process the remaining mappings to insert data we skipped adding earlier.
+		# We had to wait because `get_firmware_url` requires that the path resolves to an existing
+		# file on disk, which wasn't guaranteed until we called `_sync_required_firmware_files`.
+		for host_make_model, firmware_info in results.items():
+			for firmware_file in firmware_info.firmware_files:
+				firmware_file.url = self.get_firmware_url(
+					hostname = host_make_model.host,
+					firmware_file = firmware_file.file,
+				)
 
 		return results
 
@@ -163,8 +216,6 @@ class Command(stack.commands.sync.host.command, FirmwareArgumentProcessor):
 		)
 		force = self.str2bool(force)
 
-		# sync all firmware first to ensure consistency with the DB
-		self.call(command = 'sync.firmware')
 		host_attrs = self.getHostAttrDict(host = hosts)
 		# grab all the current firmware versions
 		CommonKey = namedtuple("CommonKey", ("host", "make", "model"))
@@ -174,7 +225,7 @@ class Command(stack.commands.sync.host.command, FirmwareArgumentProcessor):
 		}
 
 		# get the firmware info for all hosts
-		results = self.get_host_firmwares(
+		results = self._get_host_firmwares(
 			common_key = CommonKey,
 			hosts = hosts,
 			host_attrs = host_attrs,

--- a/test-framework/test-suites/integration/files/list/mock_list_firmware_run_plugins.py
+++ b/test-framework/test-suites/integration/files/list/mock_list_firmware_run_plugins.py
@@ -1,0 +1,34 @@
+from collections import namedtuple
+from unittest.mock import patch
+import stack.commands.sync.host.firmware
+import stack.commands.list.host.firmware.imp_mellanox
+import stack.commands.list.host.firmware.imp_dell_x1052
+
+# Make the mellanox implementation for list host firmware return a low version
+# number that will be a candidate for upgrading.
+mock_mellanox_list_firmware = patch.object(
+	target = stack.commands.list.host.firmware.imp_mellanox.Implementation,
+	attribute = "list_firmware",
+	autospec = True,
+).start()
+mock_mellanox_list_firmware.return_value = "0.0.0"
+
+# Make the dell implementation for list host firmware return a low version
+# number that will be a candidate for upgrading.
+mock_dell_list_firmware = patch.object(
+	target = stack.commands.list.host.firmware.imp_dell_x1052.Implementation,
+	attribute = "list_firmware",
+	autospec = True,
+).start()
+mock_dell_list_firmware.return_value = namedtuple("Versions", ("software", "boot", "hardware"))(
+	software = "0.0.0.0",
+	boot = "0.0.0.0",
+	hardware = "0.0.0.0",
+)
+
+# Mock runPlugins calls
+patch.object(
+	target = stack.commands.sync.host.firmware.Command,
+	attribute = "runPlugins",
+	autospec = True,
+).start()

--- a/test-framework/test-suites/integration/files/sync/mock_firmware_run_plugins.py
+++ b/test-framework/test-suites/integration/files/sync/mock_firmware_run_plugins.py
@@ -1,0 +1,34 @@
+from collections import namedtuple
+from unittest.mock import patch
+import stack.commands.sync.host.firmware
+import stack.commands.list.host.firmware.imp_mellanox
+import stack.commands.list.host.firmware.imp_dell_x1052
+
+# Make the mellanox implementation for list host firmware return a low version
+# number that will be a candidate for upgrading.
+mock_mellanox_list_firmware = patch.object(
+	target = stack.commands.list.host.firmware.imp_mellanox.Implementation,
+	attribute = "list_firmware",
+	autospec = True,
+).start()
+mock_mellanox_list_firmware.return_value = "0.0.0"
+
+# Make the dell implementation for list host firmware return a low version
+# number that will be a candidate for upgrading.
+mock_dell_list_firmware = patch.object(
+	target = stack.commands.list.host.firmware.imp_dell_x1052.Implementation,
+	attribute = "list_firmware",
+	autospec = True,
+).start()
+mock_dell_list_firmware.return_value = namedtuple("Versions", ("software", "boot", "hardware"))(
+	software = "0.0.0.0",
+	boot = "0.0.0.0",
+	hardware = "0.0.0.0",
+)
+
+# Mock runPlugins calls
+patch.object(
+	target = stack.commands.sync.host.firmware.Command,
+	attribute = "runPlugins",
+	autospec = True,
+).start()

--- a/test-framework/test-suites/integration/tests/fixtures/add_data.py
+++ b/test-framework/test-suites/integration/tests/fixtures/add_data.py
@@ -1,6 +1,6 @@
 import json
 import subprocess
-
+import ipaddress
 import pytest
 
 
@@ -32,7 +32,7 @@ def add_host_with_interface():
 		if result.returncode != 0:
 			pytest.fail('unable to add a dummy interface')
 
-	_inner('backend-0-0', '0', '1', 'backend', 'eth0')
+	_inner('backend-0-0', '0', '0', 'backend', 'eth0')
 
 	return _inner
 
@@ -174,9 +174,10 @@ def add_group(host):
 
 @pytest.fixture
 def add_network(host):
-	def _inner(name, address):
+	"""Adds a network to the stacki db. For historical reasons the first test network this creates is pxe=False."""
+	def _inner(name, address, pxe = False):
 		result = host.run(
-			f'stack add network {name} address={address} mask=255.255.255.0'
+			f'stack add network {name} address={address} mask=255.255.255.0 pxe={pxe}'
 		)
 		if result.rc != 0:
 			pytest.fail(f'unable to add dummy network "{name}"')
@@ -190,11 +191,62 @@ def add_network(host):
 	return _inner
 
 @pytest.fixture
-def add_host_with_net(host):
-	host.run("stack add network test pxe=true address=192.168.0.0 mask=255.255.255.0")
-	host.run("stack add host interface a:frontend interface=eth2 network=test ip=192.168.0.2")
-	host.run("stack add host backend-0-0 appliance=backend rack=0 rank=0")
-	host.run("stack add host interface backend-0-0 interface=eth0 network=test ip=192.168.0.3")
+def add_host_with_net(host, add_host_with_interface, add_network):
+	"""Adds a host with a network. The first network this adds defaults to pxe=True."""
+	def _inner(hostname, rack, rank, appliance, interface, ip, network, address, pxe):
+		# Add the host with an interface.
+		add_host_with_interface(hostname = hostname, rack = rack, rank = rank, appliance = appliance, interface = interface)
+
+		# Add the network.
+		add_network(name = network, address = address, pxe = pxe)
+
+		# Associate it to the interface.
+		result = host.run(f"stack set host interface network {hostname} network={network} interface={interface}")
+		assert result.rc == 0
+
+		# Set the interface IP
+		result = host.run(f"stack set host interface ip {hostname} ip={ip} network={network}")
+		assert result.rc == 0
+
+		# Add it to the frontend, because a lot of things in stacki expect backends to share networks with
+		# frontends.
+		result = host.run("stack list host interface a:frontend output-format=json")
+		assert result.rc == 0
+		# Try to figure out if the frontend has an interface on this network already.
+		interface_on_network = False
+		for frontend_interface in json.loads(result.stdout):
+			if frontend_interface["network"] == network:
+				interface_on_network = True
+				break
+
+		if interface_on_network:
+			return
+
+		# Need to add an interface to the frontend on this network. Make sure we choose the next latest
+		# interface name so we don't clash with other interface names.
+		latest_interface = max(frontend_interface["interface"] for frontend_interface in json.loads(result.stdout))
+		# This should be a string, so we tokenize it into characters
+		new_interface = list(latest_interface)
+		new_interface[-1] = str(int(new_interface[-1]) + 1)
+		new_interface = "".join(new_interface)
+		result = host.run(f"stack add host interface a:frontend interface={new_interface} network={network} ip={ipaddress.ip_address(ip) + 1}")
+		assert result.rc == 0
+
+	# First use of the add_host_with_interface fixture adds backend-0-0 with interface eth0.
+	# The first use of add_network adds a network called test, but that's not PXE so we don't want to use it.
+	# So the first call of this fixture needs to remove the test network, recreate it as a PXE network, and
+	# associate the network with the host's interface.
+	result = host.run(f"stack remove network test")
+	assert result.rc == 0
+	add_network(name = "test", address = "192.168.0.0", pxe = True)
+	result = host.run(f"stack set host interface network backend-0-0 network=test interface=eth0 ip=192.168.0.3")
+	assert result.rc == 0
+
+	# Add a frontend interface on the network.
+	result = host.run(f"stack add host interface a:frontend interface=eth2 network=test ip=192.168.0.2")
+	assert result.rc == 0
+
+	return _inner
 
 @pytest.fixture(params = (True, False))
 def stack_load(request, host):
@@ -210,3 +262,11 @@ def stack_load(request, host):
 		return host.run(f"stack load {dump_file} {kwargs_string} | bash -x")
 
 	return _load_using_bash
+
+@pytest.fixture
+def fake_local_firmware_file(tmp_path_factory):
+	"""Creates a fake local firmware file and returns a pathlib.Path object that points to it."""
+	# Add a fake piece of firmware.
+	fake_firmware_file = tmp_path_factory.mktemp("fake_firmware") / "foo.img"
+	fake_firmware_file.write_text("foofakefirmware")
+	return fake_firmware_file

--- a/test-framework/test-suites/integration/tests/list/test_list_host.py
+++ b/test-framework/test-suites/integration/tests/list/test_list_host.py
@@ -20,7 +20,7 @@ class TestListHost:
 			'os': host_os,
 			'osaction': 'default',
 			'rack': '0',
-			'rank': '1'
+			'rank': '0'
 		}]
 
 	def test_lookup_by_FQDN(self, host, add_host_with_interface, add_network, host_os):
@@ -44,7 +44,7 @@ class TestListHost:
 			'os': host_os,
 			'osaction': 'default',
 			'rack': '0',
-			'rank': '1'
+			'rank': '0'
 		}]
 
 	def test_lookup_by_FQDN_with_name(self, host, add_host_with_interface, add_network, host_os):
@@ -72,5 +72,5 @@ class TestListHost:
 			'os': host_os,
 			'osaction': 'default',
 			'rack': '0',
-			'rank': '1'
+			'rank': '0'
 		}]

--- a/test-framework/test-suites/integration/tests/list/test_list_host_firmware.py
+++ b/test-framework/test-suites/integration/tests/list/test_list_host_firmware.py
@@ -1,0 +1,60 @@
+import json
+import pytest
+
+@pytest.mark.parametrize(
+	"hosts, expected_results",
+	(
+		(
+			"",
+			[
+				{"host": "backend-0-0", "make": "mellanox", "model": "m7800", "desired_firmware_version": "1.2.3", "current_firmware_version": "0.0.0"},
+				{"host": "backend-0-1", "make": "dell", "model": "x1052-software", "desired_firmware_version": "1.2.3.4", "current_firmware_version": "0.0.0.0"},
+				{"host": "frontend-0-0", "make": None, "model": None, "desired_firmware_version": None, "current_firmware_version": None},
+			],
+		),
+		(
+			"backend-0-0",
+			[{"host": "backend-0-0", "make": "mellanox", "model": "m7800", "desired_firmware_version": "1.2.3", "current_firmware_version": "0.0.0"}],
+		),
+		(
+			"backend-0-1",
+			[{"host": "backend-0-1", "make": "dell", "model": "x1052-software", "desired_firmware_version": "1.2.3.4", "current_firmware_version": "0.0.0.0"}],
+		),
+	),
+)
+def test_list_host_firmware(
+	host,
+	add_host_with_net,
+	fake_local_firmware_file,
+	revert_firmware,
+	inject_code,
+	test_file,
+	hosts,
+	expected_results,
+):
+	"""Test that list host firmware filters correctly based on provided arguments."""
+	# Add a backend-0-1
+	add_host_with_net(
+		hostname = "backend-0-1",
+		rack = 0,
+		rank = 1,
+		appliance = "backend",
+		interface = "eth0",
+		ip = "192.168.1.1",
+		network = "fake_net",
+		address = "192.168.1.0",
+		pxe = True,
+	)
+	# Add a piece of mellanox firmware to backend-0-0.
+	result = host.run(f"stack add firmware 1.2.3 make=mellanox model=m7800 source={fake_local_firmware_file} hosts=backend-0-0")
+	assert result.rc == 0
+	# Add a piece of dell firmware to backend-0-1
+	result = host.run(f"stack add firmware 1.2.3.4 make=dell model=x1052-software source={fake_local_firmware_file} hosts=backend-0-1")
+	assert result.rc == 0
+
+	# Now list the firmware. We need to mock out the running of plugins so it doesn't
+	# actually try to talk to hardware that doesn't exist.
+	with inject_code(test_file("list/mock_list_firmware_run_plugins.py")):
+		result = host.run(f"stack list host firmware {hosts} output-format=json")
+		assert result.rc == 0
+		assert json.loads(result.stdout) == expected_results

--- a/test-framework/test-suites/integration/tests/list/test_list_host_firmware_mapping.py
+++ b/test-framework/test-suites/integration/tests/list/test_list_host_firmware_mapping.py
@@ -1,0 +1,107 @@
+import json
+import pytest
+
+@pytest.mark.parametrize(
+	"hosts, expected_results",
+	(
+		(
+			"",
+			[
+				{"host": "backend-0-0", "version": "1.2.3", "make": "mellanox", "model": "m7800"},
+				{"host": "backend-0-1", "version": "1.2.3.4", "make": "dell", "model": "x1052-software"},
+			],
+		),
+		("backend-0-0", [{"host": "backend-0-0", "version": "1.2.3", "make": "mellanox", "model": "m7800"}]),
+		("backend-0-1", [{"host": "backend-0-1", "version": "1.2.3.4", "make": "dell", "model": "x1052-software"}]),
+	),
+)
+def test_list_host_firmware_mapping_host_filter(
+	host,
+	add_host_with_net,
+	fake_local_firmware_file,
+	revert_firmware,
+	hosts,
+	expected_results,
+):
+	"""Test that list host firmware mapping filters correctly based on provided arguments."""
+	# Add a backend-0-1
+	add_host_with_net(
+		hostname = "backend-0-1",
+		rack = 0,
+		rank = 1,
+		appliance = "backend",
+		interface = "eth0",
+		ip = "192.168.1.1",
+		network = "fake_net",
+		address = "192.168.1.0",
+		pxe = True,
+	)
+	# Add a piece of mellanox firmware to backend-0-0.
+	result = host.run(f"stack add firmware 1.2.3 make=mellanox model=m7800 source={fake_local_firmware_file} hosts=backend-0-0")
+	assert result.rc == 0
+	# Add a piece of dell firmware to backend-0-1
+	result = host.run(f"stack add firmware 1.2.3.4 make=dell model=x1052-software source={fake_local_firmware_file} hosts=backend-0-1")
+	assert result.rc == 0
+
+	# List the firmware mappings
+	result = host.run(f"stack list host firmware mapping {hosts} output-format=json")
+	assert result.rc == 0
+	assert expected_results == json.loads(result.stdout)
+
+@pytest.mark.parametrize(
+	"make, model, versions, expected_results",
+	(
+		(
+			"",
+			"",
+			"",
+			[
+				{"host": "backend-0-0", "version": "1.2.3", "make": "mellanox", "model": "m7800"},
+				{"host": "backend-0-1", "version": "1.2.3.4", "make": "dell", "model": "x1052-software"},
+			],
+		),
+		("mellanox", "", "", [{"host": "backend-0-0", "version": "1.2.3", "make": "mellanox", "model": "m7800"}]),
+		("mellanox", "m7800", "", [{"host": "backend-0-0", "version": "1.2.3", "make": "mellanox", "model": "m7800"}]),
+		("mellanox", "m7800", "1.2.3", [{"host": "backend-0-0", "version": "1.2.3", "make": "mellanox", "model": "m7800"}]),
+		("dell", "", "", [{"host": "backend-0-1", "version": "1.2.3.4", "make": "dell", "model": "x1052-software"}]),
+		("dell", "x1052-software", "", [{"host": "backend-0-1", "version": "1.2.3.4", "make": "dell", "model": "x1052-software"}]),
+		("dell", "x1052-software", "1.2.3.4", [{"host": "backend-0-1", "version": "1.2.3.4", "make": "dell", "model": "x1052-software"}]),
+	),
+)
+def test_list_host_firmware_mapping_non_host_filter(
+	host,
+	add_host_with_net,
+	fake_local_firmware_file,
+	revert_firmware,
+	make,
+	model,
+	versions,
+	expected_results,
+):
+	"""Test that list host firmware mapping filters correctly based on provided arguments."""
+	# Add a backend-0-1
+	add_host_with_net(
+		hostname = "backend-0-1",
+		rack = 0,
+		rank = 1,
+		appliance = "backend",
+		interface = "eth0",
+		ip = "192.168.1.1",
+		network = "fake_net",
+		address = "192.168.1.0",
+		pxe = True,
+	)
+	# Add a piece of mellanox firmware to backend-0-0.
+	result = host.run(f"stack add firmware 1.2.3 make=mellanox model=m7800 source={fake_local_firmware_file} hosts=backend-0-0")
+	assert result.rc == 0
+	# Add a piece of dell firmware to backend-0-1
+	result = host.run(f"stack add firmware 1.2.3.4 make=dell model=x1052-software source={fake_local_firmware_file} hosts=backend-0-1")
+	assert result.rc == 0
+
+	# List the firmware mappings
+	result = host.run(
+		f"stack list host firmware mapping {f'make={make}' if make else ''} {f'model={model}' if model else ''} "
+		f"{f'versions={versions}' if versions else ''} output-format=json"
+	)
+	assert result.rc == 0
+	assert expected_results == json.loads(result.stdout)

--- a/test-framework/test-suites/integration/tests/sync/test_sync_firmware.py
+++ b/test-framework/test-suites/integration/tests/sync/test_sync_firmware.py
@@ -1,0 +1,60 @@
+import stack.firmware
+
+def test_sync_firmware_resync(host, fake_local_firmware_file, revert_firmware):
+	"""Add some firmware, nuke the firmware dir, and then sync firmware and make sure it shows back up."""
+	# Add a fake piece of firmware.
+	result = host.run(f"stack add firmware 1.2.3 make=mellanox model=m7800 source={fake_local_firmware_file}")
+	assert result.rc == 0
+
+	# Now find the file on disk and nuke it. The files are given random UUID4 names,
+	# so we have to glob for the file.
+	firmware_file_on_disk = [
+		firmware_file for firmware_file in stack.firmware.BASE_PATH.glob(f"**/*")
+		if firmware_file.is_file()
+	]
+	assert len(firmware_file_on_disk) == 1
+	firmware_file_on_disk = firmware_file_on_disk[0]
+	firmware_file_on_disk.unlink()
+	assert not firmware_file_on_disk.exists()
+
+	# Now run the sync command.
+	result = host.run("stack sync firmware")
+	assert result.rc == 0
+
+	# Make sure the file exists again.
+	firmware_file_on_disk = [
+		firmware_file for firmware_file in stack.firmware.BASE_PATH.glob(f"**/*")
+		if firmware_file.is_file()
+	]
+	assert len(firmware_file_on_disk) == 1
+	assert firmware_file_on_disk[0].exists()
+
+def test_sync_firmware_selective_resync(host, fake_local_firmware_file, revert_firmware):
+	"""Add two firmware files, nuke em both, selectively sync one and ensure that's the only one that shows back up."""
+	result = host.run(f"stack add firmware 1.2.3 make=mellanox model=m7800 source={fake_local_firmware_file}")
+	assert result.rc == 0
+	result = host.run(f"stack add firmware 2.3.4 make=mellanox model=m7800 source={fake_local_firmware_file}")
+	assert result.rc == 0
+
+	# Now find the files on disk and nuke em. The files are given random UUID4 names,
+	# so we have to glob for the file.
+	firmware_files_on_disk = [
+		firmware_file for firmware_file in stack.firmware.BASE_PATH.glob(f"**/*")
+		if firmware_file.is_file()
+	]
+	assert len(firmware_files_on_disk) == 2
+	for firmware_file in firmware_files_on_disk:
+		firmware_file.unlink()
+		assert not firmware_file.exists()
+
+	# Now run the sync command.
+	result = host.run(f"stack sync firmware 2.3.4 make=mellanox model=m7800")
+	assert result.rc == 0
+
+	# Make sure only one file exists
+	firmware_files_on_disk = [
+		firmware_file for firmware_file in stack.firmware.BASE_PATH.glob(f"**/*")
+		if firmware_file.is_file()
+	]
+	assert len(firmware_files_on_disk) == 1
+	assert firmware_files_on_disk[0].exists()

--- a/test-framework/test-suites/integration/tests/sync/test_sync_host_firmware.py
+++ b/test-framework/test-suites/integration/tests/sync/test_sync_host_firmware.py
@@ -1,0 +1,50 @@
+import stack.firmware
+
+def test_sync_only_needed_files(host, add_host_with_net, fake_local_firmware_file, inject_code, test_file, revert_firmware):
+	"""Test that sync host firmware only tries to sync firmware it needs, not all in the database.
+
+	This adds multiple firmware versions for the same make + model combo on purpose to exercise clustered syncing of
+	firmware files. This also requires passing the force flag to `sync host firmware`.
+	"""
+	# Add multiple piecies of firmware for mellanox, and associate it with the host we are going to sync.
+	result = host.run(f"stack add firmware 1.2.3 make=mellanox model=m7800 source={fake_local_firmware_file} hosts=backend-0-0")
+	assert result.rc == 0
+	result = host.run(f"stack add firmware 2.3.4 make=mellanox model=m7800 source={fake_local_firmware_file} hosts=backend-0-0")
+	assert result.rc == 0
+	# Add multiple firmwares for dell, and associate it with the host we are going to sync.
+	result = host.run(f"stack add firmware 1.2.3.4 make=dell model=x1052-software source={fake_local_firmware_file} hosts=backend-0-0")
+	assert result.rc == 0
+	result = host.run(f"stack add firmware 2.3.4.5 make=dell model=x1052-software source={fake_local_firmware_file} hosts=backend-0-0")
+	assert result.rc == 0
+	result = host.run(f"stack add firmware 1.2.3.4 make=dell model=x1052-boot source={fake_local_firmware_file} hosts=backend-0-0")
+	assert result.rc == 0
+	result = host.run(f"stack add firmware 2.3.4.5 make=dell model=x1052-boot source={fake_local_firmware_file} hosts=backend-0-0")
+	assert result.rc == 0
+	# Add a piece of firmware we don't care about. Don't associate it with any hosts.
+	result = host.run(f"stack add firmware 1.2.3 make=mellanox model=m6036 source={fake_local_firmware_file}")
+	assert result.rc == 0
+	# Now find the files on disk and nuke em. The files are given random UUID4 names,
+	# so we have to glob for the file.
+	firmware_files_on_disk = [
+		firmware_file for firmware_file in stack.firmware.BASE_PATH.glob(f"**/*")
+		if firmware_file.is_file()
+	]
+	assert len(firmware_files_on_disk) == 7
+	for firmware_file in firmware_files_on_disk:
+		firmware_file.unlink()
+		assert not firmware_file.exists()
+
+	# Now sync the firmware to the host. We need to mock out the running of plugins so it doesn't
+	# actually try to sync to hardware that doesn't exist.
+	with inject_code(test_file("sync/mock_firmware_run_plugins.py")):
+		result = host.run("stack sync host firmware force=true")
+		assert result.rc == 0
+
+	# Now it should have added back only the firmware for the switch-0-0 host that was to be synced.
+	firmware_files_on_disk = [
+		firmware_file for firmware_file in stack.firmware.BASE_PATH.glob(f"**/*")
+		if firmware_file.is_file()
+	]
+	assert len(firmware_files_on_disk) == 6
+	for firmware_file in firmware_files_on_disk:
+		assert firmware_file.exists()

--- a/test-framework/test-suites/unit/tests/command/stack/commands/list/host/firmware/mapping/test_command_stack_commands_list_host_firmware_mapping_plugin_basic.py
+++ b/test-framework/test-suites/unit/tests/command/stack/commands/list/host/firmware/mapping/test_command_stack_commands_list_host_firmware_mapping_plugin_basic.py
@@ -1,0 +1,79 @@
+from unittest.mock import create_autospec
+import pytest
+from stack.commands import DatabaseConnection
+from stack.commands.list.host.firmware.mapping import Command
+from stack.commands.list.host.firmware.mapping.plugin_basic import Plugin
+
+@pytest.fixture
+def basic_plugin():
+	"""A fixture that returns the plugin instance for use in tests.
+
+	This sets up the required mocks needed to construct the plugin class.
+	"""
+	mock_command = create_autospec(
+		spec = Command,
+		instance = True,
+	)
+	mock_command.db = create_autospec(
+		spec = DatabaseConnection,
+		spec_set = True,
+		instance = True,
+	)
+	return Plugin(command = mock_command)
+
+def test_provides(basic_plugin):
+	"""Test that the provides returns the basic value."""
+	assert basic_plugin.provides() == "basic"
+
+@pytest.mark.parametrize("hosts", ("", "backend-0-0", "backend-0-1", "backend-0-0 backend-0-1"))
+@pytest.mark.parametrize(
+	"make, model, versions",
+	(
+		("", "", ""),
+		("mellanox", "", ""),
+		("mellanox", "m7800", ""),
+		("mellanox", "m7800", "1.2.3"),
+		("dell", "", ""),
+		("dell", "x1052-software", ""),
+		("dell", "x1052-software", "1.2.3.4"),
+	),
+)
+@pytest.mark.parametrize("sort", ("nodes.Name", "firmware_make.name", "firmware_model.name", "firmware.version",))
+def test_get_firmware_mappings(
+	hosts,
+	make,
+	model,
+	versions,
+	sort,
+	basic_plugin,
+):
+	"""Test that get_firmware_mappings filters correctly based on provided arguments."""
+	# Run the function.
+	basic_plugin.get_firmware_mappings(
+		hosts = hosts,
+		versions = versions,
+		make = make,
+		model = model,
+		sort = sort,
+	)
+
+	query_string = basic_plugin.owner.db.select.call_args[0][0]
+	query_args = basic_plugin.owner.db.select.call_args[0][1]
+	# Assert we find the expected where clause and query args.
+	if hosts:
+		assert "nodes.Name IN %s" in query_string
+		assert hosts in query_args
+
+	if make:
+		assert "firmware_make.name=%s" in query_string
+		assert make in query_args
+
+	if model:
+		assert "firmware_model.name=%s" in query_string
+		assert model in query_args
+
+	if versions:
+		assert "firmware.version IN %s" in query_string
+		assert versions in query_args
+
+	assert sort in query_string


### PR DESCRIPTION
This simplifies some of the logic that was needlessly complex and/or
duplicating code. This also adds a smattering of tests for the updated
code.