### PR TITLE
INTERNAL: Update iso-builder to regenerate the poetry lockfile

### DIFF
--- a/tools/iso-builder/README.md
+++ b/tools/iso-builder/README.md
@@ -23,7 +23,7 @@ Optional environment variables:
 
 * **PYPI_CACHE** - Set to "true" to have the build script use our internal Stacki Builds PyPI cache, which is needed to build the "sles11" platform.
 
-* **UPDATE_VERSIONS_JSON** - Set to "true" to regenerate the versions.json file for the Python modules
+* **UPDATE_LOCKFILE** - Set to "true" to regenerate the poetry.lock file for the Python modules
 
 ## Usage
 

--- a/tools/iso-builder/Vagrantfile
+++ b/tools/iso-builder/Vagrantfile
@@ -97,7 +97,7 @@ Vagrant.configure("2") do |config|
       "IS_RELEASE" => ENV["IS_RELEASE"],
       "OS_PALLET" => ENV["OS_PALLET"],
       "PYPI_CACHE" => ENV["PYPI_CACHE"],
-      "UPDATE_VERSIONS_JSON" => ENV["UPDATE_VERSIONS_JSON"]
+      "UPDATE_LOCKFILE" => ENV["UPDATE_LOCKFILE"]
     }
 
   end

--- a/tools/iso-builder/build.sh
+++ b/tools/iso-builder/build.sh
@@ -11,10 +11,10 @@ mkdir -p /export/src
 cp -rd /vagrant /export/src/stacki
 cd /export/src/stacki
 
-# Regenerate the versions.json, if requested
-if [[ $UPDATE_VERSIONS_JSON == "true" ]]
+# Regenerate the poetry.lock, if requested
+if [[ $UPDATE_LOCKFILE == "true" ]]
 then
-    rm -f common/src/foundation/python-packages/versions.json
+    rm -f common/src/foundation/python-packages/poetry.lock
 fi
 
 # Figure out our ROLLVERSION
@@ -49,10 +49,10 @@ make ROLLVERSION=$ROLLVERSION bootstrap
 make ROLLVERSION=$ROLLVERSION
 make ROLLVERSION=$ROLLVERSION manifest-check
 
-# Copy the updated versions.json back out of the VM
-if [[ $UPDATE_VERSIONS_JSON == "true" ]]
+# Copy the updated poetry.lock back out of the VM
+if [[ $UPDATE_LOCKFILE == "true" ]]
 then
-    cp common/src/foundation/python-packages/versions.json  /vagrant/common/src/foundation/python-packages/versions.json
+    cp common/src/foundation/python-packages/poetry.lock  /vagrant/common/src/foundation/python-packages/poetry.lock
 fi
 
 # If we are redhat7 PLATFORM, we aren't done yet


### PR DESCRIPTION
Tested locally using iso-builder that this would properly remove the lockfile, have poetry regenerate it, and copy it out of the vagrant VM into the correct location in the stacki source tree.