### PR TITLE
WIP: Is this the place probepal needs to be included in?

### DIFF
--- a/redhat/src/stack/images/7.6.1810/initrd.img/version.mk
+++ b/redhat/src/stack/images/7.6.1810/initrd.img/version.mk
@@ -7,6 +7,7 @@ OVERLAY.UPDATE.PKGS	= \
 	foundation-python \
 	ludicrous-speed \
 	stack-command \
+	stack-probepal \
 	stack-pylib \
 	foundation-newt \
 	foundation-python-Flask \


### PR DESCRIPTION
This is a quick fix for the stacki install wizard failing due to not having probepal present in the pre install `/opt/stack/lib/python3.7/site-packages/stack`. Basically it adds the stack-probepal package to the initrd version.mk for redhat builds. From looking at the file before however I didn't see it included so I am not sure how it was being included.