### PR TITLE
FEATURE: Ansible output type for `list host profile`

### DIFF
--- a/common/src/stack/ansible/Makefile
+++ b/common/src/stack/ansible/Makefile
@@ -19,4 +19,8 @@ install::
 	mkdir -p $(ROOT)/opt/stack/ansible/plugins/inventory
 	$(INSTALL) -m0644 plugins/inventory/stacki.py $(ROOT)/opt/stack/ansible/plugins/inventory/
 
+	# Install the callback plugin
+	mkdir -p $(ROOT)/opt/stack/ansible/plugins/callback
+	$(INSTALL) -m0644 plugins/callback/failure_report.py $(ROOT)/opt/stack/ansible/plugins/callback/
+
 clean::

--- a/common/src/stack/ansible/etc/ansible.cfg
+++ b/common/src/stack/ansible/etc/ansible.cfg
@@ -1,7 +1,9 @@
 [defaults]
 nocows = True
 inventory_plugins = /opt/stack/ansible/plugins/inventory:~/.ansible/plugins/inventory:/usr/share/ansible/plugins/inventory
+callback_plugins = /opt/stack/ansible/plugins/callback:~/.ansible/plugins/callback:/usr/share/ansible/plugins/callback
 inventory = @stacki
+callback_whitelist = failure_report
 
 [inventory]
 enable_plugins = stacki, host_list, script, auto, yaml, ini, toml

--- a/common/src/stack/ansible/plugins/callback/failure_report.py
+++ b/common/src/stack/ansible/plugins/callback/failure_report.py
@@ -1,0 +1,74 @@
+# @copyright@
+# Copyright (c) 2006 - 2020 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+    callback: failure_report
+    type: aggregate
+    short_description: Report formatted output of failed tasks
+    description:
+      - Displays a report of failed tasks
+      - Outputs STDOUT and STDERR of shell tasks in a nice way
+'''
+
+from collections import defaultdict
+
+from ansible.plugins.callback import CallbackBase
+
+
+class CallbackModule(CallbackBase):
+	"""
+	Gather up failed tasks and report the output in a formatted way
+	"""
+
+	CALLBACK_VERSION = 2.0
+	CALLBACK_TYPE = 'aggregate'
+	CALLBACK_NAME = 'failure_report'
+	CALLBACK_NEEDS_WHITELIST = True
+
+	def __init__(self, *args, **kwargs):
+		super(CallbackModule, self).__init__(*args, **kwargs)
+
+		self.failed_tasks = defaultdict(list)
+
+	def v2_runner_on_failed(self, result, ignore_errors=False):
+		self.failed_tasks[result._host.get_name()].append(result)
+
+	def v2_playbook_on_stats(self, stats):
+		if not self.failed_tasks:
+			# Nothin' to report
+			return
+
+		# Stuff done failed. Report the output in a nicely formatted way.
+		self._display.banner("FAILED TASKS")
+
+		for host in sorted(self.failed_tasks):
+			self._display.banner("HOST [%s]" % host, color="blue")
+
+			for result in self.failed_tasks[host]:
+				self._display.banner("TASK [%s]" % result._task.name)
+
+				# Failure message
+				if "msg" in result._result:
+					self._display.display("error: %s" % result._result["msg"], color="red")
+
+				# Return code, if this was a shell task
+				if "rc" in result._result:
+					self._display.display("return: %s" % result._result["rc"])
+
+				# Stdout, indented nicely
+				if "stdout_lines" in result._result:
+					stdout = "\n        ".join(result._result["stdout_lines"])
+					self._display.display("stdout: %s" % stdout)
+
+				# Stderr, indented nicely
+				if "stderr_lines" in result._result:
+					stderr = "\n        ".join(result._result["stderr_lines"])
+					self._display.display("stderr: %s" % stderr)
+
+		self._display.display("\n")

--- a/common/src/stack/pylib/stack/redhat/gen.py
+++ b/common/src/stack/pylib/stack/redhat/gen.py
@@ -173,6 +173,8 @@ class Generator(stack.gen.Generator):
 			workers.extend([ MainTraversor(self) ])
 		elif profileType == 'bash':
 			workers.extend([ BashProfileTraversor(self) ])
+		elif profileType == 'ansible':
+			workers.extend([ stack.gen.AnsibleProfileTraversor(self) ])
 
 		return workers
 

--- a/common/src/stack/pylib/stack/sles/gen.py
+++ b/common/src/stack/pylib/stack/sles/gen.py
@@ -379,6 +379,8 @@ class Generator(stack.gen.Generator):
 					 MainTraversor(self) ])
 		elif profileType == 'bash':
 			workers.extend([ BashProfileTraversor(self) ])
+		elif profileType == 'ansible':
+			workers.extend([ stack.gen.AnsibleProfileTraversor(self) ])
 
 		return workers
 


### PR DESCRIPTION
A new profile type of `ansible` was added to the host profile generation command, which will output an Ansible playbook containing tasks to install or remove packages, as well as run scripts and create files in the `post-install`, `pre-boot`, and `post-boot` stages. 

For example, this command will output the playbook for host `backend-0-0`:
```
stack list host profile backend-0-0 chapter=main profile=ansible
```

You can run the output directly like so:
```
ansible-playbook <(stack list host profile backend-0-0 chapter=main profile=ansible)
```

As the node XML files are currently written, some of the scripts will fail. I plan on fixing these as time allows, but in the meantime this will give a good foundation for future integration of Ansible into Stacki.