### PR TITLE
FEATURE: Ship frontend-install.py as an RPM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ endif
 preroll::
 	make -C common/src pkg
 	make -C $(OS)/src pkg
+	make -C tools/fab pkg
 	mkdir -p build-$(ROLL)-$(STACK)/graph
 	mkdir -p build-$(ROLL)-$(STACK)/nodes
 	cp common/graph/* $(OS)/graph/* build-$(ROLL)-$(STACK)/graph/

--- a/common/manifest.d/common.manifest
+++ b/common/manifest.d/common.manifest
@@ -37,3 +37,4 @@ stack-ws
 stack-ws-client
 storcli
 uefi-boot-method
+stacki-fab

--- a/common/src/foundation/python/Makefile
+++ b/common/src/foundation/python/Makefile
@@ -19,8 +19,6 @@ BOOTSTRAP.sles   = libopenssl-devel bzip2 libzip2 libbz2-devel sqlite3-devel $(B
 bootstrap:
 	$(STACKBUILD)/bin/package-install $(BOOTSTRAP) $(BOOTSTRAP.$(OS))
 	$(MAKE) install-rpm
-	echo $(PKGROOT)/lib > /etc/ld.so.conf.d/stacki-python.conf
-	ldconfig
 	$(PY.PATH) -mensurepip
 
 
@@ -41,6 +39,10 @@ install::
 		cd Python-$(VERSION);					\
 		$(MAKE) install DESTDIR=$(ROOT) ;			\
 	)
+	# Lay down the ldconf file in the right place.
+	# %post and %postun will run ldconfig to apply it.
+	mkdir -p $(ROOT)/etc/ld.so.conf.d
+	cp stacki-python.conf $(ROOT)/etc/ld.so.conf.d/
 
 clean::
 	rm -rf Python-$(VERSION)

--- a/common/src/foundation/python/stacki-python.conf
+++ b/common/src/foundation/python/stacki-python.conf
@@ -1,0 +1,1 @@
+/opt/stack/lib

--- a/common/src/foundation/python/version.mk
+++ b/common/src/foundation/python/version.mk
@@ -1,3 +1,4 @@
 ORDER      = 0
 VERSION    = 3.8.1
-RPM.EXTRAS = "AutoReq: no"
+# This was the hacky way I figured out to get %post and %postun in.
+RPM.EXTRAS = "AutoReq: no\\n\\n%post\\n/sbin/ldconfig\\n\\n%postun\\n/sbin/ldconfig"

--- a/test-framework/provisioning/roles/barnacle/tasks/main.yml
+++ b/test-framework/provisioning/roles/barnacle/tasks/main.yml
@@ -35,22 +35,49 @@
       dest: /etc/resolv.conf
       mode: 0644
 
-  - name: "Report frontend-install.py URL"
-    debug:
-      msg: "https://raw.githubusercontent.com/Teradata/stacki/{{ lookup('env','GIT_BRANCH')|default('develop', True) }}/tools/fab/frontend-install.py"
+  - name: Create directory to mount stacki ISO
+    file:
+      path: /mnt/stacki
+      state: directory
 
-  - name: Download frontend-install.py
-    get_url:
-      url: "https://raw.githubusercontent.com/Teradata/stacki/{{ lookup('env','GIT_BRANCH')|default('develop', True) }}/tools/fab/frontend-install.py"
-      dest: /root/
-      mode: 0744
-    register: get_url_result
-    until: get_url_result is succeeded
-    retries: 6
-    delay: 10
+  - name: Mount the stacki ISO to access the required RPMs
+    command: mount /export/isos/{{ lookup('env','STACKI_ISO')|basename }} /mnt/stacki
+    args:
+      warn: no
+
+  - name: Find the foundation-python RPM in the stacki ISO
+    find:
+      paths: /mnt/stacki
+      patterns: foundation-python-3*.rpm
+      recurse: yes
+    register: foundation_python_rpm
+
+  - name: Find the stacki-fab RPM in the stacki ISO
+    find:
+      paths: /mnt/stacki
+      patterns: stacki-fab*.rpm
+      recurse: yes
+    register: stacki_fab_rpm
+
+  - name: Install foundation-python
+    command: "rpm -ivh {{ item.path }}"
+    args:
+      warn: no
+    loop: "{{ foundation_python_rpm.files }}"
+
+  - name: Install stacki-fab
+    command: "rpm -ivh {{ item.path }}"
+    args:
+      warn: no
+    loop: "{{ stacki_fab_rpm.files }}"
+
+  - name: Unmount stacki ISO
+    command: umount /mnt/stacki
+    args:
+      warn: no
 
   - name: Barnacle the frontend
-    shell: /root/frontend-install.py --use-existing --stacki-iso=/export/isos/{{ lookup('env','STACKI_ISO')|basename }} <<< "2"
+    shell: /opt/stack/bin/frontend-install.py --use-existing --stacki-iso=/export/isos/{{ lookup('env','STACKI_ISO')|basename }} <<< "2"
     register: barnacle_output
 
   - name: Barnacle Output

--- a/tools/cluster-up/cluster-up.sh
+++ b/tools/cluster-up/cluster-up.sh
@@ -32,6 +32,7 @@ NETMASK="255.255.255.0"
 GATEWAY=""
 DNS=""
 FORWARD_PORTS=""
+FAB_RPM=""
 
 while [[ "$#" -gt 0 ]]
 do
@@ -84,6 +85,10 @@ do
             FORWARD_PORTS="${1#*=}"
             shift 1
             ;;
+        --fab-rpm=*)
+            FAB_RPM="${1#*=}"
+            shift 1
+            ;;
         --*)
             echo -e "\033[31mError: unrecognized flag \"$1\"\033[0m"
             exit 1
@@ -111,6 +116,7 @@ then
     echo -e "  --netmask=NETMASK\t\tThe netmask for the bridge network. Default: 255.255.255.0"
     echo -e "  --gateway=GATEWAY_ADDRESS\tGateway address for the bridged interface."
     echo -e "  --dns=DNS_ADDRESS[,DNS2]\tComma separated list of DNS servers."
+    echo -e "  --fab-rpm=FAB_RPM\tOptional override of the stacki-fab RPM to use."
     exit 1
 fi
 
@@ -259,10 +265,16 @@ then
     fi
 fi
 
-# Pull frontend-install.py from the local machine if we are running from a full repo checkout
-if [[ -f ../fab/frontend-install.py ]]
+# Use the user specified stacki-fab RPM
+if [[ -n "$FAB_RPM" ]]
 then
-    cp ../fab/frontend-install.py .
+    if [[ -f "$FAB_RPM" ]]
+    then
+        cp "$FAB_RPM" .
+    else
+        echo -e "\033[31mError: Specified FAB_RPM path $FAB_RPM not found\033[0m"
+        exit 1
+    fi
 fi
 
 # Make sure the boxes are up-to-date

--- a/tools/cluster-up/provision-frontend.sh
+++ b/tools/cluster-up/provision-frontend.sh
@@ -43,17 +43,23 @@ then
     echo "nameserver ${DNS//,/ /}" >> /etc/resolv.conf
 fi
 
-# Fetch the barnacle script, if needed
-if [[ -f /vagrant/frontend-install.py ]]
+# Install the foundation-python RPM from the stacki iso.
+mkdir -p "/mnt/$ISO_FILENAME"
+mount "/export/stacki-iso/$ISO_FILENAME" "/mnt/$ISO_FILENAME"
+rpm -ivh "$(find "/mnt/$ISO_FILENAME" -name "foundation-python-3*.rpm")"
+
+# Install the stacki-fab RPM. This is either user supplied or we use what is on the stacki ISO.
+if [[ -f "$(find /vagrant -name "stacki-fab*.rpm")" ]]
 then
-    mv /vagrant/frontend-install.py .
+    rpm -ivh "$(find /vagrant -name "stacki-fab*.rpm")"
 else
-    curl -sfSLO --retry 3 https://raw.githubusercontent.com/Teradata/stacki/$(echo $ISO_FILENAME | cut -d '-' -f -2 | cut -d '_' -f 1)/tools/fab/frontend-install.py
+    rpm -ivh "$(find "/mnt/$ISO_FILENAME" -name "stacki-fab*.rpm")"
 fi
 
+umount "/mnt/$ISO_FILENAME"
+
 # Barnacle myself, choosing the second interface
-chmod u+x frontend-install.py
-./frontend-install.py --use-existing --stacki-iso="/export/stacki-iso/$ISO_FILENAME" <<< "2"
+/opt/stack/bin/frontend-install.py --use-existing --stacki-iso="/export/stacki-iso/$ISO_FILENAME" <<< "2"
 
 # Allow port forwards to talk on eth0
 if [[ -n $FORWARD_PORTS ]]

--- a/tools/fab/Makefile
+++ b/tools/fab/Makefile
@@ -1,31 +1,31 @@
 # @SI_Copyright@
 #                               stacki.com
 #                                  v3.3
-# 
+#
 #      Copyright (c) 2006 - 2016 StackIQ Inc. All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
 # met:
-#  
+#
 # 1. Redistributions of source code must retain the above copyright
 # notice, this list of conditions and the following disclaimer.
-#  
+#
 # 2. Redistributions in binary form must reproduce the above copyright
 # notice unmodified and in its entirety, this list of conditions and the
-# following disclaimer in the documentation and/or other materials provided 
+# following disclaimer in the documentation and/or other materials provided
 # with the distribution.
-#  
+#
 # 3. All advertising and press materials, printed or electronic, mentioning
-# features or use of this software must display the following acknowledgement: 
-# 
-# 	 "This product includes software developed by StackIQ" 
-#  
+# features or use of this software must display the following acknowledgement:
+#
+# 	 "This product includes software developed by StackIQ"
+#
 # 4. Except as permitted for the purposes of acknowledgment in paragraph 3,
 # neither the name or logo of this software nor the names of its
 # authors may be used to endorse or promote products derived from this
 # software without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY STACKIQ AND CONTRIBUTORS ``AS IS''
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
 # THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
@@ -42,6 +42,7 @@
 PKGROOT		= /opt/stack
 ROLLROOT	= ../..
 DEPENDS.FILES	= frontend-install.py
+RPM.REQUIRES = foundation-python
 
 include $(STACKBUILD)/etc/CCRules.mk
 

--- a/tools/fab/version.mk
+++ b/tools/fab/version.mk
@@ -1,2 +1,1 @@
 NAME=stacki-fab
-RELEASE=all

--- a/tools/iso-builder/build.sh
+++ b/tools/iso-builder/build.sh
@@ -58,8 +58,10 @@ fi
 # If we are redhat7 PLATFORM, we aren't done yet
 if [[ $PLATFORM = "redhat7" ]]
 then
+    # Install stacki-fab RPMs so we can run frontend-install
+    rpm -ivh "$(find . -wholename "./build-stacki-*/RPMS/x86_64/stacki-fab*.rpm")"
     # Barnacle with the non-bootable ISO
-    python ./tools/fab/frontend-install.py --use-existing --stacki-iso=$(ls -1 ./build-*/stacki-*.iso)
+    /opt/stack/bin/frontend-install.py --use-existing --stacki-iso=$(ls -1 ./build-*/stacki-*.iso)
 
     # Restart httpd, it seems to be in a crashed state after barnacle
     systemctl restart httpd


### PR DESCRIPTION
INTERNAL:

The workflow for barnacling a frontend will now be to install the
foundation-python RPM and the stacki-fab RPM (which requires
foundation-python) in order to lay down frontend-install.py in
/opt/stack/bin.

Updated our various tools to use this new barnacle approach.

Changed the foundation-python RPM such that it now sets up its ldconf
file on install and runs ldconfig.

Update frontend-install.py now that it no longer has to be python 2
compatible, since the RPM requires foundation-python which we control.

I manually tested that cluster up still works for SLES12 and RedHat.