### PR TITLE
Bill has cool ideas

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -412,7 +412,7 @@ pipeline {
 
                 script {
                     // releases, develop branch, and branches ending in _cov get coverage reports
-                    if (env.PLATFORM ==~ 'sles12|redhat7' && (env.IS_RELEASE == 'true' || env.GIT_BRANCH ==~ /develop|.*_cov/)) {
+                    if (env.PLATFORM ==~ 'sles12|redhat7' && (env.IS_RELEASE == 'true' || env.GIT_BRANCH ==~ /develop|.*_cov/ || currentBuild.description ==~ /(?si).*\bcoverage\b.*/)) {
                         env.COVERAGE_REPORTS = 'true'
 
                         // A VM to combine all the coverage into a combined report


### PR DESCRIPTION
INTERNAL: Trigger code coverage report by adding the word 'coverage' (case-insensitive) to the latest commit message