### PR TITLE
INTERNAL: Cleanups for `list host profile`

### DIFF
--- a/common/src/stack/command/stack/commands/list/host/profile/imp_redhat.py
+++ b/common/src/stack/command/stack/commands/list/host/profile/imp_redhat.py
@@ -11,29 +11,5 @@ import stack.redhat.gen
 
 
 class Implementation(stack.commands.list.host.profile.implementation):
-
 	def generator(self):
 		return stack.redhat.gen.Generator()
-
-	def XXchapter(self, generator, profile):
-
-		if generator.getProfileType() == 'native':
-			profile.append('<chapter name="kickstart">')
-			for section in [ 'native',
-					 'packages',
-					 'pre',
-					 'post',
-					 'boot' ]:
-				profile.append('\t<section name="%s">' % section)
-				for line in generator.generate(section):
-					profile.append(line)
-				profile.append('\t</section>')
-			profile.append('</chapter>')
-
-		elif generator.getProfileType() == 'bash':
-			profile.append('<chapter name="main">')
-			for line in generator.generate('bash'):
-				profile.append(line)
-			profile.append('</chapter>')
-
-

--- a/common/src/stack/command/stack/commands/list/host/profile/imp_sles.py
+++ b/common/src/stack/command/stack/commands/list/host/profile/imp_sles.py
@@ -12,9 +12,5 @@ import stack.sles.gen
 
 
 class Implementation(stack.commands.list.host.profile.implementation):
-	
 	def generator(self):
 		return stack.sles.gen.Generator()
-
-
-

--- a/common/src/stack/pylib/stack/gen.py
+++ b/common/src/stack/pylib/stack/gen.py
@@ -865,48 +865,10 @@ class Generator:
 	def generate_debug(self):
 		return self.debugSection.generate()
 
+	def generate_main(self):
+		return self.generate(self.profileType)
+
 	def generate_bash(self):
 		profile  = [ '#! /bin/bash' ]
 		profile.extend(self.shellSection.generate())
 		return profile
-
-
-class ProfileHandler(handler.ContentHandler,
-		     handler.DTDHandler,
-		     handler.EntityResolver,
-		     handler.ErrorHandler):
-
-	def __init__(self):
-		handler.ContentHandler.__init__(self)
-		self.recording = False
-		self.text      = ''
-		self.chapters  = {}
-		self.chapter   = None
-
-	def startElement(self, name, attrs):
-		if name == 'chapter':
-			self.chapter   = self.chapters[attrs.get('name')] = []
-			self.recording = True
-
-	def endElement(self, name):
-		if self.recording:
-			self.chapter.append(self.text)
-			self.text = ''
-
-		if name == 'chapter':
-			self.recording = False
-
-	def characters(self, s):
-		if self.recording:
-			self.text += s
-
-	def getChapter(self, chapter):
-		doc = []
-		if chapter in self.chapters:
-			for text in self.chapters[chapter]:
-				doc.append(text.lstrip())
-		return doc
-
-
-
-

--- a/common/src/stack/pylib/stack/sles/gen.py
+++ b/common/src/stack/pylib/stack/sles/gen.py
@@ -396,10 +396,3 @@ class Generator(stack.gen.Generator):
 		profile.extend(self.scriptsSection.generate())
 		profile.extend(self.footerSection.generate())
 		return profile
-
-	def generate_bash(self):
-		profile	 = [ '#! /bin/bash' ]
-		profile.extend(self.shellSection.generate())
-		return profile
-
-


### PR DESCRIPTION
Change command to use ElementTree to pull out a requested chapter. Clean up the code paths to be more straight forward. Remove some dead and duplicate code from the generators.