### PR TITLE
INTERNAL: Fix libvirt DNSMasq issue

### DIFF
--- a/test-framework/provisioning/roles/barnacle/tasks/main.yml
+++ b/test-framework/provisioning/roles/barnacle/tasks/main.yml
@@ -29,6 +29,12 @@
         192.168.0.2     frontend-0-0  frontend-0-0
       mode: 0644
 
+  - name: Setup /etc/resolv.conf to known good state
+    copy:
+      src: /etc/resolv.conf
+      dest: /etc/resolv.conf
+      mode: 0644
+
   - name: "Report frontend-install.py URL"
     debug:
       msg: "https://raw.githubusercontent.com/Teradata/stacki/{{ lookup('env','GIT_BRANCH')|default('develop', True) }}/tools/fab/frontend-install.py"


### PR DESCRIPTION
Under KVM, the default vagrant stuff uses libvirt's DNSMasq as the DNS server inside the VMs, which sometimes causes backend-0-0 to resolve when system tests are running on the same system. The end result is sometimes integration tests would try to ssh into actual `backend-0-0` servers instead of timing out quickly.

This fix makes the test-framework use the KVM server's resolv.conf inside of the provisioned test frontends.