### PR TITLE
INTERNAL: Fix periodic timeouts during CentOS tests

### DIFF
--- a/test-framework/provisioning/roles/barnacle/tasks/main.yml
+++ b/test-framework/provisioning/roles/barnacle/tasks/main.yml
@@ -35,6 +35,16 @@
       dest: /etc/resolv.conf
       mode: 0644
 
+  - name: Prevent dhclient-script from overwriting resolv.conf
+    copy:
+      dest: /etc/dhcp/dhclient-enter-hooks
+      content: |
+        make_resolv_conf() {
+          exit 0
+        }
+      mode: 0744
+    when: ansible_distribution == "CentOS"
+
   - name: Create directory to mount stacki ISO
     file:
       path: /mnt/stacki
@@ -60,16 +70,14 @@
     register: stacki_fab_rpm
 
   - name: Install foundation-python
-    command: "rpm -ivh {{ item.path }}"
+    command: "rpm -ivh {{ foundation_python_rpm.files[0].path }}"
     args:
       warn: no
-    loop: "{{ foundation_python_rpm.files }}"
 
   - name: Install stacki-fab
-    command: "rpm -ivh {{ item.path }}"
+    command: "rpm -ivh {{ stacki_fab_rpm.files[0].path }}"
     args:
       warn: no
-    loop: "{{ stacki_fab_rpm.files }}"
 
   - name: Unmount stacki ISO
     command: umount /mnt/stacki

--- a/test-framework/provisioning/roles/yum/tasks/main.yml
+++ b/test-framework/provisioning/roles/yum/tasks/main.yml
@@ -45,7 +45,7 @@
         path: /etc/yum.repos.d/dvd.repo
         section: dvd
         option: assumeyes
-        value: 1
+        value: "1"
 
     - name: Update yum
       command: yum update


### PR DESCRIPTION
We have to run dhcp on eth0 for Vagrant, which under CentOS still causes dhclient-script to overwrite /etc/resolv.conf when we don't want to. We need to use the Vagrant host's resolv.conf so that it isn't pointed to libvirts' dnsmasq server running on the host, which resolves hostnames for our VM environment which shouldn't exist (backend-0-0 created by system test-suite, but shouldn't resolve in integration test-suite).

INTERNAL: Clean up some Ansible things to make output cleaner