### PR TITLE
INTERNAL: Update django to the latest version

### DIFF
--- a/common/nodes/restapi.xml
+++ b/common/nodes/restapi.xml
@@ -15,14 +15,6 @@ https://github.com/Teradata/stacki/blob/master/LICENSE.txt
 
 <!-- COMMON -->
 <stack:script stack:stage="install-post">
-<!--
-	Create Symlink to point to pymysqldb. This
-	is required for django to work correctly, since
-	django requires MySQLdb which we cannot distribute
--->
-ln -s /opt/stack/lib/python3.7/site-packages/pymysql \
-	/opt/stack/lib/python3.7/site-packages/MySQLdb
-
 /opt/stack/share/stack/bin/ws_setup.sh
 
 <!-- enable commands because they require 'sudo' -->

--- a/common/src/foundation/python-packages/poetry.lock
+++ b/common/src/foundation/python-packages/poetry.lock
@@ -8,6 +8,17 @@ version = "2.9.2"
 
 [[package]]
 category = "main"
+description = "ASGI specs, helper code, and adapters"
+name = "asgiref"
+optional = false
+python-versions = "*"
+version = "3.2.3"
+
+[package.extras]
+tests = ["pytest (>=4.3.0,<4.4.0)", "pytest-asyncio (>=0.10.0,<0.11.0)"]
+
+[[package]]
+category = "main"
 description = "Atomic file writes."
 marker = "sys_platform == \"win32\""
 name = "atomicwrites"
@@ -124,11 +135,13 @@ category = "main"
 description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
 name = "django"
 optional = false
-python-versions = "*"
-version = "1.11.20"
+python-versions = ">=3.6"
+version = "3.0.2"
 
 [package.dependencies]
+asgiref = ">=3.2,<4.0"
 pytz = "*"
+sqlparse = ">=0.2.2"
 
 [package.extras]
 argon2 = ["argon2-cffi (>=16.1.0)"]
@@ -337,7 +350,7 @@ description = "Installer for Apache/mod_wsgi."
 name = "mod-wsgi"
 optional = false
 python-versions = "*"
-version = "4.6.8"
+version = "4.7.0"
 
 [[package]]
 category = "main"
@@ -361,7 +374,7 @@ description = "Core utilities for Python packages"
 name = "packaging"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "19.2"
+version = "20.0"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
@@ -438,7 +451,7 @@ description = "library with cross-python path, ini-parsing, io, code, log facili
 name = "py"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.8.0"
+version = "1.8.1"
 
 [[package]]
 category = "main"
@@ -470,7 +483,10 @@ description = "Pure Python MySQL Driver"
 name = "pymysql"
 optional = false
 python-versions = "*"
-version = "0.8.1"
+version = "0.9.3"
+
+[package.extras]
+rsa = ["cryptography"]
 
 [[package]]
 category = "main"
@@ -494,7 +510,7 @@ description = "Python parsing module"
 name = "pyparsing"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "2.4.5"
+version = "2.4.6"
 
 [[package]]
 category = "main"
@@ -608,6 +624,14 @@ version = "2.0.5"
 
 [[package]]
 category = "main"
+description = "Non-validating SQL parser"
+name = "sqlparse"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.3.0"
+
+[[package]]
+category = "main"
 description = "Test infrastructures"
 name = "testinfra"
 optional = false
@@ -645,7 +669,7 @@ description = "Measures number of Terminal column cells of wide-character codes"
 name = "wcwidth"
 optional = false
 python-versions = "*"
-version = "0.1.7"
+version = "0.1.8"
 
 [[package]]
 category = "main"
@@ -700,12 +724,16 @@ sles12 = ["libvirt-python"]
 sles15 = ["libvirt-python"]
 
 [metadata]
-content-hash = "f260474530594566349a38cd56988ff46493a31143cfce3f28bbf3fea9f10296"
+content-hash = "cec2ed5d651ef0c764d761bc14a39c045b594917aff75db2a98048a7b3d80b78"
 python-versions = "^3.6"
 
 [metadata.files]
 ansible = [
     {file = "ansible-2.9.2.tar.gz", hash = "sha256:2f83f8ccc50640aa41a24f6e7757ac06b0ee6189fdcaacab68851771d3b42f3a"},
+]
+asgiref = [
+    {file = "asgiref-3.2.3-py2.py3-none-any.whl", hash = "sha256:ea448f92fc35a0ef4b1508f53a04c4670255a3f33d22a81c8fc9c872036adbe5"},
+    {file = "asgiref-3.2.3.tar.gz", hash = "sha256:7e06d934a7718bf3975acbf87780ba678957b87c7adc056f13b6215d610695a0"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.3.0-py2.py3-none-any.whl", hash = "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4"},
@@ -814,8 +842,8 @@ cryptography = [
     {file = "cryptography-2.8.tar.gz", hash = "sha256:3cda1f0ed8747339bbdf71b9f38ca74c7b592f24f65cdb3ab3765e4b02871651"},
 ]
 django = [
-    {file = "Django-1.11.20-py2.py3-none-any.whl", hash = "sha256:0a73696e0ac71ee6177103df984f9c1e07cd297f080f8ec4dc7c6f3fb74395b5"},
-    {file = "Django-1.11.20.tar.gz", hash = "sha256:43a99da08fee329480d27860d68279945b7d8bf7b537388ee2c8938c709b2041"},
+    {file = "Django-3.0.2-py3-none-any.whl", hash = "sha256:4f2c913303be4f874015993420bf0bd8fd2097a9c88e6b49c6a92f9bdd3fb13a"},
+    {file = "Django-3.0.2.tar.gz", hash = "sha256:8c3575f81e11390893860d97e1e0154c47512f180ea55bd84ce8fa69ba8051ca"},
 ]
 docutils = [
     {file = "docutils-0.15.2-py2-none-any.whl", hash = "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827"},
@@ -915,7 +943,7 @@ mccabe = [
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 mod-wsgi = [
-    {file = "mod_wsgi-4.6.8.tar.gz", hash = "sha256:804c17139b7bbcd21059833cf13384402cd45f0fc07c2c5375bacac334057d81"},
+    {file = "mod_wsgi-4.7.0.tar.gz", hash = "sha256:64a6a177946b78bb1eb8ecb31fb3aea5f6d306c4eccd247433563ed6afceafe5"},
 ]
 more-itertools = [
     {file = "more-itertools-8.0.2.tar.gz", hash = "sha256:b84b238cce0d9adad5ed87e745778d20a3f8487d0f0cb8b8a586816c7496458d"},
@@ -946,8 +974,8 @@ netifaces = [
     {file = "netifaces-0.10.9.tar.gz", hash = "sha256:2dee9ffdd16292878336a58d04a20f0ffe95555465fee7c9bd23b3490ef2abf3"},
 ]
 packaging = [
-    {file = "packaging-19.2-py2.py3-none-any.whl", hash = "sha256:d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108"},
-    {file = "packaging-19.2.tar.gz", hash = "sha256:28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47"},
+    {file = "packaging-20.0-py2.py3-none-any.whl", hash = "sha256:aec3fdbb8bc9e4bb65f0634b9f551ced63983a529d6a8931817d52fdd0816ddb"},
+    {file = "packaging-20.0.tar.gz", hash = "sha256:fe1d8331dfa7cc0a883b49d75fc76380b2ab2734b220fbb87d774e4fd4b851f8"},
 ]
 paramiko = [
     {file = "paramiko-2.7.1-py2.py3-none-any.whl", hash = "sha256:9c980875fa4d2cb751604664e9a2d0f69096643f5be4db1b99599fe114a97b2f"},
@@ -979,8 +1007,8 @@ ptyprocess = [
     {file = "ptyprocess-0.6.0.tar.gz", hash = "sha256:923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0"},
 ]
 py = [
-    {file = "py-1.8.0-py2.py3-none-any.whl", hash = "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa"},
-    {file = "py-1.8.0.tar.gz", hash = "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"},
+    {file = "py-1.8.1-py2.py3-none-any.whl", hash = "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"},
+    {file = "py-1.8.1.tar.gz", hash = "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa"},
 ]
 pycodestyle = [
     {file = "pycodestyle-2.5.0-py2.py3-none-any.whl", hash = "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56"},
@@ -994,8 +1022,8 @@ pyflakes = [
     {file = "pyflakes-2.1.1.tar.gz", hash = "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"},
 ]
 pymysql = [
-    {file = "PyMySQL-0.8.1-py2.py3-none-any.whl", hash = "sha256:2e77a2a193b1d21d51934c4ca055c88971eb6c6fc6e381b428c081bc14b215f8"},
-    {file = "PyMySQL-0.8.1.tar.gz", hash = "sha256:34e19bfff13e8b2ffc38a68f9ad064609d48f3d46320e8ab8184af527e662629"},
+    {file = "PyMySQL-0.9.3-py2.py3-none-any.whl", hash = "sha256:3943fbbbc1e902f41daf7f9165519f140c4451c179380677e6a848587042561a"},
+    {file = "PyMySQL-0.9.3.tar.gz", hash = "sha256:d8c059dcd81dedb85a9f034d5e22dcb4442c0b201908bede99e306d65ea7c8e7"},
 ]
 pynacl = [
     {file = "PyNaCl-1.3.0-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:2424c8b9f41aa65bbdbd7a64e73a7450ebb4aa9ddedc6a081e7afcc4c97f7621"},
@@ -1021,8 +1049,8 @@ pynacl = [
     {file = "PyNaCl-1.3.0.tar.gz", hash = "sha256:0c6100edd16fefd1557da078c7a31e7b7d7a52ce39fdca2bec29d4f7b6e7600c"},
 ]
 pyparsing = [
-    {file = "pyparsing-2.4.5-py2.py3-none-any.whl", hash = "sha256:20f995ecd72f2a1f4bf6b072b63b22e2eb457836601e76d6e5dfcd75436acc1f"},
-    {file = "pyparsing-2.4.5.tar.gz", hash = "sha256:4ca62001be367f01bd3e92ecbb79070272a9d4964dce6a48a82ff0b8bc7e683a"},
+    {file = "pyparsing-2.4.6-py2.py3-none-any.whl", hash = "sha256:c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"},
+    {file = "pyparsing-2.4.6.tar.gz", hash = "sha256:4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f"},
 ]
 pytest = [
     {file = "pytest-5.3.2-py3-none-any.whl", hash = "sha256:e41d489ff43948babd0fad7ad5e49b8735d5d55e26628a58673c39ff61d95de4"},
@@ -1092,6 +1120,10 @@ smmap2 = [
     {file = "smmap2-2.0.5-py2.py3-none-any.whl", hash = "sha256:0555a7bf4df71d1ef4218e4807bbf9b201f910174e6e08af2e138d4e517b4dde"},
     {file = "smmap2-2.0.5.tar.gz", hash = "sha256:29a9ffa0497e7f2be94ca0ed1ca1aa3cd4cf25a1f6b4f5f87f74b46ed91d609a"},
 ]
+sqlparse = [
+    {file = "sqlparse-0.3.0-py2.py3-none-any.whl", hash = "sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177"},
+    {file = "sqlparse-0.3.0.tar.gz", hash = "sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873"},
+]
 testinfra = [
     {file = "testinfra-1.16.0-py2.py3-none-any.whl", hash = "sha256:499ba7201d1a0f418fa0318bf2ae28142893c4f9d49ab24af21441fdb529292f"},
     {file = "testinfra-1.16.0.tar.gz", hash = "sha256:da1d0d1ffd68935b950b7b83833d863436ea75398a5cbdc0d0ab9e61132e2088"},
@@ -1105,8 +1137,8 @@ urllib3 = [
     {file = "urllib3-1.25.7.tar.gz", hash = "sha256:f3c5fd51747d450d4dcf6f923c81f78f811aab8205fda64b0aba34a4e48b0745"},
 ]
 wcwidth = [
-    {file = "wcwidth-0.1.7-py2.py3-none-any.whl", hash = "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"},
-    {file = "wcwidth-0.1.7.tar.gz", hash = "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e"},
+    {file = "wcwidth-0.1.8-py2.py3-none-any.whl", hash = "sha256:8fd29383f539be45b20bd4df0dc29c20ba48654a41e661925e612311e9f3c603"},
+    {file = "wcwidth-0.1.8.tar.gz", hash = "sha256:f28b3e8a6483e5d49e7f8949ac1a78314e740333ae305b4ba5defd3e74fb37a8"},
 ]
 werkzeug = [
     {file = "Werkzeug-0.16.0-py2.py3-none-any.whl", hash = "sha256:e5f4a1f98b52b18a93da705a7458e55afb26f32bff83ff5d19189f92462d65c4"},

--- a/common/src/foundation/python-packages/pyproject.toml
+++ b/common/src/foundation/python-packages/pyproject.toml
@@ -9,10 +9,10 @@ authors = ["stacki"]
 [tool.poetry.dependencies]
 # For some reason this tool wants the python version here, so just leave it.
 python = "^3.6"
-django = "=1.11.20"
+django = "*"
 flask = "*"
 gitpython = "*"
-pymysql = "=0.8.1"
+pymysql = "*"
 configparser = "*"
 flake8 = "*"
 jmespath = "*"

--- a/common/src/stack/ws/command/add/api/user/__init__.py
+++ b/common/src/stack/ws/command/add/api/user/__init__.py
@@ -38,7 +38,7 @@ class Command(stack.commands.Command,
 	<param name="admin" type="bool">
 	Admin type user account. Default is "False"
 	</param>
-	
+
 	<example cmd="add user greg admin=True">
 	Adds a user called 'greg' with admin privileges
 	to the API
@@ -92,8 +92,7 @@ class Command(stack.commands.Command,
 		u.set_password(passwd)
 		u.is_superuser = admin
 		u.save()
-		u.groups = groups
-		u.save()
+		u.groups.set(groups)
 
 		hostname = self.getHostnames(['localhost'])[0]
 		domainname = self.getHostAttr('localhost','domainname')

--- a/common/src/stack/ws/restapi/models.py
+++ b/common/src/stack/ws/restapi/models.py
@@ -14,16 +14,16 @@ class GroupAccess(models.Model):
 	Model that stores command permissions
 	for a group.
 	"""
-	group = models.ForeignKey(Group)
-	command = models.CharField(max_length=1024)	
-	
+	group = models.ForeignKey(Group, on_delete = models.CASCADE)
+	command = models.CharField(max_length=1024)
+
 class UserAccess(models.Model):
 	"""
 	Model that stores command permissions
 	for a user.
 	"""
-	user = models.ForeignKey(User)
-	command = models.CharField(max_length=1024)	
+	user = models.ForeignKey(User, on_delete = models.CASCADE)
+	command = models.CharField(max_length=1024)
 
 class BlackList(models.Model):
 	"""

--- a/common/src/stack/ws/restapi/settings.py
+++ b/common/src/stack/ws/restapi/settings.py
@@ -19,6 +19,19 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 """
 
 import os
+import pymysql
+
+# Install pymysql as mysqldb. This is required for django to
+# work correctly, since django requires MySQLdb which we cannot
+# distribute.
+#
+# We also change pymysql version because Django checks that
+# the version of mysqldb is at least what they expect. This
+# apparently resolves as the version of pymysql in this case,
+# which is not in sync with mysqldb.
+# https://github.com/PyMySQL/PyMySQL/issues/790#issuecomment-562820913
+pymysql.version_info = (9, 9, 9, 'final', 0)
+pymysql.install_as_MySQLdb()
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/common/src/stack/ws/restapi/views.py
+++ b/common/src/stack/ws/restapi/views.py
@@ -46,7 +46,7 @@ class StackWS(View):
 	def _check_login_(func):
 		def runner(inst, *args, **kwargs):
 			request = args[0]
-			if request.user.is_authenticated():
+			if request.user.is_authenticated:
 				return func(inst, *args, **kwargs)
 			else:
 				j = json.dumps({'logged_in': False})
@@ -346,7 +346,7 @@ def log_out(request):
 
 # Function to check log in user
 def check_user(request):
-	if request.user.is_authenticated():
+	if request.user.is_authenticated:
 		s = {'user': request.user.username}
 	else:
 		s = {'user': 'None'}


### PR DESCRIPTION
This removes the symlinking of pymysql to mysqldb in favor of using the
more official workaround wherein pymysql installs itself as mysqldb in
the django settings file.

The pymysql version was bumped as part of this change.

This also fixes up some code using deprecated ways of doing things that
were removed in Django 2.x+.