### PR TITLE
FEATURE: Migrate to using `ip route` command

### DIFF
--- a/common/src/stack/command/stack/commands/add/route/__init__.py
+++ b/common/src/stack/command/stack/commands/add/route/__init__.py
@@ -109,14 +109,14 @@ class Command(stack.commands.ScopeArgumentProcessor, stack.commands.add.command)
 			for scope_mapping in scope_mappings:
 				if scope_mapping.node_id == node_id:
 					# Add the new route
-					cmd = ['route', 'add', '-host', address]
+					cmd = ['ip', 'route', 'add', address]
 
 					if interface:
 						cmd.append('dev')
 						cmd.append(interface)
 
 					if gateway:
-						cmd.append('gw')
+						cmd.append('via')
 						cmd.append(gateway)
 
 					self._exec(cmd)

--- a/common/src/stack/command/stack/commands/remove/route/__init__.py
+++ b/common/src/stack/command/stack/commands/remove/route/__init__.py
@@ -76,7 +76,7 @@ class Command(stack.commands.ScopeArgumentProcessor, stack.commands.remove.comma
 			for scope_mapping in scope_mappings:
 				if scope_mapping.node_id == node_id:
 					# Remove the route
-					self._exec(f'route del -host {address}', shlexsplit=True)
+					self._exec(f'ip route del {address}', shlexsplit=True)
 
 					# Sync the routes file
 					self._exec("""


### PR DESCRIPTION
Migrate the `add route` and `remove route` commands to use the newer `ip
route` command. SLES15 requires the newer command, but our other FE OSes
also support it natively.