### PR TITLE
INTERNAL: Move the box argument processor to its rightful place

### DIFF
--- a/common/src/stack/command/stack/argument_processors/box.py
+++ b/common/src/stack/command/stack/argument_processors/box.py
@@ -1,0 +1,52 @@
+from stack.util import flatten
+from stack.exception import ArgNotFound
+from stack.argument_processors.pallet import Pallet
+
+class BoxArgumentProcessor:
+	"""
+	An Interface class to add the ability to process box arguments.
+	"""
+
+	def get_box_names(self, args=None):
+		"""
+		Returns a list of box names from the database. For each arg in
+		the ARGS list find all the box names that match the arg (assume
+		SQL regexp). If an arg does not match anything in the database we
+		raise an exception. If the ARGS list is empty return all box names.
+		"""
+
+		boxes = []
+		if not args:
+			args = ['%']		      # find all boxes
+
+		for arg in args:
+			names = flatten(self.db.select(
+				'name from boxes where name like %s', (arg,)
+			))
+
+			if not names and arg != '%':
+				raise ArgNotFound(self, arg, 'box')
+
+			boxes.extend(names)
+
+		return boxes
+
+	def get_box_pallets(self, box='default'):
+		"""
+		Returns a list of pallets for a box
+		"""
+
+		# Make sure 'box' exists
+		self.get_box_names([box])
+
+		pallets = []
+
+		rows = self.db.select("""
+			r.id, r.name, r.version, r.rel, r.arch, o.name, r.url
+			from rolls r, boxes b, stacks s, oses o
+			where b.name=%s and b.id=s.box and s.roll=r.id and b.os=o.id
+		""", (box,))
+
+		pallets.extend([Pallet(*row) for row in rows])
+
+		return pallets

--- a/common/src/stack/command/stack/argument_processors/pallet.py
+++ b/common/src/stack/command/stack/argument_processors/pallet.py
@@ -1,5 +1,16 @@
-from collections import namedtuple
+from dataclasses import dataclass
 from stack.exception import ArgNotFound
+
+@dataclass(eq=True, order=True, frozen=True)
+class Pallet:
+	"""A dataclass representation of the Roll schema in the database."""
+	id: int
+	name: str
+	version: str
+	rel: str
+	arch: str
+	os: str
+	url: str
 
 class PalletArgumentProcessor:
 
@@ -23,10 +34,6 @@ class PalletArgumentProcessor:
 		# Find all pallet names if we weren't given one
 		if not args:
 			args = ['%']
-
-		Pallet = namedtuple('Pallet', [
-			'id', 'name', 'version', 'rel', 'arch', 'os', 'url'
-		])
 
 		pallets = []
 		for arg in args:

--- a/common/src/stack/command/stack/commands/__init__.py
+++ b/common/src/stack/command/stack/commands/__init__.py
@@ -168,60 +168,6 @@ class ApplianceArgumentProcessor:
 		return appliances
 
 
-class BoxArgumentProcessor:
-	"""
-	An Interface class to add the ability to process box arguments.
-	"""
-
-	def getBoxNames(self, args=None):
-		"""
-		Returns a list of box names from the database. For each arg in
-		the ARGS list find all the box names that match the arg (assume
-		SQL regexp). If an arg does not match anything in the database we
-		raise an exception. If the ARGS list is empty return all box names.
-		"""
-
-		boxes = []
-		if not args:
-			args = ['%']		      # find all boxes
-
-		for arg in args:
-			names = flatten(self.db.select(
-				'name from boxes where name like %s', (arg,)
-			))
-
-			if not names and arg != '%':
-				raise ArgNotFound(self, arg, 'box')
-
-			boxes.extend(names)
-
-		return boxes
-
-	def getBoxPallets(self, box='default'):
-		"""
-		Returns a list of pallets for a box
-		"""
-
-		# Make sure 'box' exists
-		self.getBoxNames([box])
-
-		pallets = []
-
-		Pallet = namedtuple(
-			"Pallet", ['id', 'name', 'version', 'rel', 'arch', 'os', 'url']
-		)
-
-		rows = self.db.select("""
-			r.id, r.name, r.version, r.rel, r.arch, o.name, r.url
-			from rolls r, boxes b, stacks s, oses o
-			where b.name=%s and b.id=s.box and s.roll=r.id and b.os=o.id
-		""", (box,))
-
-		pallets.extend([Pallet(*row) for row in rows])
-
-		return pallets
-
-
 class NetworkArgumentProcessor:
 	"""
 	An Interface class to add the ability to process network (subnet) argument.

--- a/common/src/stack/command/stack/commands/add/box/__init__.py
+++ b/common/src/stack/command/stack/commands/add/box/__init__.py
@@ -13,9 +13,9 @@
 import stack
 import stack.commands
 from stack.exception import ArgUnique, CommandError, ArgNotFound
+from stack.argument_processors.box import BoxArgumentProcessor
 
-
-class Command(stack.commands.BoxArgumentProcessor,
+class Command(BoxArgumentProcessor,
 	stack.commands.OSArgumentProcessor,
 	stack.commands.add.command):
 	"""
@@ -24,7 +24,7 @@ class Command(stack.commands.BoxArgumentProcessor,
 	<arg type='string' name='box'>
 	Name of the new box.
 	</arg>
-	
+
 	<param type='string' name='os'>
 	OS associated with the box. Default is the native os (e.g., 'redhat', 'sles').
 	</param>
@@ -39,8 +39,8 @@ class Command(stack.commands.BoxArgumentProcessor,
 			raise ArgUnique(self, 'box')
 
 		box = args[0]
-		
-		if box in self.getBoxNames():
+
+		if box in self.get_box_names():
 			raise CommandError(self, 'box "%s" exists' % box)
 
 		OS, = self.fillParams([ ('os', self.os) ])

--- a/common/src/stack/command/stack/commands/add/host/__init__.py
+++ b/common/src/stack/command/stack/commands/add/host/__init__.py
@@ -20,12 +20,12 @@ from stack.exception import (
 	ArgValue,
 )
 from stack.util import is_valid_hostname
-
+from stack.argument_processors.box import BoxArgumentProcessor
 
 class command(
 	stack.commands.HostArgumentProcessor,
 	stack.commands.ApplianceArgumentProcessor,
-	stack.commands.BoxArgumentProcessor,
+	BoxArgumentProcessor,
 	stack.commands.EnvironmentArgumentProcessor,
 	stack.commands.add.command
 ):
@@ -144,7 +144,7 @@ class Command(command):
 		if appliance not in appliances:
 			raise CommandError(self, 'appliance "%s" is not in the database' % appliance)
 
-		if box not in self.getBoxNames():
+		if box not in self.get_box_names():
 			raise CommandError(self, 'box "%s" is not in the database' % box)
 
 		osname = None

--- a/common/src/stack/command/stack/commands/add/pallet/__init__.py
+++ b/common/src/stack/command/stack/commands/add/pallet/__init__.py
@@ -54,7 +54,7 @@ class Command(command):
 	<param type='string' name='password'>
 	A password that will be used for authenticating to any remote pallet locations
 	</param>
-		
+
 	<param type='bool' name='clean'>
 	If set, then remove all files from any existing pallets of the same
 	name, version, and architecture before copying the contents of the
@@ -70,13 +70,13 @@ class Command(command):
 	Add the pallet info to the cluster database.
 	The default is: true.
 	</param>
-	
+
 	<example cmd='add pallet clean=true kernel*iso'>
 	Adds the Kernel pallet to local pallet directory.  Before the pallet is
 	added the old Kernel pallet packages are removed from the pallet
 	directory.
 	</example>
-	
+
 	<example cmd='add pallet kernel*iso https://10.0.1.3/pallets/'>
 	Added the Kernel pallet along with any pallets found at the remote server
 	 to the local pallet directory.
@@ -133,7 +133,7 @@ class Command(command):
 
 		# use rsync to perform the copy
 		# archive implies
-		# --recursive, 
+		# --recursive,
 		# --links - copy symlinks as symlinks
 		# --perms - preserve permissions
 		# --times - preserve mtimes
@@ -200,7 +200,7 @@ class Command(command):
 			msg = f'Pallet could not be unmounted from {mount_point} ({iso_name}).'
 			msg += f'\nTried: {" ".join(str(arg) for arg in proc.args)}'
 			raise CommandError(self, f'{msg}\n{proc.stdout}\n{proc.stderr}')
-		
+
 
 	def patch_pallet(self, pallet_info):
 		'''

--- a/common/src/stack/command/stack/commands/list/box/__init__.py
+++ b/common/src/stack/command/stack/commands/list/box/__init__.py
@@ -11,10 +11,10 @@
 # @rocks@
 
 import stack.commands
-
+from stack.argument_processors.box import BoxArgumentProcessor
 
 class command(stack.commands.list.command,
-	      stack.commands.BoxArgumentProcessor):
+	      BoxArgumentProcessor):
 	pass
 
 
@@ -35,8 +35,8 @@ class Command(command):
 		pallets = {}
 		carts	= {}
 
-		for box in self.getBoxNames(args):
-			for pallet in self.getBoxPallets(box):
+		for box in self.get_box_names(args):
+			for pallet in self.get_box_pallets(box):
 				fullname = '%s-%s' % (pallet.name, pallet.version)
 				if pallet.rel:
 					fullname += '-%s' % pallet.rel
@@ -54,7 +54,7 @@ class Command(command):
 
 		self.beginOutput()
 
-		for box in self.getBoxNames(args):
+		for box in self.get_box_names(args):
 			id, os = self.db.select("""
 				b.id, o.name from boxes b, oses o
 				where b.name=%s	and b.os=o.id

--- a/common/src/stack/command/stack/commands/list/box/pallet/__init__.py
+++ b/common/src/stack/command/stack/commands/list/box/pallet/__init__.py
@@ -29,7 +29,7 @@ class Command(stack.commands.list.box.command):
 	def run(self, params, args):
 		self.beginOutput()
 
-		boxes = self.getBoxNames(args)
+		boxes = self.get_box_names(args)
 
 		for box in boxes:
 			rows = self.db.select("""

--- a/common/src/stack/command/stack/commands/list/host/hash/__init__.py
+++ b/common/src/stack/command/stack/commands/list/host/hash/__init__.py
@@ -9,9 +9,10 @@
 import os
 import hashlib
 import stack.commands
+from stack.argument_processors.box import BoxArgumentProcessor
 
 class Command(stack.commands.list.host.command,
-	stack.commands.BoxArgumentProcessor):
+	BoxArgumentProcessor):
 	"""
 	Calculate and list the MD5 hashes of a host's:
 
@@ -63,7 +64,7 @@ class Command(stack.commands.list.host.command,
 			# calculate MD5s for the pallets associated with the host
 			#
 			box = self.getHostAttr(host, 'box')
-			for pallet in self.getBoxPallets(box):
+			for pallet in self.get_box_pallets(box):
 				path = '/export/stack/pallets/%s/%s/%s/%s/%s' % \
 					(pallet.name, pallet.version, pallet.rel, pallet.os, pallet.arch)
 

--- a/common/src/stack/command/stack/commands/list/node/xml/__init__.py
+++ b/common/src/stack/command/stack/commands/list/node/xml/__init__.py
@@ -20,10 +20,10 @@ import stack.commands
 from stack.exception import ArgRequired, CommandError
 from xml.sax import make_parser
 from xml.sax import saxutils
+from stack.argument_processors.box import BoxArgumentProcessor
 
-
-class Command(stack.commands.list.command, 
-	      stack.commands.BoxArgumentProcessor):
+class Command(stack.commands.list.command,
+	      BoxArgumentProcessor):
 	"""
 	Lists the XML configuration information for a host. The graph
 	traversal for the XML output is rooted at the XML node file
@@ -72,7 +72,7 @@ class Command(stack.commands.list.command,
 				('gen', 'kgen'),
 				('basedir', None),
 				])
-			
+
 		if pallets:
 			pallets = pallets.split(',')
 
@@ -111,7 +111,7 @@ class Command(stack.commands.list.command,
 			try:
 				a = saxutils.escape(attrs[key],
 						    {'"': '&#x22;',
-						     '%': '&#x25;', 
+						     '%': '&#x25;',
 						     '^': '&#x5E;'})
 			except:
 				a = attrs[key]
@@ -123,13 +123,13 @@ class Command(stack.commands.list.command,
 
 		if 'arch' not in attrs:
 			attrs['arch'] = self.arch
-			
+
 		if 'hostname' not in attrs:
 			attrs['hostname'] = self.db.getHostname()
 
 		if 'graph' not in attrs:
 			attrs['graph'] = 'default'
-			
+
 		if 'box' not in attrs:
 			attrs['box'] = 'default'
 
@@ -148,20 +148,20 @@ class Command(stack.commands.list.command,
 		attrs['version'] = stack.version
 		attrs['release'] = stack.release
 		attrs['root']	 = root
-		
+
 		# Parse the XML graph files in the chosen directory
 
-		#	
+		#
 		# get the pallets that are in the box associated with the host
-		#	
+		#
 		items = []
 		try:
-			for pallet in self.getBoxPallets(attrs['box']):
+			for pallet in self.get_box_pallets(attrs['box']):
 				items.append(os.path.join('/export', 'stack', 'pallets',
 					pallet.name, pallet.version, pallet.rel, pallet.os, pallet.arch))
 		except:
 			#
-			# there is no output from 'getBoxPallets()'.
+			# there is no output from 'get_box_pallets()'.
 			# let's assume that the database is down
 			# (e.g., we are installing and configuring
 			# the frontend's database) and we'll get
@@ -194,7 +194,7 @@ class Command(stack.commands.list.command,
 			if attrs['box'] in o['boxes'].split():
 				items.append(os.path.join('/export', 'stack',
 					'carts', o['name']))
-	
+
 				#
 				# if a cart has changed since the last time we
 				# built a kickstart file, we will need to
@@ -254,13 +254,13 @@ class Command(stack.commands.list.command,
 		#
 		# Now test for arbitrary conditionals (cond tag),
 		# old arch,os test are part of this now are still supported
-		
+
 		nodesHash = {}
 		for node, cond in nodes:
 			nodesHash[node.name] = node
 			if not stack.cond.EvalCondExpr(cond, attrs):
 				nodesHash[node.name] = None
-			
+
 		# Initialize the hash table for the dependency
 		# nodes, and filter out everyone not for our
 		# generator type (e.g. 'kgen').
@@ -340,13 +340,13 @@ class Command(stack.commands.list.command,
 
 			if pallets and pallet not in pallets:
 				continue
-				
+
 			try:
 				self.addText('%s\n' % node.getXML())
 			except Exception as msg:
 				raise stack.util.KickstartNodeError("in %s node: %s" % (node, msg))
 
 		self.addText('</stack:profile>\n')
-		
-		
+
+
 

--- a/common/src/stack/command/stack/commands/load/hostfile/imp_load_default.py
+++ b/common/src/stack/command/stack/commands/load/hostfile/imp_load_default.py
@@ -14,13 +14,13 @@ import stack.csv
 import stack.commands
 from stack.bool import str2bool
 from stack.exception import CommandError
-
+from stack.argument_processors.box import BoxArgumentProcessor
 
 class Implementation(stack.commands.ApplianceArgumentProcessor,
 	stack.commands.HostArgumentProcessor,
 	stack.commands.NetworkArgumentProcessor,
-	stack.commands.BoxArgumentProcessor,
-	stack.commands.Implementation):	
+	BoxArgumentProcessor,
+	stack.commands.Implementation):
 
 	"""
 	Load attributes into the database based on comma-separated formatted
@@ -65,7 +65,7 @@ class Implementation(stack.commands.ApplianceArgumentProcessor,
 		self.appliances = self.getApplianceNames()
 		# need all the info from networks(/subnets)
 		self.networks = dict((k, next(v)) for k, v in groupby(self.owner.call('list.network'), itemgetter('network')))
-		self.boxes = self.getBoxNames()
+		self.boxes = self.get_box_names()
 		self.actions = [entry['bootaction'] for entry in self.owner.call('list.bootaction')]
 
 		try:
@@ -88,7 +88,7 @@ class Implementation(stack.commands.ApplianceArgumentProcessor,
 							required.remove(header[i])
 
 					if len(required) > 0:
-						msg = 'the following required fields are not present in the input file: "%s"' % ', '.join(required)	
+						msg = 'the following required fields are not present in the input file: "%s"' % ', '.join(required)
 						raise CommandError(self.owner, msg)
 
 					continue
@@ -173,7 +173,7 @@ class Implementation(stack.commands.ApplianceArgumentProcessor,
 						osaction = field
 					elif header[i] == 'groups':
 						groups = field
-							
+
 				if not name:
 					msg = 'empty host name found in "name" column'
 					raise CommandError(self.owner, msg)
@@ -220,7 +220,7 @@ class Implementation(stack.commands.ApplianceArgumentProcessor,
 					raise CommandError(self.owner, msg)
 
 				self.owner.interfaces[name][interface] = {}
-				
+
 				if default:
 					self.owner.interfaces[name][interface]['default'] = default
 				if ip:
@@ -313,7 +313,7 @@ class Implementation(stack.commands.ApplianceArgumentProcessor,
 			# 'default' checking
 			#
 			ifaces = self.owner.interfaces[name].keys()
-			
+
 			#
 			# if there is only one interface, make it the default
 			#
@@ -341,7 +341,7 @@ class Implementation(stack.commands.ApplianceArgumentProcessor,
 				if multiple_defaults:
 					msg = 'host "%s" has more than one interface designated as the "default" interface.\nedit your spreadsheet so that only one interface is the "default".' % name
 					raise CommandError(self.owner, msg)
-					
+
 			#
 			# interface specific checks
 			#

--- a/common/src/stack/command/stack/commands/remove/box/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/box/__init__.py
@@ -12,9 +12,9 @@
 
 import stack.commands
 from stack.exception import ArgRequired, CommandError
+from stack.argument_processors.box import BoxArgumentProcessor
 
-
-class Command(stack.commands.BoxArgumentProcessor,
+class Command(BoxArgumentProcessor,
 	stack.commands.remove.command):
 	"""
 	Remove a box specification from the database.
@@ -22,7 +22,7 @@ class Command(stack.commands.BoxArgumentProcessor,
 	<arg type='string' name='box'>
 	A list of boxes to remove.  Boxes must not have any hosts assigned.
 	</arg>
-	
+
 	<example cmd='remove box test'>
 	Removes the box named "test" from the database.
 	</example>
@@ -32,7 +32,7 @@ class Command(stack.commands.BoxArgumentProcessor,
 		if len(args) < 1:
 			raise ArgRequired(self, 'box')
 
-		boxes = self.getBoxNames(args)
+		boxes = self.get_box_names(args)
 
 		# Prevent user from removing the default box.
 		if 'default' in boxes:

--- a/common/src/stack/command/stack/commands/report/host/repo/__init__.py
+++ b/common/src/stack/command/stack/commands/report/host/repo/__init__.py
@@ -13,10 +13,10 @@
 #
 
 import stack.commands
-
+from stack.argument_processors.box import BoxArgumentProcessor
 
 class Command(stack.commands.HostArgumentProcessor,
-	stack.commands.BoxArgumentProcessor, stack.commands.report.command):
+	BoxArgumentProcessor, stack.commands.report.command):
 	"""
 	Create a report that describes the repository configuration file
 	that should be put on hosts.
@@ -24,7 +24,7 @@ class Command(stack.commands.HostArgumentProcessor,
 	<arg optional='0' type='string' name='host'>
 	Host name of machine
 	</arg>
-	
+
 	<example cmd='report host repo backend-0-0'>
 	Create a report of the repository configuration file for backend-0-0.
 	</example>
@@ -38,7 +38,7 @@ class Command(stack.commands.HostArgumentProcessor,
 		for host in hosts:
 			osname = self.db.getHostOS(host)
 			server = self.getHostAttr(host, 'Kickstart_PrivateAddress')
-			
+
 			self.runImplementation(osname, (host, server))
 
 		self.endOutput(padChar='', trimOwner=True)

--- a/common/src/stack/command/stack/commands/report/host/repo/imp_redhat.py
+++ b/common/src/stack/command/stack/commands/report/host/repo/imp_redhat.py
@@ -19,7 +19,7 @@ class Implementation(stack.commands.Implementation):
 
 		repo.append('<stack:file stack:name="%s">' % filename)
 
-		for pallet in self.owner.getBoxPallets(box):
+		for pallet in self.owner.get_box_pallets(box):
 			repo.append('[%s-%s-%s]' % (pallet.name, pallet.version, pallet.rel))
 			repo.append('name=%s %s %s' % (pallet.name, pallet.version, pallet.rel))
 			repo.append('baseurl=http://%s/install/pallets/%s/%s/%s/%s/%s' % \

--- a/common/src/stack/command/stack/commands/report/host/repo/imp_sles.py
+++ b/common/src/stack/command/stack/commands/report/host/repo/imp_sles.py
@@ -18,7 +18,7 @@ class Implementation(stack.commands.Implementation):
 		filename = '/etc/zypp/repos.d/stacki.repo'
 		repo.append('<stack:file stack:name="%s">' % filename)
 
-		for pallet in self.owner.getBoxPallets(box):
+		for pallet in self.owner.get_box_pallets(box):
 
 			repo.append('[%s-%s-%s]' % (pallet.name, pallet.version, pallet.rel))
 			repo.append('name=%s %s %s' % (pallet.name, pallet.version, pallet.rel))

--- a/common/src/stack/command/stack/commands/run/pallet/__init__.py
+++ b/common/src/stack/command/stack/commands/run/pallet/__init__.py
@@ -16,12 +16,12 @@ import subprocess
 import stack.commands
 from stack.argument_processors.pallet import PalletArgumentProcessor
 from stack.exception import ArgRequired, CommandError
-
+from stack.argument_processors.box import BoxArgumentProcessor
 
 class Command(
 	stack.commands.run.command,
 	PalletArgumentProcessor,
-	stack.commands.BoxArgumentProcessor
+	BoxArgumentProcessor
 ):
 	"""
 	Installs a pallet on the fly
@@ -68,7 +68,7 @@ class Command(
 			# Make sure the pallets exist and are enabled for the frontend box
 			box = self.call("list.host",["localhost"])[0]["box"]
 			# List of all pallets enabled for the frontend
-			fe_pallets = self.getBoxPallets(box)
+			fe_pallets = self.get_box_pallets(box)
 			# List of all pallets specified on the command line
 			arg_pallets = self.get_pallets(args, params)
 			# Find the intersection of the 2 list of pallets

--- a/common/src/stack/command/stack/commands/set/host/box/__init__.py
+++ b/common/src/stack/command/stack/commands/set/host/box/__init__.py
@@ -5,10 +5,10 @@
 # @copyright@
 
 import stack.commands
-
+from stack.argument_processors.box import BoxArgumentProcessor
 
 class Command(stack.commands.set.host.command,
-	      stack.commands.BoxArgumentProcessor):
+	      BoxArgumentProcessor):
 	"""
 	Sets the box for a list of hosts.
 
@@ -33,7 +33,7 @@ class Command(stack.commands.set.host.command,
 		])
 
 		# Check to make sure this is a valid box name
-		self.getBoxNames([ box ])
+		self.get_box_names([ box ])
 
 		for host in hosts:
 			self.db.execute("""


### PR DESCRIPTION
Converted the Pallet namedtuple into a dataclass that will be expanded
upon in a later changeset. Nothing currently uses tuple unpacking with
the namedtuple returned from get_pallets, so this shouldn't change
behavior.

Changed the box argument processor to use the same Pallet dataclass as
the pallet argument processor when returning pallet information.