### PR TITLE
INTERNAL: Provide more information when sub-commands fail

### DIFF
--- a/common/src/stack/command/stack/commands/add/appliance/attr/__init__.py
+++ b/common/src/stack/command/stack/commands/add/appliance/attr/__init__.py
@@ -44,5 +44,5 @@ class Command(stack.commands.add.appliance.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'appliance')
 
-		self.command('set.appliance.attr', self._argv + [ 'force=no' ])
+		self.command('set.appliance.attr', self._argv + [ 'force=no' ], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/add/appliance/firewall/__init__.py
+++ b/common/src/stack/command/stack/commands/add/appliance/firewall/__init__.py
@@ -105,5 +105,5 @@ class Command(stack.commands.add.appliance.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'appliance')
 
-		self.command('add.firewall', self._argv + ['scope=appliance'])
+		self.command('add.firewall', self._argv + ['scope=appliance'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/add/appliance/route/__init__.py
+++ b/common/src/stack/command/stack/commands/add/appliance/route/__init__.py
@@ -46,5 +46,5 @@ class Command(stack.commands.add.appliance.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'appliance')
 
-		self.command('add.route', self._argv + ['scope=appliance'])
+		self.command('add.route', self._argv + ['scope=appliance'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/add/appliance/storage/controller/__init__.py
+++ b/common/src/stack/command/stack/commands/add/appliance/storage/controller/__init__.py
@@ -66,5 +66,5 @@ class Command(stack.commands.add.appliance.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'appliance')
 
-		self.command('add.storage.controller', self._argv + ['scope=appliance'])
+		self.command('add.storage.controller', self._argv + ['scope=appliance'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/add/appliance/storage/partition/__init__.py
+++ b/common/src/stack/command/stack/commands/add/appliance/storage/partition/__init__.py
@@ -50,5 +50,5 @@ class Command(stack.commands.add.appliance.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'appliance')
 
-		self.command('add.storage.partition', self._argv + ['scope=appliance'])
+		self.command('add.storage.partition', self._argv + ['scope=appliance'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/add/attr/__init__.py
+++ b/common/src/stack/command/stack/commands/add/attr/__init__.py
@@ -18,7 +18,7 @@ class Command(stack.commands.add.command):
 	<param type='string' name='value' optional='0'>
 	Value of the attribute
 	</param>
-	
+
 	<param type='boolean' name='shadow'>
 	If set to true, then set the 'shadow' value (only readable by root
 	and apache).
@@ -33,5 +33,5 @@ class Command(stack.commands.add.command):
 	"""
 
 	def run(self, params, args):
-		self.command('set.attr', self._argv + [ 'force=no' ])
+		self.command('set.attr', self._argv + [ 'force=no' ], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/add/bootaction/__init__.py
+++ b/common/src/stack/command/stack/commands/add/bootaction/__init__.py
@@ -15,12 +15,12 @@ class Command(stack.commands.add.command):
 	Label name for the bootaction. You can see the bootaction label names by
 	executing: 'stack list bootaction [host(s)]'.
 	</arg>
-	
+
 	<param type='string' name='os'>
 	Operating System for the bootaction.
 	The default os is Redhat.
 	</param>
-	
+
 	<param type='string' name='type'>
 	Type of bootaction. Either 'os' or 'install'.
 	</param>
@@ -48,5 +48,5 @@ class Command(stack.commands.add.command):
 	"""
 
 	def run(self, params, args):
-		self.command('set.bootaction', self._argv + [ 'force=no' ])
+		self.command('set.bootaction', self._argv + [ 'force=no' ], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/add/environment/attr/__init__.py
+++ b/common/src/stack/command/stack/commands/add/environment/attr/__init__.py
@@ -38,5 +38,5 @@ class Command(stack.commands.add.environment.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'environment')
 
-		self.command('set.environment.attr', self._argv + ['force=no'])
+		self.command('set.environment.attr', self._argv + ['force=no'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/add/environment/firewall/__init__.py
+++ b/common/src/stack/command/stack/commands/add/environment/firewall/__init__.py
@@ -83,5 +83,5 @@ class Command(stack.commands.add.environment.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'environment')
 
-		self.command('add.firewall', self._argv + ['scope=environment'])
+		self.command('add.firewall', self._argv + ['scope=environment'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/add/environment/route/__init__.py
+++ b/common/src/stack/command/stack/commands/add/environment/route/__init__.py
@@ -40,5 +40,5 @@ class Command(stack.commands.add.environment.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'environment')
 
-		self.command('add.route', self._argv + ['scope=environment'])
+		self.command('add.route', self._argv + ['scope=environment'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/add/environment/storage/controller/__init__.py
+++ b/common/src/stack/command/stack/commands/add/environment/storage/controller/__init__.py
@@ -66,5 +66,5 @@ class Command(stack.commands.add.environment.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'environment')
 
-		self.command('add.storage.controller', self._argv + ['scope=environment'])
+		self.command('add.storage.controller', self._argv + ['scope=environment'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/add/environment/storage/partition/__init__.py
+++ b/common/src/stack/command/stack/commands/add/environment/storage/partition/__init__.py
@@ -50,5 +50,5 @@ class Command(stack.commands.add.environment.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'environment')
 
-		self.command('add.storage.partition', self._argv + ['scope=environment'])
+		self.command('add.storage.partition', self._argv + ['scope=environment'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/add/host/attr/__init__.py
+++ b/common/src/stack/command/stack/commands/add/host/attr/__init__.py
@@ -23,7 +23,7 @@ class Command(stack.commands.add.host.command):
 	<param type='string' name='value' optional='0'>
 	Value of the attribute
 	</param>
-	
+
 	<param type='boolean' name='shadow'>
 	If set to true, then set the 'shadow' value (only readable by root
 	and apache).
@@ -38,5 +38,5 @@ class Command(stack.commands.add.host.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'host')
 
-		self.command('set.host.attr', self._argv + ['force=no'])
+		self.command('set.host.attr', self._argv + ['force=no'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/add/host/firewall/__init__.py
+++ b/common/src/stack/command/stack/commands/add/host/firewall/__init__.py
@@ -105,5 +105,5 @@ class Command(stack.commands.add.host.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'host')
 
-		self.command('add.firewall', self._argv + ['scope=host'])
+		self.command('add.firewall', self._argv + ['scope=host'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/add/host/route/__init__.py
+++ b/common/src/stack/command/stack/commands/add/host/route/__init__.py
@@ -57,5 +57,5 @@ class Command(stack.commands.add.host.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'host')
 
-		self.command('add.route', self._argv + ['scope=host'])
+		self.command('add.route', self._argv + ['scope=host'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/add/host/storage/controller/__init__.py
+++ b/common/src/stack/command/stack/commands/add/host/storage/controller/__init__.py
@@ -66,5 +66,5 @@ class Command(stack.commands.add.host.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'host')
 
-		self.command('add.storage.controller', self._argv + ['scope=host'])
+		self.command('add.storage.controller', self._argv + ['scope=host'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/add/host/storage/partition/__init__.py
+++ b/common/src/stack/command/stack/commands/add/host/storage/partition/__init__.py
@@ -50,5 +50,5 @@ class Command(stack.commands.add.host.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'host')
 
-		self.command('add.storage.partition', self._argv + ['scope=host'])
+		self.command('add.storage.partition', self._argv + ['scope=host'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/add/os/attr/__init__.py
+++ b/common/src/stack/command/stack/commands/add/os/attr/__init__.py
@@ -34,5 +34,5 @@ class Command(stack.commands.add.os.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'os')
 
-		self.command('set.os.attr', self._argv + ['force=no'])
+		self.command('set.os.attr', self._argv + ['force=no'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/add/os/firewall/__init__.py
+++ b/common/src/stack/command/stack/commands/add/os/firewall/__init__.py
@@ -97,5 +97,5 @@ class Command(stack.commands.add.os.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'os')
 
-		self.command('add.firewall', self._argv + ['scope=os'])
+		self.command('add.firewall', self._argv + ['scope=os'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/add/os/route/__init__.py
+++ b/common/src/stack/command/stack/commands/add/os/route/__init__.py
@@ -46,5 +46,5 @@ class Command(stack.commands.add.os.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'os')
 
-		self.command('add.route', self._argv + ['scope=os'])
+		self.command('add.route', self._argv + ['scope=os'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/add/os/storage/controller/__init__.py
+++ b/common/src/stack/command/stack/commands/add/os/storage/controller/__init__.py
@@ -66,5 +66,5 @@ class Command(stack.commands.add.os.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'os')
 
-		self.command('add.storage.controller', self._argv + ['scope=os'])
+		self.command('add.storage.controller', self._argv + ['scope=os'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/add/os/storage/partition/__init__.py
+++ b/common/src/stack/command/stack/commands/add/os/storage/partition/__init__.py
@@ -50,5 +50,5 @@ class Command(stack.commands.add.os.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'os')
 
-		self.command('add.storage.partition', self._argv + ['scope=os'])
+		self.command('add.storage.partition', self._argv + ['scope=os'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/list/appliance/attr/__init__.py
+++ b/common/src/stack/command/stack/commands/list/appliance/attr/__init__.py
@@ -14,13 +14,13 @@ class Command(stack.commands.list.appliance.command):
 	<arg optional='1' type='string' name='appliance'>
 	Name of appliance
 	</arg>
-	
+
 	<example cmd='list appliance attr backend'>
 	List the attributes for backend appliances
 	</example>
 	"""
 
 	def run(self, params, args):
-		self.addText(self.command('list.attr', self._argv + [ 'scope=appliance' ]))
+		self.addText(self.command('list.attr', self._argv + [ 'scope=appliance' ], verbose_errors = False))
 		return self.rc
 

--- a/common/src/stack/command/stack/commands/list/appliance/firewall/__init__.py
+++ b/common/src/stack/command/stack/commands/list/appliance/firewall/__init__.py
@@ -25,5 +25,5 @@ class Command(stack.commands.NetworkArgumentProcessor,
 	"""
 
 	def run(self, params, args):
-		self.addText(self.command('list.firewall', self._argv + ['scope=appliance']))
+		self.addText(self.command('list.firewall', self._argv + ['scope=appliance'], verbose_errors = False))
 		return self.rc

--- a/common/src/stack/command/stack/commands/list/appliance/route/__init__.py
+++ b/common/src/stack/command/stack/commands/list/appliance/route/__init__.py
@@ -24,5 +24,5 @@ class Command(stack.commands.list.appliance.command):
 	"""
 
 	def run(self, params, args):
-		self.addText(self.command('list.route', self._argv + ['scope=appliance']))
+		self.addText(self.command('list.route', self._argv + ['scope=appliance'], verbose_errors = False))
 		return self.rc

--- a/common/src/stack/command/stack/commands/list/appliance/storage/controller/__init__.py
+++ b/common/src/stack/command/stack/commands/list/appliance/storage/controller/__init__.py
@@ -18,5 +18,5 @@ class Command(stack.commands.list.appliance.command):
 	"""
 
 	def run(self, params, args):
-		self.addText(self.command('list.storage.controller', self._argv + ['scope=appliance']))
+		self.addText(self.command('list.storage.controller', self._argv + ['scope=appliance'], verbose_errors = False))
 		return self.rc

--- a/common/src/stack/command/stack/commands/list/appliance/storage/partition/__init__.py
+++ b/common/src/stack/command/stack/commands/list/appliance/storage/partition/__init__.py
@@ -18,5 +18,5 @@ class Command(stack.commands.list.appliance.command):
 	"""
 
 	def run(self, params, args):
-		self.addText(self.command('list.storage.partition', self._argv + ['scope=appliance']))
+		self.addText(self.command('list.storage.partition', self._argv + ['scope=appliance'], verbose_errors = False))
 		return self.rc

--- a/common/src/stack/command/stack/commands/list/environment/attr/__init__.py
+++ b/common/src/stack/command/stack/commands/list/environment/attr/__init__.py
@@ -12,14 +12,14 @@ class Command(stack.commands.list.environment.command):
 	Lists the set of attributes for environments.
 
 	<arg optional='1' type='string' name='environment'>
-	Name of environment (e.g. "test") 
+	Name of environment (e.g. "test")
 	</arg>
-	
+
 	<example cmd='list environment attr test'>
 	List the attributes for the test environment
 	</example>
 	"""
 
 	def run(self, params, args):
-		self.addText(self.command('list.attr', self._argv + [ 'scope=environment' ]))
+		self.addText(self.command('list.attr', self._argv + [ 'scope=environment' ], verbose_errors = False))
 		return self.rc

--- a/common/src/stack/command/stack/commands/list/environment/firewall/__init__.py
+++ b/common/src/stack/command/stack/commands/list/environment/firewall/__init__.py
@@ -19,5 +19,5 @@ class Command(stack.commands.NetworkArgumentProcessor,
 	"""
 
 	def run(self, params, args):
-		self.addText(self.command('list.firewall', self._argv + ['scope=environment']))
+		self.addText(self.command('list.firewall', self._argv + ['scope=environment'], verbose_errors = False))
 		return self.rc

--- a/common/src/stack/command/stack/commands/list/environment/route/__init__.py
+++ b/common/src/stack/command/stack/commands/list/environment/route/__init__.py
@@ -19,5 +19,5 @@ class Command(stack.commands.list.environment.command):
 	"""
 
 	def run(self, params, args):
-		self.addText(self.command('list.route', self._argv + ['scope=environment']))
+		self.addText(self.command('list.route', self._argv + ['scope=environment'], verbose_errors = False))
 		return self.rc

--- a/common/src/stack/command/stack/commands/list/environment/storage/controller/__init__.py
+++ b/common/src/stack/command/stack/commands/list/environment/storage/controller/__init__.py
@@ -17,5 +17,5 @@ class Command(stack.commands.list.environment.command):
 	"""
 
 	def run(self, params, args):
-		self.addText(self.command('list.storage.controller', self._argv + ['scope=environment']))
+		self.addText(self.command('list.storage.controller', self._argv + ['scope=environment'], verbose_errors = False))
 		return self.rc

--- a/common/src/stack/command/stack/commands/list/environment/storage/partition/__init__.py
+++ b/common/src/stack/command/stack/commands/list/environment/storage/partition/__init__.py
@@ -17,5 +17,5 @@ class Command(stack.commands.list.environment.command):
 	"""
 
 	def run(self, params, args):
-		self.addText(self.command('list.storage.partition', self._argv + ['scope=environment']))
+		self.addText(self.command('list.storage.partition', self._argv + ['scope=environment'], verbose_errors = False))
 		return self.rc

--- a/common/src/stack/command/stack/commands/list/host/attr/__init__.py
+++ b/common/src/stack/command/stack/commands/list/host/attr/__init__.py
@@ -20,7 +20,7 @@ class Command(stack.commands.list.host.command):
 	<arg optional='1' type='string' name='host'>
 	Host name of machine
 	</arg>
-	
+
 	<param type='string' name='attr'>
 	A shell syntax glob pattern to specify to attributes to
 	be listed.
@@ -46,6 +46,6 @@ class Command(stack.commands.list.host.command):
 	"""
 
 	def run(self, params, args):
-		self.addText(self.command('list.attr', self._argv + [ 'scope=host' ]))
+		self.addText(self.command('list.attr', self._argv + [ 'scope=host' ], verbose_errors = False))
 		return self.rc
 

--- a/common/src/stack/command/stack/commands/list/host/firewall/__init__.py
+++ b/common/src/stack/command/stack/commands/list/host/firewall/__init__.py
@@ -25,5 +25,5 @@ class Command(stack.commands.NetworkArgumentProcessor,
 	"""
 
 	def run(self, params, args):
-		self.addText(self.command('list.firewall', self._argv + ['scope=host']))
+		self.addText(self.command('list.firewall', self._argv + ['scope=host'], verbose_errors = False))
 		return self.rc

--- a/common/src/stack/command/stack/commands/list/host/route/__init__.py
+++ b/common/src/stack/command/stack/commands/list/host/route/__init__.py
@@ -28,5 +28,5 @@ class Command(stack.commands.list.host.command):
 	"""
 
 	def run(self, params, args):
-		self.addText(self.command('list.route', self._argv + ['scope=host']))
+		self.addText(self.command('list.route', self._argv + ['scope=host'], verbose_errors = False))
 		return self.rc

--- a/common/src/stack/command/stack/commands/list/host/storage/controller/__init__.py
+++ b/common/src/stack/command/stack/commands/list/host/storage/controller/__init__.py
@@ -18,5 +18,5 @@ class Command(stack.commands.list.host.command):
 	"""
 
 	def run(self, params, args):
-		self.addText(self.command('list.storage.controller', self._argv + ['scope=host']))
+		self.addText(self.command('list.storage.controller', self._argv + ['scope=host'], verbose_errors = False))
 		return self.rc

--- a/common/src/stack/command/stack/commands/list/host/storage/partition/__init__.py
+++ b/common/src/stack/command/stack/commands/list/host/storage/partition/__init__.py
@@ -18,5 +18,5 @@ class Command(stack.commands.list.host.command):
 	"""
 
 	def run(self, params, args):
-		self.addText(self.command('list.storage.partition', self._argv + ['scope=host']))
+		self.addText(self.command('list.storage.partition', self._argv + ['scope=host'], verbose_errors = False))
 		return self.rc

--- a/common/src/stack/command/stack/commands/list/os/attr/__init__.py
+++ b/common/src/stack/command/stack/commands/list/os/attr/__init__.py
@@ -13,15 +13,15 @@ class Command(stack.commands.list.os.command):
 	Lists the set of attributes for OSes.
 
 	<arg optional='1' type='string' name='os'>
-	Name of OS (e.g. "linux", "sunos") 
+	Name of OS (e.g. "linux", "sunos")
 	</arg>
-	
+
 	<example cmd='list os attr linux'>
 	List the attributes for the Linux OS
 	</example>
 	"""
 
 	def run(self, params, args):
-		self.addText(self.command('list.attr', self._argv + [ 'scope=os' ]))
+		self.addText(self.command('list.attr', self._argv + [ 'scope=os' ], verbose_errors = False))
 		return self.rc
 

--- a/common/src/stack/command/stack/commands/list/os/firewall/__init__.py
+++ b/common/src/stack/command/stack/commands/list/os/firewall/__init__.py
@@ -25,5 +25,5 @@ class Command(stack.commands.NetworkArgumentProcessor,
 	"""
 
 	def run(self, params, args):
-		self.addText(self.command('list.firewall', self._argv + ['scope=os']))
+		self.addText(self.command('list.firewall', self._argv + ['scope=os'], verbose_errors = False))
 		return self.rc

--- a/common/src/stack/command/stack/commands/list/os/route/__init__.py
+++ b/common/src/stack/command/stack/commands/list/os/route/__init__.py
@@ -27,5 +27,5 @@ class Command(stack.commands.list.os.command):
 	"""
 
 	def run(self, params, args):
-		self.addText(self.command('list.route', self._argv + ['scope=os']))
+		self.addText(self.command('list.route', self._argv + ['scope=os'], verbose_errors = False))
 		return self.rc

--- a/common/src/stack/command/stack/commands/list/os/storage/controller/__init__.py
+++ b/common/src/stack/command/stack/commands/list/os/storage/controller/__init__.py
@@ -18,5 +18,5 @@ class Command(stack.commands.list.os.command):
 	"""
 
 	def run(self, params, args):
-		self.addText(self.command('list.storage.controller', self._argv + ['scope=os']))
+		self.addText(self.command('list.storage.controller', self._argv + ['scope=os'], verbose_errors = False))
 		return self.rc

--- a/common/src/stack/command/stack/commands/list/os/storage/partition/__init__.py
+++ b/common/src/stack/command/stack/commands/list/os/storage/partition/__init__.py
@@ -18,5 +18,5 @@ class Command(stack.commands.list.os.command):
 	"""
 
 	def run(self, params, args):
-		self.addText(self.command('list.storage.partition', self._argv + ['scope=os']))
+		self.addText(self.command('list.storage.partition', self._argv + ['scope=os'], verbose_errors = False))
 		return self.rc

--- a/common/src/stack/command/stack/commands/remove/appliance/attr/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/appliance/attr/__init__.py
@@ -20,16 +20,16 @@ class Command(stack.commands.remove.appliance.command):
 	<arg type='string' name='appliance' optional='1' repeat='1'>
 	One or more appliances
 	</arg>
-	
+
 	<param type='string' name='attr' optional='0'>
 	The attribute name that should be removed.
 	</param>
-	
+
 	<example cmd='remove appliance attr backend attr=sge'>
 	Removes the attribute sge for backend appliances
 	</example>
 	"""
 
 	def run(self, params, args):
-		self.command('set.attr', self._argv + [ 'scope=appliance', 'value=' ])
+		self.command('set.attr', self._argv + [ 'scope=appliance', 'value=' ], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/remove/appliance/firewall/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/appliance/firewall/__init__.py
@@ -32,5 +32,5 @@ class Command(stack.commands.remove.appliance.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'appliance')
 
-		self.command('remove.firewall', self._argv + ['scope=appliance'])
+		self.command('remove.firewall', self._argv + ['scope=appliance'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/remove/appliance/route/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/appliance/route/__init__.py
@@ -36,5 +36,5 @@ class Command(stack.commands.remove.appliance.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'appliance')
 
-		self.command('remove.route', self._argv + ['scope=appliance'])
+		self.command('remove.route', self._argv + ['scope=appliance'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/remove/appliance/storage/controller/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/appliance/storage/controller/__init__.py
@@ -36,5 +36,5 @@ class Command(stack.commands.remove.appliance.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'appliance')
 
-		self.command('remove.storage.controller', self._argv + ['scope=appliance'])
+		self.command('remove.storage.controller', self._argv + ['scope=appliance'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/remove/appliance/storage/partition/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/appliance/storage/partition/__init__.py
@@ -35,5 +35,5 @@ class Command(stack.commands.remove.appliance.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'appliance')
 
-		self.command('remove.storage.partition', self._argv + ['scope=appliance'])
+		self.command('remove.storage.partition', self._argv + ['scope=appliance'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/remove/environment/attr/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/environment/attr/__init__.py
@@ -14,16 +14,16 @@ class Command(stack.commands.remove.environment.command):
 	<arg type='string' name='environment' repeat='1' optional='1'>
 	One or more Environment specifications (e.g., 'test').
 	</arg>
-	
+
 	<param type='string' name='attr' optional='0'>
 	The attribute name that should be removed.
 	</param>
-	
+
 	<example cmd='remove environment attr test attr=sge'>
 	Removes the attribute sge for text environment machines.
 	</example>
 	"""
 
 	def run(self, params, args):
-		self.command('set.attr', self._argv + [ 'scope=environment', 'value=' ])
+		self.command('set.attr', self._argv + [ 'scope=environment', 'value=' ], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/remove/environment/firewall/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/environment/firewall/__init__.py
@@ -26,5 +26,5 @@ class Command(stack.commands.remove.environment.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'environment')
 
-		self.command('remove.firewall', self._argv + ['scope=environment'])
+		self.command('remove.firewall', self._argv + ['scope=environment'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/remove/environment/route/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/environment/route/__init__.py
@@ -26,5 +26,5 @@ class Command(stack.commands.remove.environment.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'environment')
 
-		self.command('remove.route', self._argv + ['scope=environment'])
+		self.command('remove.route', self._argv + ['scope=environment'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/remove/environment/storage/controller/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/environment/storage/controller/__init__.py
@@ -36,5 +36,5 @@ class Command(stack.commands.remove.environment.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'environment')
 
-		self.command('remove.storage.controller', self._argv + ['scope=environment'])
+		self.command('remove.storage.controller', self._argv + ['scope=environment'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/remove/environment/storage/partition/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/environment/storage/partition/__init__.py
@@ -35,5 +35,5 @@ class Command(stack.commands.remove.environment.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'environment')
 
-		self.command('remove.storage.partition', self._argv + ['scope=environment'])
+		self.command('remove.storage.partition', self._argv + ['scope=environment'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/remove/host/attr/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/host/attr/__init__.py
@@ -20,16 +20,16 @@ class Command(stack.commands.remove.host.command):
 	<arg type='string' name='host' optional='1' repeat='1'>
 	One or more hosts
 	</arg>
-	
+
 	<param type='string' name='attr' optional='0'>
 	The attribute name that should be removed.
 	</param>
-	
+
 	<example cmd='remove host attr backend-0-0 attr=cpus'>
 	Removes the attribute cpus for host backend-0-0.
 	</example>
 	"""
 
 	def run(self, params, args):
-		self.command('set.attr', self._argv + [ 'scope=host', 'value=' ])
+		self.command('set.attr', self._argv + [ 'scope=host', 'value=' ], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/remove/host/firewall/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/host/firewall/__init__.py
@@ -32,5 +32,5 @@ class Command(stack.commands.remove.host.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'host')
 
-		self.command('remove.firewall', self._argv + ['scope=host'])
+		self.command('remove.firewall', self._argv + ['scope=host'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/remove/host/route/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/host/route/__init__.py
@@ -45,5 +45,5 @@ class Command(stack.commands.remove.host.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'host')
 
-		self.command('remove.route', self._argv + ['scope=host'])
+		self.command('remove.route', self._argv + ['scope=host'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/remove/host/storage/controller/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/host/storage/controller/__init__.py
@@ -36,5 +36,5 @@ class Command(stack.commands.remove.host.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'host')
 
-		self.command('remove.storage.controller', self._argv + ['scope=host'])
+		self.command('remove.storage.controller', self._argv + ['scope=host'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/remove/host/storage/partition/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/host/storage/partition/__init__.py
@@ -35,5 +35,5 @@ class Command(stack.commands.remove.host.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'host')
 
-		self.command('remove.storage.partition', self._argv + ['scope=host'])
+		self.command('remove.storage.partition', self._argv + ['scope=host'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/remove/os/attr/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/os/attr/__init__.py
@@ -20,17 +20,17 @@ class Command(stack.commands.remove.os.command):
 	<arg type='string' name='os' optional='1' repeat='1'>
 	One or more OS specifications (e.g., 'linux').
 	</arg>
-	
+
 	<param type='string' name='attr' optional='0'>
 	The attribute name that should be removed.
 	</param>
-	
+
 	<example cmd='remove os attr linux attr=sge'>
 	Removes the attribute sge for linux OS machines.
 	</example>
 	"""
 
 	def run(self, params, args):
-		self.command('set.attr', self._argv + [ 'scope=os', 'value=' ])
+		self.command('set.attr', self._argv + [ 'scope=os', 'value=' ], verbose_errors = False)
 		return self.rc
 

--- a/common/src/stack/command/stack/commands/remove/os/firewall/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/os/firewall/__init__.py
@@ -32,5 +32,5 @@ class Command(stack.commands.remove.os.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'os')
 
-		self.command('remove.firewall', self._argv + ['scope=os'])
+		self.command('remove.firewall', self._argv + ['scope=os'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/remove/os/route/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/os/route/__init__.py
@@ -36,5 +36,5 @@ class Command(stack.commands.remove.os.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'os')
 
-		self.command('remove.route', self._argv + ['scope=os'])
+		self.command('remove.route', self._argv + ['scope=os'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/remove/os/storage/controller/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/os/storage/controller/__init__.py
@@ -36,5 +36,5 @@ class Command(stack.commands.remove.os.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'os')
 
-		self.command('remove.storage.controller', self._argv + ['scope=os'])
+		self.command('remove.storage.controller', self._argv + ['scope=os'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/remove/os/storage/partition/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/os/storage/partition/__init__.py
@@ -35,5 +35,5 @@ class Command(stack.commands.remove.os.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'os')
 
-		self.command('remove.storage.partition', self._argv + ['scope=os'])
+		self.command('remove.storage.partition', self._argv + ['scope=os'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/set/appliance/attr/__init__.py
+++ b/common/src/stack/command/stack/commands/set/appliance/attr/__init__.py
@@ -38,5 +38,5 @@ class Command(stack.commands.set.appliance.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'appliance')
 
-		self.command('set.attr', self._argv + ['scope=appliance'])
+		self.command('set.attr', self._argv + ['scope=appliance'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/set/environment/attr/__init__.py
+++ b/common/src/stack/command/stack/commands/set/environment/attr/__init__.py
@@ -38,5 +38,5 @@ class Command(stack.commands.set.environment.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'environment')
 
-		self.command('set.attr', self._argv + ['scope=environment'])
+		self.command('set.attr', self._argv + ['scope=environment'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/set/host/attr/__init__.py
+++ b/common/src/stack/command/stack/commands/set/host/attr/__init__.py
@@ -38,5 +38,5 @@ class Command(stack.commands.set.host.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'host')
 
-		self.command('set.attr', self._argv + ['scope=host'])
+		self.command('set.attr', self._argv + ['scope=host'], verbose_errors = False)
 		return self.rc

--- a/common/src/stack/command/stack/commands/set/os/attr/__init__.py
+++ b/common/src/stack/command/stack/commands/set/os/attr/__init__.py
@@ -34,5 +34,5 @@ class Command(stack.commands.set.os.command):
 		if len(args) == 0:
 			raise ArgRequired(self, 'os')
 
-		self.command('set.attr', self._argv + ['scope=os'])
+		self.command('set.attr', self._argv + ['scope=os'], verbose_errors = False)
 		return self.rc

--- a/test-framework/test-suites/integration/tests/load/test_load_storage_partition.py
+++ b/test-framework/test-suites/integration/tests/load/test_load_storage_partition.py
@@ -458,37 +458,37 @@ class TestLoadStoragePartition:
 		path = test_file('load/storage_partition_raid_missing_options.csv')
 		result = host.run(f'stack load storage partition file={path}')
 		assert result.rc == 255
-		assert 'error - missing options for software raid device "md0"' in result.stderr
+		assert 'missing options for software raid device "md0"' in result.stderr
 
 	def test_raid_missing_level(self, host, test_file):
 		path = test_file('load/storage_partition_raid_missing_level.csv')
 		result = host.run(f'stack load storage partition file={path}')
 		assert result.rc == 255
-		assert 'error - missing "--level=RAID" option for software raid device "md0"' in result.stderr
+		assert 'missing "--level=RAID" option for software raid device "md0"' in result.stderr
 
 	def test_raid_missing_device(self, host, test_file):
 		path = test_file('load/storage_partition_raid_missing_device.csv')
 		result = host.run(f'stack load storage partition file={path}')
 		assert result.rc == 255
-		assert 'error - device "raid.02" not defined for software raid device "md0"' in result.stderr
+		assert 'device "raid.02" not defined for software raid device "md0"' in result.stderr
 
 	def test_lvm_missing_name(self, host, test_file):
 		path = test_file('load/storage_partition_lvm_missing_name.csv')
 		result = host.run(f'stack load storage partition file={path}')
 		assert result.rc == 255
-		assert 'error - missing "--name" option for LVM partition "/"' in result.stderr
+		assert 'missing "--name" option for LVM partition "/"' in result.stderr
 
 	def test_lvm_invalid_device(self, host, test_file):
 		path = test_file('load/storage_partition_lvm_invalid_device.csv')
 		result = host.run(f'stack load storage partition file={path}')
 		assert result.rc == 255
-		assert 'error - device "pv.02" not defined for volgroups' in result.stderr
+		assert 'device "pv.02" not defined for volgroups' in result.stderr
 
 	def test_lvm_unknown_device(self, host, test_file):
 		path = test_file('load/storage_partition_lvm_unknown_device.csv')
 		result = host.run(f'stack load storage partition file={path}')
 		assert result.rc == 255
-		assert 'error - unknown device(s) detected: volgrp02' in result.stderr
+		assert 'unknown device(s) detected: volgrp02' in result.stderr
 
 	def test_create_spreadsheet_dirs(self, host, test_file, rmtree):
 		# Remove the existing spreadsheets directory


### PR DESCRIPTION
This ensures that the sub-command that was run is captured as most
CommandErrors assume the command in question is being run directly,
thus losing some context when being called from another command.

This provides a flag that defaults to on so commands can selectively
disable this feature. This also updates the scoped commands to use this
flag to turn this feature off, as they secretly use an internal only
scope parameter to delegate to a common command that holds all of the
logic.

Sample output:
```
frontend-0-0:~ # stack sync config
Sync Config
	       Sync Host Repo
	       Sync DNS
	       Sync Host
error - Failed to run sub-command 'sync dhcpd ' with error:
	DCHP is messed up, yo.
```