### PR TITLE
FEATURE: Add hooks into pallet operations on the frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,19 @@ preroll::
 	make -C tools/fab pkg
 	mkdir -p build-$(ROLL)-$(STACK)/graph
 	mkdir -p build-$(ROLL)-$(STACK)/nodes
+	mkdir -p build-$(ROLL)-$(STACK)/pallet_hooks/common
+	mkdir -p build-$(ROLL)-$(STACK)/pallet_hooks/$(OS)
 	cp common/graph/* $(OS)/graph/* build-$(ROLL)-$(STACK)/graph/
 	cp common/nodes/* $(OS)/nodes/* build-$(ROLL)-$(STACK)/nodes/
+# mkisofs fails because the directory structure is too deep in the build env
+# for the version on sles11. We just simply skip this step for sles11 as the
+# sles12 pallet holds all the hooks and initrds for sles11 anyways.
+ifneq ($(RELEASE),sles11)
+	-cp -r common/pallet_hooks/ build-$(ROLL)-$(STACK)/pallet_hooks/common/
+	-cp -r $(OS)/pallet_hooks/  build-$(ROLL)-$(STACK)/pallet_hooks/$(OS)/
+endif
 
 clean::
 	rm -rf build-$(ROLL)-$(STACK)/graph/
 	rm -rf build-$(ROLL)-$(STACK)/nodes/
+	rm -rf build-$(ROLL)-$(STACK)/pallet_hooks/

--- a/common/nodes/pxe.xml
+++ b/common/nodes/pxe.xml
@@ -47,9 +47,6 @@ mkdir -p /tftpboot/pxelinux/pxelinux.cfg
 chown root.apache /tftpboot/pxelinux/pxelinux.cfg
 chmod 775 /tftpboot/pxelinux/pxelinux.cfg
 
-cp /opt/stack/images/vmlinuz* /tftpboot/pxelinux/
-cp /opt/stack/images/initrd* /tftpboot/pxelinux/
-
 <!-- copy all the syslinux programs to the pxelinux directory -->
 cp -R /usr/share/syslinux/* /tftpboot/pxelinux/
 

--- a/common/src/stack/command/stack/argument_processors/pallet.py
+++ b/common/src/stack/command/stack/argument_processors/pallet.py
@@ -1,10 +1,34 @@
+import pathlib
+from operator import attrgetter
+import re
+import subprocess
 from dataclasses import dataclass
+import jsoncomment
 from stack.exception import ArgNotFound
+
+# Pallet info from Probepal and the database columns do not have the same names.
+# They do have a mapping that ends up being the same values as one another. So
+# here we map PalletInfo attribute names to the pallet DB column names.
+PALLET_ATTR_MAPPINGS = {
+	'name': 'name',
+	'version': 'version',
+	'rel': 'release',
+	'arch': 'arch',
+	'os': 'distro_family',
+}
+# Since we normalize to a Pallet dataclass, this pallet_info_getter uses those
+# attribute names (the keys) from the mappings.
+pallet_info_getter = attrgetter(*PALLET_ATTR_MAPPINGS)
+# Module level "constants"
+PALLET_HOOK_DIRNAME = "pallet_hooks"
+PALLET_HOOK_ROOT = pathlib.Path(f"/opt/stack/") / PALLET_HOOK_DIRNAME
+PALLET_HOOK_METADATA_FILENAME = "pallet_hooks.json"
 
 @dataclass(eq=True, order=True, frozen=True)
 class Pallet:
 	"""A dataclass representation of the Roll schema in the database."""
 	id: int
+	# name, version, rel, arch, and os need to match the keys of PALLET_ATTR_MAPPINGS
 	name: str
 	version: str
 	rel: str
@@ -12,11 +36,32 @@ class Pallet:
 	os: str
 	url: str
 
+	@classmethod
+	def create_from_probepal_pallet_info(cls, pallet_info):
+		"""Create a Pallet from a PalletInfo instance."""
+		# Don't try to create if attributes are missing from the pallet_info object provided.
+		if not all(hasattr(pallet_info, attr_name) for attr_name in PALLET_ATTR_MAPPINGS.values()):
+			raise ValueError(
+				f"Unable to create Pallet from provided PalletInfo.\nPalletInfo was: {pallet_info}."
+			)
+
+		# Map the values of probepal.PalletInfo to the correct attributes of Pallet.
+		mapped_kwargs = {
+			key: getattr(pallet_info, PALLET_ATTR_MAPPINGS[key])
+			for key in PALLET_ATTR_MAPPINGS
+		}
+		# id and url aren't known from a PalletInfo so just set them to non-existant values.
+		return cls(
+			id=-1,
+			**mapped_kwargs,
+			url="",
+		)
+
 class PalletArgumentProcessor:
 
 	def get_pallets(self, args, params):
 		"""
-		Returns a Pallet namedtuple with the fields:
+		Returns a Pallet dataclass with the fields:
 			name, version, rel, arch, os, url
 
 		If args is None or empty then all pallets are returned.
@@ -51,3 +96,66 @@ class PalletArgumentProcessor:
 			pallets.extend([Pallet(*row) for row in rows])
 
 		return pallets
+
+	def _normalize_pallet_info(self, pallet_info):
+		"""Normalize the pallet info to a Pallet dataclass."""
+		# If this already has the attributes to be a Pallet, just use it.
+		if all(hasattr(pallet_info, attr_name) for attr_name in PALLET_ATTR_MAPPINGS):
+			return pallet_info
+
+		return Pallet.create_from_probepal_pallet_info(pallet_info)
+
+	def _get_pallet_hooks(self, operation, pallet_info):
+		"""Yield the pallet hooks that should run for this pallet and operation."""
+		# Find all pallet_hooks.json
+		hook_metadata_files = (
+			path for path in PALLET_HOOK_ROOT.glob(f"**/{PALLET_HOOK_METADATA_FILENAME}")
+		)
+
+		# Filter to the hooks that should run for this pallet.
+		# We allow comments in our JSON.
+		json_comment = jsoncomment.JsonComment()
+		for hook_file in hook_metadata_files:
+			hook_metadata = json_comment.loads(hook_file.read_text())
+
+			# Check if any scripts called out in the file should be run.
+			# This should only happen if all conditions are satisfied and we
+			# are performing a matching operation.
+			for script_file, conditions in hook_metadata.items():
+				try:
+					if all(
+						re.fullmatch(conditions[key], getattr(pallet_info, key))
+						for key in PALLET_ATTR_MAPPINGS
+					) and any(
+						re.fullmatch(operation_condition, operation)
+						for operation_condition in conditions["operations"]
+					):
+						yield (hook_file.parent / script_file).resolve(strict=True)
+				except KeyError as exception:
+					self.notify(f"{hook_file} is missing the following required key: {exception}")
+				except FileNotFoundError as exception:
+					self.notify(f"{script_file} specified in {hook_file} not found:\n\n{exception}")
+
+	def run_pallet_hooks(self, operation, pallet_info):
+		"""Run the hooks for the pallet operation in progress."""
+		pallet_info = self._normalize_pallet_info(pallet_info)
+		self.notify(f'checking for hooks in {PALLET_HOOK_ROOT} for {"-".join(pallet_info_getter(pallet_info))}')
+
+		# Find all executable files within the script directory and sort them by name.
+		hooks = sorted(
+			self._get_pallet_hooks(operation=operation, pallet_info=pallet_info),
+			key=lambda script_path: script_path.name,
+		)
+		# Execute the hooks in name sorted order.
+		for hook in hooks:
+			self.notify(f'running hook: {hook}')
+			try:
+				self._exec(str(hook), cwd=hook.parent, check=True)
+			except (PermissionError, subprocess.CalledProcessError) as exception:
+				self.notify(f'Unable to run hook {hook}:\n\n{exception}\n\nstdout:\n{exception.stdout}\n\nstderr:\n{exception.stderr}')
+
+	def get_pallet_hook_directory(self, pallet_info):
+		"""Calculate the hook directory for a given pallet."""
+		pallet_info = self._normalize_pallet_info(pallet_info)
+		pallet_hook_dir = pathlib.Path("-".join(pallet_info_getter(pallet_info)))
+		return pathlib.Path(PALLET_HOOK_ROOT) / pallet_hook_dir

--- a/common/src/stack/command/stack/argument_processors/pallet.py
+++ b/common/src/stack/command/stack/argument_processors/pallet.py
@@ -150,7 +150,7 @@ class PalletArgumentProcessor:
 		for hook in hooks:
 			self.notify(f'running hook: {hook}')
 			try:
-				self._exec(str(hook), cwd=hook.parent, check=True)
+				self._exec(['/usr/bin/env', str(hook)], cwd=hook.parent, check=True)
 			except (PermissionError, subprocess.CalledProcessError) as exception:
 				msg = f'Unable to run hook {hook}:\n\n{exception}\n'
 				# CalledProcessError has additional info...

--- a/common/src/stack/command/stack/argument_processors/pallet.py
+++ b/common/src/stack/command/stack/argument_processors/pallet.py
@@ -152,7 +152,11 @@ class PalletArgumentProcessor:
 			try:
 				self._exec(str(hook), cwd=hook.parent, check=True)
 			except (PermissionError, subprocess.CalledProcessError) as exception:
-				self.notify(f'Unable to run hook {hook}:\n\n{exception}\n\nstdout:\n{exception.stdout}\n\nstderr:\n{exception.stderr}')
+				msg = f'Unable to run hook {hook}:\n\n{exception}\n'
+				# CalledProcessError has additional info...
+				if hasattr(exception, 'stdout'):
+					msg += f'\nstdout:\n{exception.stdout}\n\nstderr:\n{exception.stderr}'
+				self.notify(msg)
 
 	def get_pallet_hook_directory(self, pallet_info):
 		"""Calculate the hook directory for a given pallet."""

--- a/common/src/stack/command/stack/commands/__init__.py
+++ b/common/src/stack/command/stack/commands/__init__.py
@@ -44,7 +44,6 @@ from stack.bool import str2bool, bool2str
 from stack.util import flatten
 import stack.util
 
-
 _logPrefix = ''
 _debug     = False
 

--- a/common/src/stack/command/stack/commands/add/pallet/__init__.py
+++ b/common/src/stack/command/stack/commands/add/pallet/__init__.py
@@ -229,28 +229,6 @@ class Command(PalletArgumentProcessor, command):
 			raise CommandError(self, f'{msg}\n{proc.stdout}\n{proc.stderr}')
 
 
-	def patch_pallet(self, pallet_info):
-		'''
-		Run any available pallet patches
-		'''
-
-		pallet_patch_dir = '-'.join(probepal_info_getter(pallet_info))
-		patch_dir = pathlib.Path(f'/opt/stack/pallet-patches/{pallet_patch_dir}')
-		print(f'checking for patches in {patch_dir}')
-		if not patch_dir.is_dir():
-			return
-
-		patches = sorted(list(patch_dir.glob('*.sh')) + list(patch_dir.glob('*.py')), key=lambda p: p.name)
-		for patch in patches:
-			print(f'applying patch: {patch}')
-			try:
-				self._exec(str(patch), cwd=patch_dir, check=True)
-			except PermissionError as e:
-				raise CommandError(self, f'Unable to apply patch: {str(patch)}\n{e}')
-			except subprocess.CalledProcessError as e:
-				print(e)
-
-
 	def run(self, params, args):
 		clean, stacki_pallet_dir, updatedb, run_hooks, self.username, self.password = self.fillParams([
 			('clean', False),

--- a/common/src/stack/command/stack/commands/disable/pallet/__init__.py
+++ b/common/src/stack/command/stack/commands/disable/pallet/__init__.py
@@ -53,6 +53,10 @@ class Command(PalletArgumentProcessor,
 	box is specified the pallet is disabled for the default box.
 	</param>
 
+	<param type='bool' name='run_hooks'>
+	Controls whether pallets hooks are run. This defaults to True.
+	</param>
+
 	<example cmd='disable pallet kernel'>
 	Disable the kernel pallet.
 	</example>
@@ -72,9 +76,10 @@ class Command(PalletArgumentProcessor,
 		if len(args) < 1:
 			raise ArgRequired(self, 'pallet')
 
-		(arch, box) = self.fillParams([
+		arch, box, run_hooks = self.fillParams([
 			('arch', self.arch),
-			('box', 'default')
+			('box', 'default'),
+			('run_hooks', True),
 		])
 
 		# We need to write the default arch back to the params list
@@ -89,6 +94,10 @@ class Command(PalletArgumentProcessor,
 		box_id = rows[0][0]
 
 		for pallet in self.get_pallets(args, params):
+			# Run any hooks before we remove repos.
+			if run_hooks:
+				self.run_pallet_hooks(operation="disable", pallet_info=pallet)
+
 			self.db.execute(
 				'delete from stacks where box=%s and roll=%s',
 				(box_id, pallet.id)

--- a/common/src/stack/command/stack/commands/remove/pallet/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/pallet/__init__.py
@@ -55,6 +55,10 @@ class Command(command):
 	supplied, then all OSes will be removed.
 	</param>
 
+	<param type='bool' name='run_hooks'>
+	Controls whether pallets hooks are run. This defaults to True.
+	</param>
+
 	<example cmd='remove pallet kernel'>
 	Remove all versions and architectures of the kernel pallet.
 	</example>
@@ -74,10 +78,18 @@ class Command(command):
 		if len(args) < 1:
 			raise ArgRequired(self, 'pallet')
 
+		run_hooks, = self.fillParams([
+			('run_hooks', True),
+		])
+
 		self.beginOutput()
 
 		regenerate = False
 		for pallet in self.get_pallets(args, params):
+			# Run any hooks before we regenerate the repo file and remove the pallet.
+			if run_hooks:
+				self.run_pallet_hooks(operation="remove", pallet_info=pallet)
+
 			self.clean_pallet(pallet)
 			regenerate = True
 

--- a/redhat/pallet_hooks/pallet_hooks.json
+++ b/redhat/pallet_hooks/pallet_hooks.json
@@ -1,0 +1,18 @@
+# This maps the script path, relative to the pallet_hooks directory, to the pallet information
+# that this script should be run for. This also specifies which operations should trigger the
+# script being run.
+#
+# The full pallet information must be provided, I.E. name, version, rel, os, and arch.
+# However, these can be valid python regular expressions to allow wildcard matching.
+{
+	# This one will run against any pallet named stacki which has a redhat7 release
+	# when they are enabled, I.E. `stack enable pallet stacki release=redhat7`.
+	"stacki-redhat7/010-add-stacki-images.sh": {
+		"name": "stacki",
+		"version": ".*",
+		"rel": "redhat7",
+		"os": ".*",
+		"arch": ".*",
+		"operations": ["enable"],
+	},
+}

--- a/redhat/pallet_hooks/stacki-redhat7/010-add-stacki-images.sh
+++ b/redhat/pallet_hooks/stacki-redhat7/010-add-stacki-images.sh
@@ -1,0 +1,11 @@
+#! /bin/bash
+
+set -e
+
+# Install the stacki RedHat images.
+yum --assumeyes install stack-images
+
+# Copy the vmlinuz and initrd. Redhat throws the version in the filename
+# so we use * to ignore that.
+cp /opt/stack/images/initrd.img*redhat7-x86_64 /tftpboot/pxelinux/
+cp /opt/stack/images/vmlinuz*redhat7-x86_64 /tftpboot/pxelinux/

--- a/sles/pallet_hooks/SLES-11sp3-sles11-sles-x86_64/010-add-stacki-squashfs.sh
+++ b/sles/pallet_hooks/SLES-11sp3-sles11-sles-x86_64/010-add-stacki-squashfs.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+cp -r /opt/stack/pallet-patches/SLES-11sp3-sles11-sles-x86_64/add-stacki-squashfs/* /export/stack/pallets/SLES/11sp3/sles11/sles/x86_64/

--- a/sles/pallet_hooks/SLES-11sp3-sles11-sles-x86_64/010-add-stacki-squashfs.sh
+++ b/sles/pallet_hooks/SLES-11sp3-sles11-sles-x86_64/010-add-stacki-squashfs.sh
@@ -1,3 +1,6 @@
 #! /bin/bash
 
-cp -r /opt/stack/pallet-patches/SLES-11sp3-sles11-sles-x86_64/add-stacki-squashfs/* /export/stack/pallets/SLES/11sp3/sles11/sles/x86_64/
+PALLET_DIR=/export/stack/pallets/SLES/11sp3/sles11/sles/x86_64/
+if [[ -d $PALLET_DIR ]]; then
+  cp -r /opt/stack/pallet-patches/SLES-11sp3-sles11-sles-x86_64/add-stacki-squashfs/* $PALLET_DIR
+fi

--- a/sles/pallet_hooks/SLES-12sp2-sles12-sles-x86_64/010-add-stacki-squashfs.sh
+++ b/sles/pallet_hooks/SLES-12sp2-sles12-sles-x86_64/010-add-stacki-squashfs.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+cp -r /opt/stack/pallet-patches/SLES-12sp2-sles12-sles-x86_64/add-stacki-squashfs/* /export/stack/pallets/SLES/12sp2/sles12/sles/x86_64/

--- a/sles/pallet_hooks/SLES-12sp2-sles12-sles-x86_64/010-add-stacki-squashfs.sh
+++ b/sles/pallet_hooks/SLES-12sp2-sles12-sles-x86_64/010-add-stacki-squashfs.sh
@@ -1,3 +1,6 @@
 #! /bin/bash
 
-cp -r /opt/stack/pallet-patches/SLES-12sp2-sles12-sles-x86_64/add-stacki-squashfs/* /export/stack/pallets/SLES/12sp2/sles12/sles/x86_64/
+PALLET_DIR=/export/stack/pallets/SLES/12sp2/sles12/sles/x86_64/
+if [[ -d $PALLET_DIR ]]; then
+  cp -r /opt/stack/pallet-patches/SLES-12sp2-sles12-sles-x86_64/add-stacki-squashfs/* $PALLET_DIR
+fi

--- a/sles/pallet_hooks/SLES-12sp3-sles12-sles-x86_64/010-add-stacki-squashfs.sh
+++ b/sles/pallet_hooks/SLES-12sp3-sles12-sles-x86_64/010-add-stacki-squashfs.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+cp -r /opt/stack/pallet-patches/SLES-12sp3-sles12-sles-x86_64/add-stacki-squashfs/* /export/stack/pallets/SLES/12sp3/sles12/sles/x86_64/

--- a/sles/pallet_hooks/SLES-12sp3-sles12-sles-x86_64/010-add-stacki-squashfs.sh
+++ b/sles/pallet_hooks/SLES-12sp3-sles12-sles-x86_64/010-add-stacki-squashfs.sh
@@ -1,3 +1,6 @@
 #! /bin/bash
 
-cp -r /opt/stack/pallet-patches/SLES-12sp3-sles12-sles-x86_64/add-stacki-squashfs/* /export/stack/pallets/SLES/12sp3/sles12/sles/x86_64/
+PALLET_DIR=/export/stack/pallets/SLES/12sp3/sles12/sles/x86_64/
+if [[ -d $PALLET_DIR ]]; then
+  cp -r /opt/stack/pallet-patches/SLES-12sp3-sles12-sles-x86_64/add-stacki-squashfs/* $PALLET_DIR
+fi

--- a/sles/pallet_hooks/pallet_hooks.json
+++ b/sles/pallet_hooks/pallet_hooks.json
@@ -1,0 +1,54 @@
+# This maps the script path, relative to the pallet_hooks directory, to the pallet information
+# that this script should be run for. This also specifies which operations should trigger the
+# script being run.
+#
+# The full pallet information must be provided, I.E. name, version, rel, os, and arch.
+# However, these can be valid python regular expressions to allow wildcard matching.
+{
+	# The SLES scripts match against the exact pallet info when they are enabled, I.E.
+	# `stack enable pallet SLES`.
+	"SLES-11sp3-sles11-sles-x86_64/010-add-stacki-squashfs.sh": {
+		"name": "SLES",
+		"version": "11sp3",
+		"rel": "sles11",
+		"os": "sles",
+		"arch": "x86_64",
+		"operations": ["enable"],
+	},
+	"SLES-12sp2-sles12-sles-x86_64/010-add-stacki-squashfs.sh": {
+		"name": "SLES",
+		"version": "12sp2",
+		"rel": "sles12",
+		"os": "sles",
+		"arch": "x86_64",
+		"operations": ["enable"],
+	},
+	"SLES-12sp3-sles12-sles-x86_64/010-add-stacki-squashfs.sh": {
+		"name": "SLES",
+		"version": "12sp3",
+		"rel": "sles12",
+		"os": "sles",
+		"arch": "x86_64",
+		"operations": ["enable"],
+	},
+	# This one will run against any pallet named stacki which has a sles12 release
+	# when they are enabled, I.E. `stack enable pallet stacki release=sles12`.
+	"stacki-sles12/010-add-stacki-images.sh": {
+		"name": "stacki",
+		"version": ".*",
+		"rel": "sles12",
+		"os": ".*",
+		"arch": ".*",
+		"operations": ["enable"],
+	},
+	# This one will run against any pallet named stacki which has a sles11 release
+	# when they are enabled, I.E. `stack enable pallet stacki release=sles11`.
+	"stacki-sles11/010-add-stacki-images.sh": {
+		"name": "stacki",
+		"version": ".*",
+		"rel": "sles11",
+		"os": ".*",
+		"arch": ".*",
+		"operations": ["enable"],
+	},
+}

--- a/sles/pallet_hooks/stacki-sles11/010-add-stacki-images.sh
+++ b/sles/pallet_hooks/stacki-sles11/010-add-stacki-images.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+# Try to run the pallet patches, but allow these to fail.
+# The sles11 initrd and vmlinuz are in the sles12 stacki iso, so
+# it should already be set up for us.
+set +e
+
+../SLES-11sp3-sles11-sles-x86_64/010-add-stacki-squashfs.sh

--- a/sles/pallet_hooks/stacki-sles12/010-add-stacki-images.sh
+++ b/sles/pallet_hooks/stacki-sles12/010-add-stacki-images.sh
@@ -1,0 +1,22 @@
+#! /bin/bash
+
+set -e
+
+# Install the stack SLES images.
+zypper --non-interactive install stack-sles-sles12-images
+
+# Copy the vmlinuz and initrd
+cp /opt/stack/images/initrd-sles-sles11-11sp3-x86_64 /tftpboot/pxelinux/
+cp /opt/stack/images/initrd-sles-sles12-12sp2-x86_64 /tftpboot/pxelinux/
+cp /opt/stack/images/initrd-sles-sles12-12sp3-x86_64 /tftpboot/pxelinux/
+
+cp /opt/stack/images/vmlinuz-sles-sles11-11sp3-x86_64 /tftpboot/pxelinux/
+cp /opt/stack/images/vmlinuz-sles-sles12-12sp2-x86_64 /tftpboot/pxelinux/
+cp /opt/stack/images/vmlinuz-sles-sles12-12sp3-x86_64 /tftpboot/pxelinux/
+
+# Now try to run the pallet patches, but allow these to fail.
+set +e
+
+../SLES-12sp2-sles12-sles-x86_64/010-add-stacki-squashfs.sh
+../SLES-12sp3-sles12-sles-x86_64/010-add-stacki-squashfs.sh
+../SLES-11sp3-sles11-sles-x86_64/010-add-stacki-squashfs.sh

--- a/sles/src/stack/images/SLES/sles11/11sp3/010-add-stacki-squashfs.sh
+++ b/sles/src/stack/images/SLES/sles11/11sp3/010-add-stacki-squashfs.sh
@@ -1,3 +1,0 @@
-#! /bin/bash
-
-cp -r add-stacki-squashfs/* /export/stack/pallets/SLES/11sp3/sles11/sles/x86_64/

--- a/sles/src/stack/images/SLES/sles12/12sp2/010-add-stacki-squashfs.sh
+++ b/sles/src/stack/images/SLES/sles12/12sp2/010-add-stacki-squashfs.sh
@@ -1,3 +1,0 @@
-#! /bin/bash
-
-cp -r add-stacki-squashfs/* /export/stack/pallets/SLES/12sp2/sles12/sles/x86_64/

--- a/sles/src/stack/images/SLES/sles12/12sp3/010-add-stacki-squashfs.sh
+++ b/sles/src/stack/images/SLES/sles12/12sp3/010-add-stacki-squashfs.sh
@@ -1,3 +1,0 @@
-#! /bin/bash
-
-cp -r add-stacki-squashfs/* /export/stack/pallets/SLES/12sp3/sles12/sles/x86_64/

--- a/sles/src/stack/images/common/images.mk
+++ b/sles/src/stack/images/common/images.mk
@@ -63,7 +63,6 @@ install:: keyring
 	mkdir -p $(ROOT)/$(PALLET_PATCH_DIR)/add-stacki-squashfs
 	cd SLES-pallet-patches && (find . -type f | cpio -pudv $(ROOT)/$(PALLET_PATCH_DIR)/add-stacki-squashfs)
 	$(INSTALL) -m0644 sles-stacki.img $(ROOT)/$(PALLET_PATCH_DIR)/add-stacki-squashfs/boot/x86_64/sles-stacki.img
-	$(INSTALL) -m0755 010-add-stacki-squashfs.sh $(ROOT)/$(PALLET_PATCH_DIR)/010-add-stacki-squashfs.sh
 	# Add the SHA1 of the stacki image to content file
 	echo "HASH $(SHA)  boot/x86_64/sles-stacki.img" >> $(ROOT)/$(PALLET_PATCH_DIR)/add-stacki-squashfs/content
 	# Sign the content file

--- a/test-framework/provisioning/roles/barnacle/tasks/main.yml
+++ b/test-framework/provisioning/roles/barnacle/tasks/main.yml
@@ -91,3 +91,9 @@
   - name: Barnacle Output
     echo:
       output: "{{ barnacle_output.stdout }}"
+
+  - name: Remove the dvd repo from Yum
+    yum_repository:
+      name: dvd
+      state: absent
+    when: ansible_distribution == "CentOS"

--- a/test-framework/test-suites/integration/tests/add/test_add_pallet.py
+++ b/test-framework/test-suites/integration/tests/add/test_add_pallet.py
@@ -21,7 +21,7 @@ class TestAddPallet:
 		assert result.rc == 255
 		assert result.stderr == dedent('''\
 			error - must supply a password along with the username
-			[pallet ...] [clean=bool] [dir=string] [password=string] [updatedb=string] [username=string]
+			[pallet ...] [clean=bool] [dir=string] [password=string] [run_hooks=bool] [updatedb=string] [username=string]
 		''')
 
 	def test_password_no_username(self, host, create_pallet_isos):
@@ -29,7 +29,7 @@ class TestAddPallet:
 		assert result.rc == 255
 		assert result.stderr == dedent('''\
 			error - must supply a password along with the username
-			[pallet ...] [clean=bool] [dir=string] [password=string] [updatedb=string] [username=string]
+			[pallet ...] [clean=bool] [dir=string] [password=string] [run_hooks=bool] [updatedb=string] [username=string]
 		''')
 
 	def test_minimal(self, host, create_pallet_isos, revert_export_stack_pallets):
@@ -111,7 +111,7 @@ class TestAddPallet:
 			assert result.rc == 0
 			#Unmount the iso no matter what happens after test exits
 			cleanup.callback(host.run, 'umount /mnt/cdrom')
-		
+
 			result = host.run(f'stack add pallet {create_pallet_isos}/minimal-1.0-sles12.x86_64.disk1.iso')
 			assert result.rc == 0
 
@@ -157,7 +157,7 @@ class TestAddPallet:
 			]
 
 	def test_mounted_cdrom(self, host, create_pallet_isos, revert_export_stack_pallets):
-		with ExitStack() as cleanup: 
+		with ExitStack() as cleanup:
 			# Mount our pallet
 			result = host.run(f'mount | grep /mnt/cdrom')
 			print(result)
@@ -210,7 +210,7 @@ class TestAddPallet:
 
 	def test_pallet_already_mounted(self, host, create_pallet_isos, revert_export_stack_pallets):
 		''' shouldn't matter if an iso is mounted elsewhere, we should still be able to add it as a pallet '''
-		with ExitStack() as cleanup: 
+		with ExitStack() as cleanup:
 			# Mount our pallet
 			result = host.run(f'mount | grep /mnt/cdrom')
 			print(result)
@@ -219,7 +219,7 @@ class TestAddPallet:
 
 			cleanup.callback(host.run, 'umount /mnt/cdrom')
 
-			# Unmount ISO  
+			# Unmount ISO
 			result = host.run(f'umount /mnt/cdrom')
 			assert result.rc == 0
 

--- a/test-framework/test-suites/integration/tests/conftest.py
+++ b/test-framework/test-suites/integration/tests/conftest.py
@@ -30,7 +30,11 @@ def pytest_configure(config):
 		filesystem_revert_fixtures = [
 			"revert_etc",
 			"revert_export_stack_carts",
-			"revert_export_stack_pallets"
+			"revert_export_stack_pallets",
+			"revert_firmware",
+			"revert_pallet_patches",
+			"revert_pallet_hooks",
+			"revert_opt_stack_images",
 		]
 
 		for fixture in filesystem_revert_fixtures:

--- a/test-framework/test-suites/integration/tests/disable/test_disable_pallet.py
+++ b/test-framework/test-suites/integration/tests/disable/test_disable_pallet.py
@@ -10,7 +10,7 @@ class TestDisablePallet:
 		assert result.rc == 255
 		assert result.stderr == dedent('''\
 			error - "pallet" argument is required
-			{pallet ...} [arch=string] [box=string] [os=string] [release=string] [version=string]
+			{pallet ...} [arch=string] [box=string] [os=string] [release=string] [run_hooks=bool] [version=string]
 		''')
 
 	def test_invalid_pallet(self, host):
@@ -18,7 +18,7 @@ class TestDisablePallet:
 		assert result.rc == 255
 		assert result.stderr == dedent('''\
 			error - "test" argument is not a valid pallet with parameters arch=x86_64
-			{pallet ...} [arch=string] [box=string] [os=string] [release=string] [version=string]
+			{pallet ...} [arch=string] [box=string] [os=string] [release=string] [run_hooks=bool] [version=string]
 		''')
 
 	def test_invalid_box(self, host):

--- a/test-framework/test-suites/integration/tests/enable/test_enable_pallet.py
+++ b/test-framework/test-suites/integration/tests/enable/test_enable_pallet.py
@@ -1,6 +1,8 @@
 import json
 from textwrap import dedent
-
+import pathlib
+import pytest
+from stack.argument_processors.pallet import PALLET_HOOK_ROOT
 
 class TestEnablePallet:
 	def test_no_args(self, host):
@@ -8,7 +10,7 @@ class TestEnablePallet:
 		assert result.rc == 255
 		assert result.stderr == dedent('''\
 			error - "pallet" argument is required
-			{pallet ...} [arch=string] [box=string] [os=string] [release=string] [version=string]
+			{pallet ...} [arch=string] [box=string] [os=string] [release=string] [run_hooks=bool] [version=string]
 		''')
 
 	def test_invalid_pallet(self, host):
@@ -16,7 +18,7 @@ class TestEnablePallet:
 		assert result.rc == 255
 		assert result.stderr == dedent('''\
 			error - "test" argument is not a valid pallet with parameters arch=x86_64
-			{pallet ...} [arch=string] [box=string] [os=string] [release=string] [version=string]
+			{pallet ...} [arch=string] [box=string] [os=string] [release=string] [run_hooks=bool] [version=string]
 		''')
 
 	def test_invalid_box(self, host):
@@ -33,18 +35,18 @@ class TestEnablePallet:
 		result = host.run(f'stack enable pallet test-different-os')
 		assert result.rc == 255
 		assert result.stderr == 'error - incompatible pallet "test-different-os" with OS "ubuntu"\n'
-	
+
 	def test_wrong_version(self, host, create_pallet_isos, revert_export_stack_pallets):
 		# Add our test pallet
 		result = host.run(f'stack add pallet {create_pallet_isos}/test-different-version-test_foo-prod.x86_64.disk1.iso')
-		assert result.rc == 0 
+		assert result.rc == 0
 
 		# Try to enable it with the version parameter being wrong
 		result = host.run(f'stack enable pallet test-different-version version=1.0')
 		assert result.rc == 255
 		assert result.stderr == dedent('''\
 			error - "test-different-version" argument is not a valid pallet with parameters version=1.0, arch=x86_64
-			{pallet ...} [arch=string] [box=string] [os=string] [release=string] [version=string]
+			{pallet ...} [arch=string] [box=string] [os=string] [release=string] [run_hooks=bool] [version=string]
 		''')
 
 	def test_default_box(self, host, host_os, create_pallet_isos, revert_etc, revert_export_stack_pallets):
@@ -137,3 +139,109 @@ class TestEnablePallet:
 				'version': '1.0'
 			}
 		]
+
+	def test_stacki_enable_hooks_sles12(
+		self,
+		host,
+		host_os,
+		revert_etc,
+		revert_export_stack_pallets,
+		revert_pallet_patches,
+		revert_pallet_hooks,
+		revert_opt_stack_images,
+	):
+		"""Test the stacki hooks for sles12 work as expected."""
+		if host_os != "sles":
+			pytest.skip("This only tests hooks for SLES")
+
+		# remove the stacki-sles-sles12-images RPM
+		result = host.run("zypper --non-interactive remove stack-sles-sles12-images")
+		assert result.rc == 0
+
+		# remove the sles pallet
+		result = host.run("stack remove pallet SLES")
+		assert result.rc == 0
+
+		# clean up /tftboot/pxelinux, /opt/stack/pallet-patches, and /opt/stack/pallet_hooks
+		result = host.run("rm -f /tftpboot/pxelinux/vmlinuz-sles*")
+		assert result.rc == 0
+		result = host.run("rm -f /tftpboot/pxelinux/initrd-sles*")
+		assert result.rc == 0
+		result = host.run("rm -rf /opt/stack/pallet-patches/*")
+		assert result.rc == 0
+		result = host.run(f"rm -rf {PALLET_HOOK_ROOT}/*")
+		assert result.rc == 0
+
+		# Re-add the stacki pallet to re-copy the patches and hooks
+		result = host.run(f"stack add pallet /export/isos/stacki*sles12*.iso")
+		assert result.rc == 0
+
+		# Add the SLES pallet back.
+		result = host.run("stack add pallet /export/isos/SLE-12-SP3-Server-DVD-x86_64-GM-DVD1.iso")
+		assert result.rc == 0
+		# Get the sha256sum for the original content and boot/x86_64/config files (unpatched)
+		original_content_shasum = host.file("/export/stack/pallets/SLES/12sp3/sles12/sles/x86_64/content").sha256sum
+		original_config_shasum = host.file("/export/stack/pallets/SLES/12sp3/sles12/sles/x86_64/boot/x86_64/config").sha256sum
+
+		# Now re-enable the stacki pallet to patch the SLES pallet.
+		result = host.run("stack enable pallet stacki")
+		assert result.rc == 0
+
+		# Now get the sha256sum for the patched files.
+		new_content_shasum = host.file("/export/stack/pallets/SLES/12sp3/sles12/sles/x86_64/content").sha256sum
+		new_config_shasum = host.file("/export/stack/pallets/SLES/12sp3/sles12/sles/x86_64/boot/x86_64/config").sha256sum
+		# Make sure they do not match
+		assert original_content_shasum != new_content_shasum
+		assert original_config_shasum != new_config_shasum
+		# They should match the files in the pallet-patches location
+		source_content_shasum = host.file("/opt/stack/pallet-patches/SLES-12sp3-sles12-sles-x86_64/add-stacki-squashfs/content").sha256sum
+		assert new_content_shasum == source_content_shasum
+		source_config_shasum = host.file("/opt/stack/pallet-patches/SLES-12sp3-sles12-sles-x86_64/add-stacki-squashfs/boot/x86_64/config").sha256sum
+		assert new_config_shasum == source_config_shasum
+
+		# Make sure the vmlinuz and initrds were laid down.
+		assert host.file("/tftpboot/pxelinux/initrd-sles-sles11-11sp3-x86_64").exists
+		assert host.file("/tftpboot/pxelinux/initrd-sles-sles12-12sp2-x86_64").exists
+		assert host.file("/tftpboot/pxelinux/initrd-sles-sles12-12sp3-x86_64").exists
+		assert host.file("/tftpboot/pxelinux/vmlinuz-sles-sles11-11sp3-x86_64").exists
+		assert host.file("/tftpboot/pxelinux/vmlinuz-sles-sles12-12sp2-x86_64").exists
+		assert host.file("/tftpboot/pxelinux/vmlinuz-sles-sles12-12sp3-x86_64").exists
+
+	def test_stacki_enable_hooks_redhat7(
+			self,
+			host,
+			host_os,
+			revert_etc,
+			revert_export_stack_pallets,
+			revert_pallet_patches,
+			revert_pallet_hooks,
+			revert_opt_stack_images,
+		):
+			"""Test the stacki hooks for redhat7 work as expected."""
+			if host_os != "redhat":
+				pytest.skip("This only tests hooks for RedHat")
+
+			# remove the stacki-sles-sles12-images RPM
+			result = host.run("yum --assumeyes remove stack-images")
+			assert result.rc == 0
+
+			# clean up /tftboot/pxelinux and /opt/stack/pallet_hooks
+			result = host.run("rm -f /tftpboot/pxelinux/initrd.img*redhat7-x86_64")
+			assert result.rc == 0
+			result = host.run("rm -f /tftpboot/pxelinux/vmlinuz*redhat7-x86_64")
+			assert result.rc == 0
+			result = host.run(f"rm -rf {PALLET_HOOK_ROOT}/*")
+			assert result.rc == 0
+
+			# Re-add the stacki pallet to re-copy the patches and hooks
+			result = host.run(f"stack add pallet /export/isos/stacki*redhat7*.iso")
+			assert result.rc == 0
+
+			# Now re-enable the stacki pallet to lay down the vmlinuz and initrd.
+			result = host.run("stack enable pallet stacki")
+			assert result.rc == 0
+
+			# Make sure the vmlinuz and initrds were laid down. Have to do globbing
+			# as the version number (potentially a git hash) is baked into the filename.
+			assert len(list(pathlib.Path("/tftpboot/pxelinux").glob("initrd.img*redhat7-x86_64"))) == 1
+			assert len(list(pathlib.Path("/tftpboot/pxelinux").glob("vmlinuz*redhat7-x86_64"))) == 1

--- a/test-framework/test-suites/integration/tests/fixtures/reverts.py
+++ b/test-framework/test-suites/integration/tests/fixtures/reverts.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 import stack.firmware
+from stack.argument_processors.pallet import PALLET_HOOK_ROOT
 
 @pytest.fixture
 def revert_database(dump_mysql):
@@ -206,3 +207,41 @@ def revert_firmware(request):
 	yield
 
 	_remove_overlay(stack.firmware.BASE_PATH, request)
+
+@pytest.fixture
+def revert_pallet_patches(request):
+	"""Revert the filesystem where pallet patches are laid down."""
+	patch_dir = Path("/opt/stack/pallet-patches")
+	# Some OSes (I.E. RedHat) might not have this, so gotta make it
+	# otherwise the fixture blows up.
+	patch_dir.mkdir(parents=True, exist_ok=True)
+	_add_overlay(patch_dir)
+
+	yield
+
+	_remove_overlay(patch_dir, request)
+
+@pytest.fixture
+def revert_pallet_hooks(request):
+	"""Revert the filesystem where pallet hooks are laid down."""
+	# Gotta make sure the directory exists
+	# otherwise the fixture blows up.
+	PALLET_HOOK_ROOT.mkdir(parents=True, exist_ok=True)
+	_add_overlay(PALLET_HOOK_ROOT)
+
+	yield
+
+	_remove_overlay(PALLET_HOOK_ROOT, request)
+
+@pytest.fixture
+def revert_opt_stack_images(request):
+	"""Revert the filesystem where initrds and vmlinuz get installed by the stacki-images RPMs."""
+	image_dir = Path("/opt/stack/images")
+	# Gotta make sure the directory exists
+	# otherwise the fixture blows up.
+	image_dir.mkdir(parents=True, exist_ok=True)
+	_add_overlay(image_dir)
+
+	yield
+
+	_remove_overlay(image_dir, request)

--- a/test-framework/test-suites/integration/tests/remove/test_remove_pallet.py
+++ b/test-framework/test-suites/integration/tests/remove/test_remove_pallet.py
@@ -9,7 +9,7 @@ class TestRemovePallet:
 		assert result.rc == 255
 		assert result.stderr == dedent('''\
 			error - "pallet" argument is required
-			{pallet ...} [arch=string] [os=string] [release=string] [version=string]
+			{pallet ...} [arch=string] [os=string] [release=string] [run_hooks=bool] [version=string]
 		''')
 
 	def test_invalid(self, host):
@@ -17,7 +17,7 @@ class TestRemovePallet:
 		assert result.rc == 255
 		assert result.stderr == dedent('''\
 			error - "test" argument is not a valid pallet
-			{pallet ...} [arch=string] [os=string] [release=string] [version=string]
+			{pallet ...} [arch=string] [os=string] [release=string] [run_hooks=bool] [version=string]
 		''')
 
 	def test_no_parameters(self, host, create_pallet_isos, revert_etc):
@@ -121,7 +121,7 @@ class TestRemovePallet:
 		assert result.rc == 255
 		assert result.stderr == dedent('''\
 			error - "minimal" argument is not a valid pallet with parameters arch=x86
-			{pallet ...} [arch=string] [os=string] [release=string] [version=string]
+			{pallet ...} [arch=string] [os=string] [release=string] [run_hooks=bool] [version=string]
 		''')
 
 		# The pallet should still be in the DB
@@ -168,7 +168,7 @@ class TestRemovePallet:
 		assert result.rc == 255
 		assert result.stderr == dedent('''\
 			error - "minimal" argument is not a valid pallet with parameters os=redhat
-			{pallet ...} [arch=string] [os=string] [release=string] [version=string]
+			{pallet ...} [arch=string] [os=string] [release=string] [run_hooks=bool] [version=string]
 		''')
 
 		# The pallet should still be in the DB

--- a/tools/fab/frontend-install.py
+++ b/tools/fab/frontend-install.py
@@ -295,6 +295,9 @@ if osname == 'redhat':
 new_pkgs = [
 	'stack-templates',
 	'stack-probepal',
+	'foundation-python-jsoncomment',
+	'foundation-python-json-spec',
+	'foundation-python-six',
 ]
 
 for new_pkg in new_pkgs:


### PR DESCRIPTION
This allows for pallets to add scripts into a pallet_hooks folder at
the pallet root that will be run as specified in the
pallet_hooks/pallet_hooks.json.

This is mainly to enable SLES pallet patching and dropping the right
stacki initrd and vmlinuz on disk when supporting multiple versions of
the same OS, but this is a generic facility that pallets can use to
perform additional work during a `stack * pallet` operation.