### PR TITLE
INTERNAL: Add locking in the Vagrantfile used by test-framework

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -525,11 +525,6 @@ pipeline {
                     }
 
                     steps {
-                        // Note: There is a race condition getting bridged networks
-                        // when you kick off vagrant at the exact same time. So, cause
-                        // a slight delay.
-                        sleep 10
-
                         // Run the integration tests
                         dir('integration_1') {
                             // Give the tests up to 90 minutes to finish
@@ -583,11 +578,6 @@ pipeline {
                     }
 
                     steps {
-                        // Note: There is a race condition getting bridged networks
-                        // when you kick off vagrant at the exact same time. So, cause
-                        // a slight delay.
-                        sleep 20
-
                         // Run the integration tests
                         dir('integration_2') {
                             // Give the tests up to 90 minutes to finish
@@ -641,11 +631,6 @@ pipeline {
                     }
 
                     steps {
-                        // Note: There is a race condition getting bridged networks
-                        // when you kick off vagrant at the exact same time. So, cause
-                        // a slight delay.
-                        sleep 30
-
                         // Run the integration tests
                         dir('integration_3') {
                             // Give the tests up to 90 minutes to finish
@@ -692,8 +677,6 @@ pipeline {
 
                 stage('System') {
                     steps {
-                        sleep 40
-
                         // Run the system tests
                         dir('system') {
                             // Give the tests up to 90 minutes to finish
@@ -782,8 +765,6 @@ pipeline {
                     }
 
                     steps {
-                        sleep 50
-
                         dir('combine/test-suites/unit') {
                             script {
                                 // Create a VM to combine the coverage data

--- a/test-framework/Vagrantfile
+++ b/test-framework/Vagrantfile
@@ -1,4 +1,5 @@
 require 'json'
+require 'thread'
 
 # We need the vagrant-reload plugin
 unless Vagrant.has_plugin?("vagrant-reload")
@@ -38,6 +39,26 @@ if ENV['GIT_BRANCH'].nil?
 end
 
 Vagrant.configure("2") do |config|
+  # Note: This requires Vagrant 2.2.0 or newer
+  config.trigger.before :up do |trigger|
+    trigger.info = "Acquiring Lock..."
+    trigger.ruby do |env, machine|
+      # The vagrant-libvirt plugin has a race condition getting
+      # virtual bridges and IPs. So, we make sure concurrent processes
+      # are spread out with a lock.
+      lock = File.open(File.join(env.home_path, "test-framework.lock"), "w+")
+      lock.flock(File::LOCK_EX)
+      machine.ui.info("Lock acquired")
+
+      Thread.new {
+        # Give vagrant 60 seconds to get an IP
+        sleep 60
+        lock.flock(File::LOCK_UN)
+        lock.close()
+      }
+    end
+  end
+
   config.vm.define "frontend", autostart: false do |config|
     if STACKI_ISO =~  /-sles12\./
       config.vm.box = "stacki/sles-12.3"

--- a/test-framework/test-suites/integration/run-tests.sh
+++ b/test-framework/test-suites/integration/run-tests.sh
@@ -46,7 +46,7 @@ then
 
     # Capture the test status but continue after failure
     set +e
-    vagrant ssh frontend -c "sudo -i pytest -vvv \
+    vagrant ssh frontend --no-tty -c "sudo -i /opt/stack/bin/pytest -vvv \
         --timeout=300 --timeout_method=signal \
         --junit-xml=/export/reports/integration-junit.xml \
         --cov-config=/export/test-suites/_common/$COVERAGERC \
@@ -58,17 +58,17 @@ then
     STATUS=$?
 
     # Move the coverage data
-    vagrant ssh frontend -c "sudo -i mv /root/.coverage /export/reports/integration.coverage"
+    vagrant ssh frontend --no-tty -c "sudo -i mv /root/.coverage /export/reports/integration.coverage"
 
     exit $STATUS
 elif [[ $AUDIT -eq 1 ]]
 then
-    vagrant ssh frontend -c "sudo -i pytest -vvv \
+    vagrant ssh frontend --no-tty -c "sudo -i /opt/stack/bin/pytest -vvv \
         --audit \
         ${EXTRA_FLAGS[*]} \
         /export/test-suites/integration/tests/"
 else
-    vagrant ssh frontend -c "sudo -i pytest -vvv \
+    vagrant ssh frontend --no-tty -c "sudo -i /opt/stack/bin/pytest -vvv \
         --timeout=300 --timeout_method=signal \
         --junit-xml=/export/reports/integration-junit.xml \
         ${EXTRA_FLAGS[*]} \

--- a/test-framework/test-suites/integration/set-up.d/common.sh
+++ b/test-framework/test-suites/integration/set-up.d/common.sh
@@ -4,5 +4,5 @@
 set -e
 
 # Install pytest-cov on the frontend
-vagrant ssh frontend -c "sudo -i python3 -m ensurepip"
-vagrant ssh frontend -c "sudo -i pip3 install pytest-cov==2.8.1 pytest-test-groups==1.0.3 pytest-timeout==1.3.3 coverage==4.5.4"
+vagrant ssh frontend --no-tty -c "sudo -i /opt/stack/bin/python3 -m ensurepip"
+vagrant ssh frontend --no-tty -c "sudo -i /opt/stack/bin/pip3 install pytest-cov==2.8.1 pytest-test-groups==1.0.3 pytest-timeout==1.3.3 coverage==4.5.4"

--- a/test-framework/test-suites/system/files/wait-for-backend.sh
+++ b/test-framework/test-suites/system/files/wait-for-backend.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+for i in {1..60}
+do
+    if grep $1 /var/log/checklist.log | grep -q 'TFTP_RRQ'
+    then
+        echo "TFTP found for $1"
+        break
+    fi
+
+    sleep 10
+done

--- a/test-framework/test-suites/system/run-tests.sh
+++ b/test-framework/test-suites/system/run-tests.sh
@@ -16,7 +16,7 @@ then
 fi
 
 # Run the tests
-vagrant ssh frontend -c "sudo -i pytest -vvv \
+vagrant ssh frontend --no-tty -c "sudo -i /opt/stack/bin/pytest -vvv \
 	--junit-xml=/export/reports/system-junit.xml \
 	/opt/stack/lib/python3*/site-packages/stack/commands/report/system/tests/ \
 	/export/test-suites/system/tests/"
@@ -24,9 +24,9 @@ vagrant ssh frontend -c "sudo -i pytest -vvv \
 if [[ $1 == "--coverage" ]]
 then
     # Generate the coverage reports
-    vagrant ssh frontend -c "sudo -i coverage combine"
-    vagrant ssh frontend -c "sudo -i coverage html -i -d /export/reports/system"
+    vagrant ssh frontend --no-tty -c "sudo -i coverage combine"
+    vagrant ssh frontend --no-tty -c "sudo -i coverage html -i -d /export/reports/system"
 
     # Move the coverage data
-    vagrant ssh frontend -c "sudo -i mv /root/.coverage /export/reports/system.coverage"
+    vagrant ssh frontend --no-tty -c "sudo -i mv /root/.coverage /export/reports/system.coverage"
 fi

--- a/test-framework/test-suites/system/set-up.d/_common.sh
+++ b/test-framework/test-suites/system/set-up.d/_common.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
-# Bring up the backends a bit apart
-# Note: Vagrant Virtualbox provider doesn't support --parallel, so we do it here
+# Bring up the backends in order, so we know the IPs even though we are using discovery
 vagrant up backend-0-0 &
-sleep 10
+vagrant ssh frontend --no-tty -c "sudo -i /export/test-suites/system/files/wait-for-backend.sh 192.168.0.1"
+
 vagrant up backend-0-1 &
-sleep 10
+vagrant ssh frontend --no-tty -c "sudo -i /export/test-suites/system/files/wait-for-backend.sh 192.168.0.3"
+
 vagrant up backend-0-2 &
-sleep 10
+vagrant ssh frontend --no-tty -c "sudo -i /export/test-suites/system/files/wait-for-backend.sh 192.168.0.4"
 
 # Monitor the backend installs
-vagrant ssh frontend -c "sudo -i /export/test-suites/system/files/monitor-backends.py --timeout=$1"
+vagrant ssh frontend --no-tty -c "sudo -i /export/test-suites/system/files/monitor-backends.py --timeout=$1"

--- a/test-framework/test-suites/system/set-up.d/stacki-redhat7.sh
+++ b/test-framework/test-suites/system/set-up.d/stacki-redhat7.sh
@@ -7,10 +7,10 @@ set -e
 if [[ "$#" -eq 1 && $1 =~ stacki-.*-redhat7\.x86_64\.disk1\.iso ]]
 then
     # Load hostfile and set partitioning for backend-0-0 and backend-0-1
-    vagrant ssh frontend -c "sudo -i /export/test-suites/system/files/set-redhat-host-partitions.sh"
+    vagrant ssh frontend --no-tty -c "sudo -i /export/test-suites/system/files/set-redhat-host-partitions.sh"
 
     # Start discovery
-    vagrant ssh frontend -c "sudo -i stack enable discovery"
+    vagrant ssh frontend --no-tty -c "sudo -i stack enable discovery"
 
     # Bring up the backends (120 minute timeout)
     ./set-up.d/_common.sh 120

--- a/test-framework/test-suites/system/set-up.d/stacki-sles11.sh
+++ b/test-framework/test-suites/system/set-up.d/stacki-sles11.sh
@@ -31,10 +31,10 @@ then
     cd - >/dev/null
 
     # Create the sles11sp3 box on the frontend
-    vagrant ssh frontend -c "sudo -i /export/test-suites/system/files/create-sles11sp3-box.sh $2"
+    vagrant ssh frontend --no-tty -c "sudo -i /export/test-suites/system/files/create-sles11sp3-box.sh $2"
 
     # Start discovery
-    vagrant ssh frontend -c "sudo -i stack enable discovery box=sles11sp3 installaction='install sles 11.3'"
+    vagrant ssh frontend --no-tty -c "sudo -i stack enable discovery box=sles11sp3 installaction='install sles 11.3'"
 
     # Bring up the backends (120 minute timeout)
     ./set-up.d/_common.sh 120

--- a/test-framework/test-suites/system/set-up.d/stacki-sles12.sh
+++ b/test-framework/test-suites/system/set-up.d/stacki-sles12.sh
@@ -7,7 +7,7 @@ set -e
 if [[ "$#" -eq 1 && $1 =~ stacki-.*-sles12\.x86_64\.disk1\.iso ]]
 then
     # Start discovery
-    vagrant ssh frontend -c "sudo -i stack enable discovery"
+    vagrant ssh frontend --no-tty -c "sudo -i stack enable discovery"
 
     # Bring up the backends (120 minute timeout)
     ./set-up.d/_common.sh 120

--- a/test-framework/test-suites/unit/run-tests.sh
+++ b/test-framework/test-suites/unit/run-tests.sh
@@ -23,7 +23,7 @@ then
 
     # Capture the test status but continue after failure
     set +e
-    vagrant ssh frontend -c "sudo -i pytest -vvv \
+    vagrant ssh frontend --no-tty -c "sudo -i /opt/stack/bin/pytest -vvv \
         --junitxml=/export/reports/unit-junit.xml \
         --cov-config=/export/test-suites/_common/$COVERAGERC \
         --cov=wsclient \
@@ -33,11 +33,11 @@ then
     STATUS=$?
 
     # Move the coverage data
-    vagrant ssh frontend -c "sudo -i mv /root/.coverage /export/reports/unit.coverage"
+    vagrant ssh frontend --no-tty -c "sudo -i mv /root/.coverage /export/reports/unit.coverage"
 
     exit $STATUS
 else
-    vagrant ssh frontend -c "sudo -i pytest -vvv \
+    vagrant ssh frontend --no-tty -c "sudo -i /opt/stack/bin/pytest -vvv \
         --junitxml=/export/reports/unit-junit.xml \
         /export/test-suites/unit/tests/"
 fi

--- a/test-framework/test-suites/unit/set-up.d/common.sh
+++ b/test-framework/test-suites/unit/set-up.d/common.sh
@@ -4,5 +4,5 @@
 set -e
 
 # Install pytest-cov on the frontend
-vagrant ssh frontend -c "sudo -i python3 -m ensurepip"
-vagrant ssh frontend -c "sudo -i pip3 install pytest-cov==2.6.1 coverage==4.5.4"
+vagrant ssh frontend --no-tty -c "sudo -i /opt/stack/bin/python3 -m ensurepip"
+vagrant ssh frontend --no-tty -c "sudo -i /opt/stack/bin/pip3 install pytest-cov==2.6.1 coverage==4.5.4"


### PR DESCRIPTION
This change adds an interprocess lock via a Vagrant trigger to ensure only a single instance of `test-framework` is trying to grab a virtual bridge or a DHCP IP at a given time. The lock only lasts for 60 seconds (I had no way to easily hook Vagrant for when the network is set up), but that seems to be twice as much time as needed.

This change requires Vagrant version 2.2.0 (or newer), which has been released for over 1.5 years so should be a reasonable requirement.

Also, now that there is locking involved, I couldn't rely on simple sleeps to bring the backends up in a deterministic order. So, I wrote a little monitoring script to wait for one backend to come up before launching the next.