### PR TITLE
FEATURE: Improve `discover-nodes` --no-install mode

### DIFF
--- a/common/src/stack/discovery/bin/discover-nodes.py
+++ b/common/src/stack/discovery/bin/discover-nodes.py
@@ -27,7 +27,7 @@ class TUI(Subscriber):
 
 	def error(self, message):
 		form = snack.GridForm(self._screen, "Error", 1, 3)
-		
+
 		form.add(snack.TextboxReflowed(40, message), 0, 0)
 		form.add(snack.Textbox(0, 2, ""), 0, 1)
 		form.add(snack.Button("Quit"), 0, 2)
@@ -50,11 +50,11 @@ class TUI(Subscriber):
 
 		# Launch the form and wait for the quit button to be pressed
 		form.runOnce()
-	
+
 	def finish(self):
 		self.unsubscribe("discovery")
 		self._screen.finish()
-	
+
 	def callback(self, message):
 		payload = message.getPayload()
 
@@ -71,12 +71,12 @@ class TUI(Subscriber):
 			# In case we see a kickstart of a node already in the db
 			if ip_address not in self._callback_data:
 				self._callback_data[ip_address] = ["Unknown", "Unknown", ""]
-			
-			if status_code == 200:
+
+			if status_code in {200, 204}:
 				self._callback_data[ip_address][2] = "Success"
 			else:
 				self._callback_data[ip_address][2] = f"Error: {status_code}"
-		
+
 		self._textbox.setText('\n'.join([
 			"{0}   {1:20}   {2}".format(*data) for data in self._callback_data.values()
 		]))
@@ -158,7 +158,7 @@ else:
 	error_message = result.stderr.strip()
 	if error_message.startswith("error - "):
 		error_message = error_message[8:]
-	
+
 	tui.error(error_message)
 
 # We are done

--- a/common/src/stack/kickstart/profile.py
+++ b/common/src/stack/kickstart/profile.py
@@ -260,11 +260,26 @@ if profile_update_macs:
 		stack.api.Call('config host interface',
 			[ client.addr ] + params)
 
-#
-# Generate the system profile
-#
-client.main()
-		
+# See if we are actually installing
+do_install = True
+output = stack.api.Call('list host attr', [client.addr, 'attr=discovery.install'])
+if output and not stack.bool.str2bool(output[0]['value']):
+	do_install = False
+
+if do_install:
+	# Generate the system profile
+	client.main()
+else:
+	# Signal to the node to shutdown
+	print("Status: 204 No Content")
+	print()
+
+	# Set the boot action back to os
+	stack.api.Call("set host boot", [client.addr, "action=os"])
+
+	# Remove the discovery.install attribute
+	stack.api.Call("remove host attr", [client.addr, "attr=discovery.install"])
+
 #
 # Release resource semaphore.
 #

--- a/redhat/src/stack/images/7.6.1810/initrd.img/opt/stack/bin/stacki-profile.py
+++ b/redhat/src/stack/images/7.6.1810/initrd.img/opt/stack/bin/stacki-profile.py
@@ -7,11 +7,13 @@
 # @copyright@
 #
 
+import os
 import random
 import re
 import subprocess
-import time
 import sys
+import time
+
 
 
 # Start to build the curl command
@@ -94,7 +96,14 @@ while True:
 	try:
 		http_code = int(result.stdout.splitlines()[0])
 
-		if http_code == 200:
+		if http_code == 204:
+			# We aren't doing the install so power down
+			os.system("poweroff --force")
+
+			# Give it a minute to power down
+			time.sleep(60)
+
+		elif http_code == 200:
 			# It worked!
 			break
 

--- a/sles/src/stack/images/common/sles-stacki.img-patches/opt/stack/bin/stacki-profile.py
+++ b/sles/src/stack/images/common/sles-stacki.img-patches/opt/stack/bin/stacki-profile.py
@@ -7,146 +7,131 @@
 # @copyright@
 #
 
-import subprocess
-import random
-import time
-import os
 import json
+import os
+import random
+import re
+import subprocess
+import sys
+import time
 
-def get_ipmi_mac():
-	# Get IPMI mac
-	mac = None
-	p = subprocess.Popen(["/usr/bin/ipmitool", "lan","print","1"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-	o, e = p.communicate()
 
-	if not o:
-		return None
+with open('/tmp/stacki-profile.debug', 'w') as debug:
+	for key, value in os.environ.items():
+		debug.write(f'{key} {value}\n')
 
-	for line in o.decode().split('\n'):
-		if line.startswith("MAC Address"):
-			k, v = line.split(":",1)
-			mac = v.strip()
+# Start to build the curl command
+command = [
+	'/usr/bin/curl', '--silent', '--write-out', '%{http_code}',
+	'--local-port', '1-100', '--output', '/tmp/stacki-profile.xml',
+	'--insecure'
+]
 
-	return mac
-
-debug = open('/tmp/stacki-profile.debug', 'w')
-
-for i in os.environ:
-	debug.write('%s %s\n' % (i, os.environ[i]))	
-
-debug.close()
-
-#
-# make sure the target directory is there
-#
-try:
-	os.makedirs('/tmp/profile')
-except:
-	pass
-
-ipmi_mac = get_ipmi_mac()
-
-# to include IB information, load ib_ipoib driver
+# Load ib_ipoib driver to include IB information
 subprocess.call(["/sbin/modprobe","ib_ipoib"])
-#
-# get the interfaces
-#
-linkcmd = [ 'ip', '-oneline', 'link', 'show' ]
 
-p = subprocess.Popen(linkcmd, stdout = subprocess.PIPE)
+# Get the interfaces to report back the device and macs
+result = subprocess.run(
+	['ip', '-oneline', 'link', 'show'],
+	capture_output=True,
+	universal_newlines=True
+)
 
-interface_number = 0
+ndx=0
+for line in result.stdout.splitlines():
+	device, link, mac = re.match(r"""
+		\d+:\s+         # Index
+		(\S+)           # Device name
+		:\s.+           # Junk we don't care about
+		link/(\S+)\s+   # The link type
+		([0-9a-f:]+)\s  # The MAC address
+	""", line, re.VERBOSE).groups()
 
-curlcmd = [ '/usr/bin/curl', '-s', '-w', '%{http_code}', '--local-port', '1-100',
-	'--output', '/tmp/stacki-profile.xml', '--insecure' ]
+	if link == 'loopback':
+		continue
 
-o, e = p.communicate()
-output = o.decode()
-for line in output.split('\n'):
-	interface = None
-	hwaddr = None
+	command.extend([
+		'--header', f'X-RHN-Provisioning-MAC-{ndx}: {device} {mac}'
+	])
 
-	tokens = line.split()
-	if len(tokens) > 13:
-		# print 'tokens: %s' % tokens
-		#
-		# strip off last ':'
-		#
-		interface = tokens[1].strip()[0:-1]
+	ndx += 1
 
-		for i in range(2, len(tokens)):
-			if str(tokens[i]).startswith('link/') and \
-					'loopback' not in tokens[i]:
-				#
-				# we know the next token is the ethernet MAC
-				#
-				hwaddr = tokens[i+1]
-				break
+# Get the IPMI mac if we can
+result = subprocess.run(
+	['/usr/bin/ipmitool', 'lan', 'print', '1'],
+	capture_output=True,
+	universal_newlines=True
+)
 
-		if interface and hwaddr:
-			curlcmd.append('--header')
-			curlcmd.append('X-RHN-Provisioning-MAC-%d: %s %s'
-				% (interface_number, interface, hwaddr))
+for line in result.stdout.splitlines():
+	if line.startswith("MAC Address"):
+		mac = line.split(":", 1)[1].strip()
+		command.extend([
+			'--header', f'X-RHN-Provisioning-MAC-{ndx}: ipmi {mac}'
+		])
 
-			interface_number += 1
+		break
 
-if ipmi_mac:
-	curlcmd.append('--header')
-	curlcmd.append('X-RHN-Provisioning-MAC-%d: %s %s'
-			% (interface_number, "ipmi", ipmi_mac))
-#
-# get the number of CPUs
-#
-numcpus = 0
-f = open('/proc/cpuinfo', 'r')
-for line in f.readlines():
-	l = line.split(':')
-	if l[0].strip() == 'processor':
-		numcpus += 1
-f.close()
+# Get the number of CPUs
+with open('/proc/cpuinfo') as f:
+	cpus = len(re.findall(r'^processor\s+:\s+\d+', f.read(), re.MULTILINE))
 
+# Find the frontend server
 server = os.environ.get('Server', None)
 if not server:
-	cmdline = open('/proc/cmdline', 'r')
-	cmdargs = cmdline.readline()
-	cmdline.close()
-
-	for cmdarg in cmdargs.split():
-		l = cmdarg.split('=')
-		if l[0].strip() == 'Server':
-			server = l[1]
+	with open('/proc/cmdline') as f:
+		for arg in f.readline().split():
+			parts = arg.split('=', 1)
+			if parts[0].strip() == 'Server':
+				server = parts[1].strip()
 
 if not server:
 	# No server found on boot line, so maybe we are in AWS and can find
 	# it from the user-data json.
-	p = subprocess.Popen([ '/usr/bin/curl', 'http://169.254.169.254/latest/user-data' ],
-			     stdout=subprocess.PIPE,
-			     stderr=subprocess.PIPE)
-	o, e = p.communicate()
+	result = subprocess.run(
+		['/usr/bin/curl', 'http://169.254.169.254/latest/user-data'],
+		capture_output=True,
+		universal_newlines=True
+	)
+
 	try:
-		data = json.loads(o)
+		data = json.loads(result.stdout)
 	except:
 		data = {}
+
 	server = data.get('master')
 
+# Append the URL to request
+if not server:
+	sys.exit("Error: no server found!")
 
-request = 'https://%s/install/sbin/profile.cgi?os=sles&arch=x86_64&np=%d' % \
-	(server, numcpus)
-curlcmd.append(request)
+command.append(
+	f'https://{server}/install/sbin/profile.cgi'
+	f'?os=sles&arch=x86_64&np={cpus}'
+)
 
-#
-# retry until we get an installation file. if the HTTP request fails, then sleep
-# for a random amount of time (between 3 and 10 seconds) before we retry.
-#
-http_code = 0
-while http_code != 200:
-	p = subprocess.Popen(curlcmd, stdout=subprocess.PIPE, stderr=open('/dev/null'))
+# Retry until we get an installation file
+while True:
+	result = subprocess.run(
+		command, capture_output=True, universal_newlines=True
+	)
 
 	try:
-		http_code = int(p.stdout.readline())
-	except:
-		http_code = 0
+		http_code = int(result.stdout.splitlines()[0])
 
-	if http_code != 200:
-		time.sleep(random.randint(3, 10))
+		if http_code == 204:
+			# We aren't doing the install so power down
+			os.system("poweroff --force")
 
+			# Give it a minute to power down
+			time.sleep(60)
+
+		elif http_code == 200:
+			# It worked!
+			break
+
+	except (ValueError, IndexError):
+		pass
+
+	# No luck, try again in a bit
+	time.sleep(random.randint(3, 10))

--- a/sles/src/stack/images/common/sles-stacki.img-patches/usr/lib/YaST2/startup/First-Stage/F08-stacki
+++ b/sles/src/stack/images/common/sles-stacki.img-patches/usr/lib/YaST2/startup/First-Stage/F08-stacki
@@ -39,6 +39,8 @@ function halt_install {
 #		configure the system.
 #
 
+mkdir -p /tmp/profile/
+
 cat /tmp/stacki-profile.xml \
 	| /opt/stack/bin/stack list host profile chapter=main \
 	> /tmp/profile/autoinst.xml


### PR DESCRIPTION
When running `discover-nodes` with the --no-install flag, any nodes discovered will report back the mac address and device names from all the network interfaces, then power down.

Note: This is stacked on top of `bugfix/only-profile-redhat-once`