### PR TITLE
FEATURE: Ensure probepal can fingerprint SLE 15 SP2 iso

### DIFF
--- a/common/src/stack/probepal/pylib/probe_sles_15_media.py
+++ b/common/src/stack/probepal/pylib/probe_sles_15_media.py
@@ -30,11 +30,12 @@ class Sles15MediaProbe(Probe):
 			^SUSE\ -\                # preamble
 			(?P<os>\w+)-             # match the OS: SLE
 			(?P<rel>\w+)-            # match the release: 15
-			((?P<servicepack>\w+)-)? # optionally, match the version: SP1
-			(?P<disctype>\w+)-       # match the disctype: Packages
+			((?P<servicepack>\w+)-)? # optionally, match the version: SP1, SP2
+			(?P<disctype>\w+)-       # match the disctype: Packages, Full
 			(?P<arch>\w+)-           # match the arch
 			.+-                      # the build number of the iso
-			\w+(?P<dvd_num>\d+)      # match just the disk number
+			(\w+(?P<dvd_num>\d+)|    # match just the disk number or.. 
+			(?P<source>\w+))         # if there is no disk number, match source
 			''',
 			re.VERBOSE
 		)
@@ -43,9 +44,9 @@ class Sles15MediaProbe(Probe):
 		if not match:
 			return []
 
-		getter = itemgetter('os', 'rel', 'servicepack', 'disctype', 'arch', 'dvd_num')
+		getter = itemgetter('os', 'rel', 'servicepack', 'disctype', 'arch', 'dvd_num', 'source')
 
-		os, rel, servicepack, disctype, arch, dvd_num = getter(match.groupdict())
+		os, rel, servicepack, disctype, arch, dvd_num, source = getter(match.groupdict())
 
 		distro_family = None
 		if os == 'SLE':
@@ -55,6 +56,9 @@ class Sles15MediaProbe(Probe):
 			servicepack = servicepack.lower()
 		else:
 			servicepack = ''
+
+		if not dvd_num:
+			dvd_num = source
 
 		version = f'{rel}{servicepack}'
 		release = f'{distro_family}{rel}'

--- a/test-framework/test-suites/unit/files/pallet_artifacts/SLE-15-SP2-Full-x86_64-PublicBeta-Media1.iso.treeinfo
+++ b/test-framework/test-suites/unit/files/pallet_artifacts/SLE-15-SP2-Full-x86_64-PublicBeta-Media1.iso.treeinfo
@@ -1,0 +1,22 @@
+[header]
+version = 1.0
+
+[general]
+arch = x86_64
+family = SUSE Linux Enterprise
+name = SUSE Linux Enterprise
+version = 15 SP2
+platforms = x86_64,xen
+
+[release]
+name = SUSE Linux Enterprise
+short = sle
+version = 15 SP2
+
+[images-x86_64]
+kernel = boot/x86_64/loader/linux
+initrd = boot/x86_64/loader/initrd
+
+[images-xen]
+kernel = boot/x86_64/loader/linux
+initrd = boot/x86_64/loader/initrd

--- a/test-framework/test-suites/unit/files/pallet_artifacts/SLE-15-SP2-Full-x86_64-PublicBeta-Media2.iso.media
+++ b/test-framework/test-suites/unit/files/pallet_artifacts/SLE-15-SP2-Full-x86_64-PublicBeta-Media2.iso.media
@@ -1,0 +1,3 @@
+SUSE - SLE-15-SP2-Full-x86_64-Build136.2-Media-SOURCE
+SLE-15-SP2-Full-x86_64-Build136.2
+1

--- a/test-framework/test-suites/unit/tests/pylib/stack/test_pylib_stack_prober.py
+++ b/test-framework/test-suites/unit/tests/pylib/stack/test_pylib_stack_prober.py
@@ -37,6 +37,8 @@ PALLET_DATA = [
 	['Packages-1', '15', 'sles15', 'x86_64', 'sles', 'Sles15MediaProbe', {'SLE-15-Packages-x86_64-GM-DVD1.iso.media': 'media.1/media'}],
 	['Packages-1', '15sp1', 'sles15', 'x86_64', 'sles', 'Sles15MediaProbe', {'SLE-15-SP1-Packages-x86_64-GM-DVD1.iso.media': 'media.1/media'}],
 	['Packages-2', '15sp1', 'sles15', 'x86_64', 'sles', 'Sles15MediaProbe', {'SLE-15-SP1-Packages-x86_64-GM-DVD2.iso.media': 'media.1/media'}],
+	['SLES', '15sp2', 'sles15', 'x86_64', 'sles', 'ProductMDProbe', {'SLE-15-SP2-Full-x86_64-PublicBeta-Media1.iso.treeinfo': '.treeinfo'}],
+	['Full-SOURCE', '15sp2', 'sles15', 'x86_64', 'sles', 'Sles15MediaProbe', {'SLE-15-SP2-Full-x86_64-PublicBeta-Media2.iso.media': 'media.1/media'}],
 	['SUSE-Enterprise-Storage', '4', 'ses4', 'x86_64', 'sles', 'SLES_11_12_Probe', {'SUSE-Enterprise-Storage-4-DVD-x86_64-GM-DVD1.iso.content': 'content'}],
 	['Ubuntu', '18.04.3', 'ubuntu18.04', 'x86_64', 'ubuntu', 'UbuntuProbe', {'ubuntu-18.04.3-desktop-amd64.iso.disk.info': '.disk/info'}],
 	['Ubuntu-Server', '18.04.3', 'ubuntu18.04', 'x86_64', 'ubuntu', 'UbuntuProbe', {'ubuntu-18.04.3-live-server-amd64.iso.disk.info': '.disk/info'}],


### PR DESCRIPTION
Probing `SLE-15-SP2-Full-x86_64-PublicBeta-Media1.iso` yields
```
probepal /mnt/media1
{
    "/mnt/media1": [
        {
            "name": "SLES",
            "version": "15sp2",
            "release": "sles15",
            "arch": "x86_64",
            "distro_family": "sles",
            "pallet_root": "/mnt/media1",
            "probe_name": "ProductMDProbe"
        }
    ]
}
```

Probing `SLE-15-SP2-Full-x86_64-PublicBeta-Media2.iso` yields 
```
probepal /mnt/media2
{
    "/mnt/media2": [
        {
            "name": "Full-SOURCE",
            "version": "15sp2",
            "release": "sles15",
            "arch": "x86_64",
            "distro_family": "sles",
            "pallet_root": "/mnt/media2",
            "probe_name": "Sles15MediaProbe"
        }
  
```

Tests: https://sdvl3jenk015.td.teradata.com/blue/organizations/jenkins/stacki%20-%20sles12/detail/feature%2Fprobe_sles15sp2/1/pipeline/202