### PR TITLE
FEATURE: symlink foundation python to 'spython3', to avoid confusion …

### DIFF
--- a/common/nodes/foundation-python.xml
+++ b/common/nodes/foundation-python.xml
@@ -11,6 +11,10 @@
 
 
 <stack:script stack:stage="install-post">
+ln -s /opt/stack/bin/python3 /opt/stack/bin/spython3
+</stack:script>
+
+<stack:script stack:stage="install-post">
 
 <stack:file stack:name="/etc/ld.so.conf.d/foundation.conf">
 /lib

--- a/test-framework/test-suites/system/tests/stacki/test_frontend.py
+++ b/test-framework/test-suites/system/tests/stacki/test_frontend.py
@@ -108,3 +108,14 @@ def test_foundation_python(host):
 	assert results.rc == 0
 	assert results.stdout.strip() == ''
 	assert results.stderr.strip() == ''
+
+	# ensure the symlinks for foundation python all point to the same thing
+	spython_results = host.run("readlink -f /opt/stack/bin/spython3")
+	assert results.rc == 0
+	assert results.stderr.strip() == ''
+	python_results = host.run("readlink -f /opt/stack/bin/python3")
+	assert results.rc == 0
+	assert results.stderr.strip() == ''
+
+	assert python_results.stdout.strip() == spython_results.stdout.strip()
+	assert python_results.stdout.startswith("/opt/stack/bin/python3")


### PR DESCRIPTION
…and save typing when another python3 is installed on the system