### PR TITLE
INTERNAL: Update SLES initrd makefiles to consider OS and RELEASE

### DIFF
--- a/common/nodes/pxe.xml
+++ b/common/nodes/pxe.xml
@@ -15,7 +15,7 @@ stack-images
 
 <stack:package stack:cond="os == 'sles'">
 tftp
-stack-sles-images
+stack-&os;-&release;-images
 </stack:package>
 
 <stack:package>
@@ -64,4 +64,4 @@ cp /boot/memtest86* /tftpboot/pxelinux/memtest
 </stack:script>
 
 
-</stack:stack> 
+</stack:stack>

--- a/sles/manifest.d/sles.manifest
+++ b/sles/manifest.d/sles.manifest
@@ -1,1 +1,0 @@
-stack-sles-images

--- a/sles/manifest.d/sles.sles11
+++ b/sles/manifest.d/sles.sles11
@@ -1,4 +1,3 @@
--stack-sles-images
 -stack-aws-client
 -stack-aws-server
 -stack-barnacle

--- a/sles/manifest.d/sles.sles12
+++ b/sles/manifest.d/sles.sles12
@@ -1,0 +1,1 @@
+stack-sles-sles12-images

--- a/sles/src/stack/images/Makefile
+++ b/sles/src/stack/images/Makefile
@@ -8,7 +8,24 @@ ROLLROOT	= ../../../..
 
 include $(STACKBUILD)/etc/CCRules.mk
 
-SRCDIRS = SLES/sles11/11sp3 SLES/sles12/12sp2 SLES/sles12/12sp3
+# Make sure we're building the SLES os.
+ifeq ($(OS), sles)
+# Only build and pack up the images for the SLES release we are building.
+# Add more cases to this as more SLES versions are supported, I.E.
+# `else ifeq($(RELEASE), sles15)`. SLES 11 is a special case where it
+# gets no bits because we package them up in SLES 12 due to being unable
+# to build the image on SLES 11.
+ifeq ($(RELEASE), sles12)
+SRCDIRS = SLES/sles12/12sp2 SLES/sles12/12sp3 SLES/sles11/11sp3
+else
+SRCDIRS =
+endif
+endif
+
+# Debug output of the OS, RELEASE, and SRCDIRS variables.
+$(info OS is $(OS))
+$(info RELEASE is $(RELEASE))
+$(info SRCDIRS is $(SRCDIRS))
 
 bootstrap: # nothing to do
 

--- a/sles/src/stack/images/version.mk
+++ b/sles/src/stack/images/version.mk
@@ -1,2 +1,2 @@
-NAME		= stack-sles-images
+NAME		= stack-$(OS)-$(RELEASE)-images
 ORDER		= 99


### PR DESCRIPTION
This lays down the initial pattern for selectively building initrds
based on the OS and RELEASE combination. The idea here being that
we're going to want stacki for OS RELEASE to build and ship its own
initrd bits, rather than a SLES stacki building initrd bits for all
supported OSes.

SLES11 is a special case, and will still be built by SLES12, but SLES15
will build its own bits. This also accommodates supporting OpenSUSE 15.