### PR TITLE
FEATURE: output information about the added pallets

### DIFF
--- a/common/src/stack/command/stack/commands/add/pallet/plugin_remote_iso.py
+++ b/common/src/stack/command/stack/commands/add/pallet/plugin_remote_iso.py
@@ -52,7 +52,7 @@ class Plugin(stack.commands.Plugin):
 			try:
 				remote_filename = pathlib.Path(urllib.parse.urlparse(canon_arg).path).name
 				# passing True will display a % progress indicator in stdout
-				local_path = fetch(canon_arg, self.owner.username, self.owner.password, True, f'{tempdir}/{remote_filename}')
+				local_path = fetch(canon_arg, self.owner.username, self.owner.password, False, f'{tempdir}/{remote_filename}')
 			except FetchError as e:
 				raise CommandError(self, e)
 

--- a/test-framework/test-suites/integration/tests/add/test_add_pallet.py
+++ b/test-framework/test-suites/integration/tests/add/test_add_pallet.py
@@ -34,8 +34,18 @@ class TestAddPallet:
 
 	def test_minimal(self, host, create_pallet_isos, revert_export_stack_pallets):
 		# Add our minimal pallet
-		result = host.run(f'stack add pallet {create_pallet_isos}/minimal-1.0-sles12.x86_64.disk1.iso')
+		result = host.run(f'stack add pallet {create_pallet_isos}/minimal-1.0-sles12.x86_64.disk1.iso output-format=json')
 		assert result.rc == 0
+
+		assert json.loads(result.stdout) == [
+			{
+				'pallet': 'minimal',
+				'version': '1.0',
+				'release': 'sles12',
+				'arch': 'x86_64',
+				'os': 'sles'
+			}
+		]
 
 		# Check it made it in as expected
 		result = host.run('stack list pallet minimal output-format=json')
@@ -262,8 +272,18 @@ class TestAddPallet:
 
 	def test_network_iso(self, host, run_pallet_isos_server, revert_export_stack_pallets):
 		# Add the minimal pallet ISO from the network
-		result = host.run('stack add pallet http://127.0.0.1:8000/minimal-1.0-sles12.x86_64.disk1.iso')
+		result = host.run('stack add pallet http://127.0.0.1:8000/minimal-1.0-sles12.x86_64.disk1.iso output-format=json')
 		assert result.rc == 0
+
+		assert json.loads(result.stdout) == [
+			{
+				'pallet': 'minimal',
+				'version': '1.0',
+				'release': 'sles12',
+				'arch': 'x86_64',
+				'os': 'sles'
+			}
+		]
 
 		# Check it made it in as expected
 		result = host.run('stack list pallet minimal output-format=json')
@@ -398,5 +418,20 @@ class TestAddPallet:
 				'os': 'sles',
 				'boxes': '',
 				'url': 'http://127.0.0.1:8000/minimal-1.0-sles12.x86_64.disk1.iso'
+			}
+		]
+
+	def test_add_pallet_output_wsclient(self, host, run_pallet_isos_server, revert_export_stack_pallets):
+		# Add the minimal pallet ISO from the network
+		result = host.run('wsclient add pallet http://127.0.0.1:8000/minimal-1.0-sles12.x86_64.disk1.iso')
+		assert result.rc == 0
+
+		assert json.loads(result.stdout) == [
+			{
+				'pallet': 'minimal',
+				'version': '1.0',
+				'release': 'sles12',
+				'arch': 'x86_64',
+				'os': 'sles'
 			}
 		]


### PR DESCRIPTION
when adding a pallet, the information for the pallets added is output. Some example output is below.

stack add pallet ~/tdc-infrastructure-01.04.20.00-sles12sp3.x86_64.disk1.iso ~/tdc-clientutils-16.20-1.0-sles12.x86_64.disk1.iso output-format=json
Copying tdc-infrastructure-01.04.20.00-sles12sp3-sles-x86_64 ...
checking for patches in /opt/stack/pallet-patches/tdc-infrastructure-01.04.20.00-sles12sp3-sles-x86_64
Copying tdc-clientutils-16.20-1.0-sles12-sles-x86_64 ...
checking for patches in /opt/stack/pallet-patches/tdc-clientutils-16.20-1.0-sles12-sles-x86_64
[
        {
                "pallet": "tdc-infrastructure",
                "version": "01.04.20.00",
                "release": "sles12sp3",
                "arch": "x86_64",
                "os": "sles"
        },
        {
                "pallet": "tdc-clientutils-16.20",
                "version": "1.0",
                "release": "sles12",
                "arch": "x86_64",
                "os": "sles"
        }
]

When called with wsclient, the other output doesnt show up (moved to notify)

wsclient add pallet ~/tdc-infrastructure-01.04.20.00-sles12sp3.x86_64.disk1.iso ~/tdc-clientutils-16.20-1.0-sles12.x86_64.disk1.iso
[{"pallet": "tdc-infrastructure", "version": "01.04.20.00", "release": "sles12sp3", "arch": "x86_64", "os": "sles"}, {"pallet": "tdc-clientutils-16.20", "version": "1.0", "release": "sles12", "arch": "x86_64", "os": "sles"}]
