### PR TITLE
INTERNAL: Require rsyslog in base node since it writes rsyslog configs

### DIFF
--- a/common/nodes/base.xml
+++ b/common/nodes/base.xml
@@ -16,6 +16,7 @@ Base class for all nodes.
 	OpenIPMI
 	wget
 	bridge-utils
+	rsyslog
 </stack:package>
 
 


### PR DESCRIPTION
This also has the side effect of ensuring SLES15 has rsyslog (which it doesn't appear to have by default).