### PR TITLE
INTERNAL: Fix the path for pylib when using use-the-src

### DIFF
--- a/common/src/stack/command/stack/__init__.py
+++ b/common/src/stack/command/stack/__init__.py
@@ -10,5 +10,16 @@
 # https://github.com/Teradata/stacki/blob/master/LICENSE.txt
 # @copyright@
 
+import os
+import site
+
+site_pkgs_path = [p for p in site.getsitepackages() if p.startswith('/opt/stack/lib/python')][0]
+
+# Needed for use-the-src when symlinking pylib
+# as its location differs in the package vs the src
+# Related to https://bugs.python.org/issue17639
+__path__.append(os.path.join(os.path.split(__file__)[0], '..', '..', 'pylib', 'stack'))
+__path__.append(f'{site_pkgs_path}/stack')
+
 version = 'no-version'
 release = 'no-release'


### PR DESCRIPTION
Tested by bringing up a cluster-up with use-the-src enabled and running `stack list host` with no traceback about missing `stack.graph`, which was the previous behavior.