### PR TITLE
INTERNAL: Make any_python available to pallets as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,18 +23,6 @@ endif
 	cd sles   && $(ROLLSBUILD)/bin/get3rdparty.py
 
 bootstrap-make:
-	# setup any_python
-	# this lets some of our build scripts be written in a python2 and python3
-	# and scripts can use /usr/bin/env any_python for the shebang
-	# note `then :;` is the bash equivalent of `pass`. skip linking if link exists
-	(									\
-		if [ "$(shell which any_python)" != "" ]; then :;		\
-		elif [ "$(shell which python)" != "" ]; then			\
-			ln -s $(shell which python) /usr/bin/any_python;	\
-		elif [ "$(shell which python3)" != "" ]; then			\
-			ln -s $(shell which python3) /usr/bin/any_python;	\
-		fi;								\
-	)
 	$(MAKE) -C $(OS) -f bootstrap.mk RELEASE=$(RELEASE) bootstrap
 	$(MAKE) -C common/src/stack/build bootstrap
 

--- a/common/src/stack/build/build/etc/CCCommon.mk
+++ b/common/src/stack/build/build/etc/CCCommon.mk
@@ -33,5 +33,29 @@ COMPANY   = StackIQ
 COPYRIGHT = (c) $(YEAR) $(COMPANY)
 VENDOR    = $(COMPANY)
 
+##
+## Setup any_python.
+## This lets some of our build scripts be written in a python2 and python3
+## and scripts can use /usr/bin/env any_python for the shebang.
+##
+## This should run at parse time when make is run before any targets are run.
+## This is put in this location so that building pallets will also set this up.
+##
+ANY_PYTHON = /usr/bin/any_python
+$(info CCCommon.mk is setting up any_python)
+# If any_python is not already set up.
+ifeq ($(shell which any_python),)
+# Try to set it to python2 before setting it to python3.
+ifneq ($(shell which python),)
+$(info symlinking $(shell which python) to $(ANY_PYTHON))
+$(shell ln -s "$(shell which python)" $(ANY_PYTHON))
+else ifneq ($(shell which python3),)
+$(info symlinking $(shell which python3) to $(ANY_PYTHON))
+$(shell ln -s "$(shell which python3)" $(ANY_PYTHON))
+endif
+# Else any_python is already set up.
+else
+$(info any_python already set up)
+endif
 
 endif # __CCCOMMON_MK


### PR DESCRIPTION
This converts the any_python script that was in the top level make file
bootstrap target to be a set of makefile logic in CCCommon.mk. This
logic now runs at parse time rather than target run time, and will
ensure that pallets using the Stacki build system also get any_python
set up correctly.

Before this would cause other pallet builds to fail since the Stacki top
level bootstrap target wasn't invoked as part of their build.

Tested by building both OS-Updates and TDC-Infrastructure for SLES 12SP3 using the SLES 12 SP3 stacki iso built from this branch.