### PR TITLE
INTERNAL: Help node bash scripts be more idempotent

### DIFF
--- a/common/nodes/ansible.xml
+++ b/common/nodes/ansible.xml
@@ -13,7 +13,7 @@ https://github.com/Teradata/stacki/blob/master/LICENSE.txt
 
 <stack:script stack:stage="install-post">
 mkdir -p /etc/ansible
-ln -s /opt/stack/etc/ansible.cfg /etc/ansible/ansible.cfg
+ln -s --force /opt/stack/etc/ansible.cfg /etc/ansible/ansible.cfg
 </stack:script>
 
 </stack:stack>

--- a/common/nodes/apache.xml
+++ b/common/nodes/apache.xml
@@ -80,10 +80,10 @@ chown apache:root /var/tmp/profile.semaphore
 
 <!-- REDHAT -->
 <stack:script stack:stage="install-post" stack:cond="os == 'redhat'">
-ln -s /opt/stack/etc/apache-stack.conf /etc/httpd/conf.d/stack.conf
+ln -s --force /opt/stack/etc/apache-stack.conf /etc/httpd/conf.d/stack.conf
 
 <!-- Set up mod_wsgi -->
-ln -s /opt/stack/lib/python3.*/site-packages/mod_wsgi/server/mod_wsgi-*.so /usr/lib64/httpd/modules/mod_wsgi.so
+ln -s --force /opt/stack/lib/python3.*/site-packages/mod_wsgi/server/mod_wsgi-*.so /usr/lib64/httpd/modules/mod_wsgi.so
 
 <stack:file stack:name="/etc/httpd/conf.modules.d/02-wsgi.conf">
 LoadModule wsgi_module modules/mod_wsgi.so
@@ -184,11 +184,11 @@ CustomLog ssl_request_log "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
 ]]>
 </stack:file>
 
-ln -s /opt/stack/etc/apache-ssl.conf /etc/apache2/conf.d/ssl.conf
-ln -s /opt/stack/etc/apache-stack.conf /etc/apache2/conf.d/stack.conf
+ln -s --force /opt/stack/etc/apache-ssl.conf /etc/apache2/conf.d/ssl.conf
+ln -s --force /opt/stack/etc/apache-stack.conf /etc/apache2/conf.d/stack.conf
 
 <!-- Set up mod_wsgi -->
-ln -s /opt/stack/lib/python3.*/site-packages/mod_wsgi/server/mod_wsgi-*.so /usr/lib64/apache2/mod_wsgi.so
+ln -s --force /opt/stack/lib/python3.*/site-packages/mod_wsgi/server/mod_wsgi-*.so /usr/lib64/apache2/mod_wsgi.so
 /usr/sbin/a2enmod wsgi
 
 <!-- Twiddle some modules -->

--- a/common/nodes/aws-server.xml
+++ b/common/nodes/aws-server.xml
@@ -10,7 +10,7 @@
 
 <stack:script stack:stage="boot-post">
 
-ln -s /opt/stack/images /export/stack/images
+ln -s --force /opt/stack/images /export/stack/images
 
 systemctl enable stack-aws-server-init
 

--- a/common/nodes/database.xml
+++ b/common/nodes/database.xml
@@ -55,7 +55,7 @@ password	= $root_pw
 </stack:file>
 
 <!-- symlink to root's home dir -->
-ln -s /etc/root.my.cnf /root/.my.cnf
+ln -s --force /etc/root.my.cnf /root/.my.cnf
 
 <!-- Generate random password for apache access to database -->
 apache_pw=`/opt/stack/sbin/gen_random_pw`

--- a/common/nodes/foundation-python.xml
+++ b/common/nodes/foundation-python.xml
@@ -11,7 +11,7 @@
 
 
 <stack:script stack:stage="install-post">
-ln -s /opt/stack/bin/python3 /opt/stack/bin/spython3
+ln -s --force /opt/stack/bin/python3 /opt/stack/bin/spython3
 </stack:script>
 
 <stack:script stack:stage="install-post">

--- a/common/nodes/ludicrous-server.xml
+++ b/common/nodes/ludicrous-server.xml
@@ -22,12 +22,12 @@ WSGIScriptAlias /ludicrous /var/www/wsgi/stacki-ludicrous.wsgi  process-group=st
 
 <!-- REDHAT -->
 <stack:script stack:stage="install-post" stack:cond="os == 'redhat'">
-ln -s /opt/stack/etc/apache-ludicrous.conf /etc/httpd/conf.d/ludicrous.conf
+ln -s --force /opt/stack/etc/apache-ludicrous.conf /etc/httpd/conf.d/ludicrous.conf
 </stack:script>
 
 <!-- SLES -->
 <stack:script stack:stage="install-post" stack:cond="os == 'sles'">
-ln -s /opt/stack/etc/apache-ludicrous.conf /etc/apache2/conf.d/ludicrous.conf
+ln -s --force /opt/stack/etc/apache-ludicrous.conf /etc/apache2/conf.d/ludicrous.conf
 </stack:script>
 
 </stack:stack>

--- a/common/nodes/profile-server.xml
+++ b/common/nodes/profile-server.xml
@@ -32,9 +32,9 @@
 <!-- set up the install directory so it can be served by the web -->
 (
 	cd /var/www/html ;
-	ln -s /export/stack install;
+	ln -s --force /export/stack install;
 	cd install/sbin ;
-	ln -s . public ;
+	ln -s --force . public ;
 ) 
 </stack:script>
 

--- a/common/nodes/restapi.xml
+++ b/common/nodes/restapi.xml
@@ -29,12 +29,12 @@ WSGIScriptAlias /stack /var/www/wsgi/stacki-ws.wsgi process-group=stacki-ws
 
 <!-- REDHAT -->
 <stack:script stack:stage="install-post" stack:cond="os == 'redhat'">
-ln -s /opt/stack/etc/apache-ws.conf /etc/httpd/conf.d/ws.conf
+ln -s --force /opt/stack/etc/apache-ws.conf /etc/httpd/conf.d/ws.conf
 </stack:script>
 
 <!-- SLES -->
 <stack:script stack:stage="install-post" stack:cond="os == 'sles'">
-ln -s /opt/stack/etc/apache-ws.conf /etc/apache2/conf.d/ws.conf
+ln -s --force /opt/stack/etc/apache-ws.conf /etc/apache2/conf.d/ws.conf
 </stack:script>
 
 </stack:stack>

--- a/common/nodes/ssl-server.xml
+++ b/common/nodes/ssl-server.xml
@@ -38,12 +38,12 @@ chmod ao+rx /export/stack/pallets
 
 <!-- REDHAT -->
 <stack:script stack:stage="install-post" stack:cond="os == 'redhat'">
-ln -s /opt/stack/etc/apache-https.conf /etc/httpd/conf.d/https.conf
+ln -s --force /opt/stack/etc/apache-https.conf /etc/httpd/conf.d/https.conf
 </stack:script>
 
 <!-- SLES -->
 <stack:script stack:stage="install-post" stack:cond="os == 'sles'">
-ln -s /opt/stack/etc/apache-https.conf /etc/apache2/conf.d/https.conf
+ln -s --force /opt/stack/etc/apache-https.conf /etc/apache2/conf.d/https.conf
 </stack:script>
 
 </stack:stack>


### PR DESCRIPTION
Force create symlinks so they can be created multiple times. Make `stack:file` append mode idempotent when using the `ansible` profile output.