### PR TITLE
FEATURE: pip2src should take into account dependencies when making Makefiles for RPMs.

### DIFF
--- a/common/src/stack/build/build/bin/pip2src
+++ b/common/src/stack/build/build/bin/pip2src
@@ -176,6 +176,11 @@ def write_makefiles(package, package_prefix):
 		with srcdir.joinpath("Makefile").open("w") as makefile:
 			makefile.write("PKGROOT  = /opt/stack\n")
 			makefile.write(f"ROLLROOT = {os.environ['ROLLROOT']}/../..\n")
+			dep_list = []
+			for dependency in package.dependencies:
+				dep_list.append(f"{package_prefix}-{dependency.name} = {dependency.version}")
+			if dep_list:
+				makefile.write(f"RPM.REQUIRES = {', '.join(dep_list)}\n")
 			makefile.write("\n")
 			makefile.write("include $(STACKBUILD)/etc/CCRules.mk\n")
 			makefile.write("\n")


### PR DESCRIPTION
Include dependencies in python packages so they don't have to be specified explicitly in frontend_install.py later. Let the magic of Yum/Zypper dependency management do its thing.

Before:
```
# rpm -qpR foundation-python-Flask-1.1.1-sles12.x86_64.rpm
/opt/stack/bin/python3
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsLzma) <= 4.4.6-1
```

After:
```
# rpm -qpR foundation-python-Flask-1.1.1-sles12.x86_64.rpm
/opt/stack/bin/python3
foundation-python-Click = 7.0
foundation-python-Jinja2 = 2.10.3
foundation-python-Werkzeug = 0.16.0
foundation-python-itsdangerous = 1.1.0
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsLzma) <= 4.4.6-1
```

