### PR TITLE
List Host should Show no OS or Install Action when host isn't Kickstartable

### DIFF
--- a/common/src/stack/command/stack/commands/__init__.py
+++ b/common/src/stack/command/stack/commands/__init__.py
@@ -2498,7 +2498,7 @@ class Command:
 		"""
 
 		if type(host) == type([]):
-			params = host
+			params = host.copy()
 		else:
 			params = [host]
 

--- a/common/src/stack/command/stack/commands/list/host/plugin_basic.py
+++ b/common/src/stack/command/stack/commands/list/host/plugin_basic.py
@@ -49,6 +49,15 @@ class Plugin(stack.commands.Plugin):
 			if row[0] in host_info:
 				host_info[row[0]].extend(row[1:])
 
+		kickable_hosts = self.owner.getHostAttrDict(hosts, 'kickstartable')
+
+		for host in hosts:
+			if not self.owner.str2bool(kickable_hosts[host]['kickstartable']):
+				# Installaction
+				host_info[host][-1] = None
+				# osaction
+				host_info[host][-2] = None
+
 		keys.extend(['rack', 'rank',
 			     'appliance',
 			     'os', 'box',

--- a/test-framework/test-suites/integration/tests/list/test_list_host.py
+++ b/test-framework/test-suites/integration/tests/list/test_list_host.py
@@ -74,3 +74,24 @@ class TestListHost:
 			'rack': '0',
 			'rank': '0'
 		}]
+
+	def test_lookup_non_kickstartable(self, host, add_host, host_os):
+		# Set the host to non-kickstartable
+		result = host.run('stack set host attr backend-0-0 attr=kickstartable value=false')
+		assert result.rc == 0
+
+		# List the host
+		result = host.run('stack list host backend-0-0 output-format=json')
+		assert result.rc == 0
+		assert json.loads(result.stdout) == [{
+			'appliance': 'backend',
+			'box': 'default',
+			'comment': None,
+			'environment': None,
+			'host': 'backend-0-0',
+			'installaction': None,
+			'os': host_os,
+			'osaction': None,
+			'rack': '0',
+			'rank': '0'
+		}]


### PR DESCRIPTION
JIRA: https://jira.td.teradata.com/jira/browse/STACKI-1541

When a node's kickstartable attribute is set to False, the OS and Install action columns in list host should show blanks instead of the normal values. This is because the kickstartable attribute being set to False indicates Stacki isn't managing it via pxe boot so another visual clue to the user that this is the case could reduce potential confusion about why a node isn't pxe booting.

Current:
```
HOST            RACK RANK APPLIANCE       OS   BOX      ENVIRONMENT OSACTION INSTALLACTION COMMENT
sd-stacki-132   0    0    frontend        sles frontend ----------- default  default       -------
ethernet-230-1  230  1    switch          sles default  ----------- default  default       -------
vms-230-11      230  11   vms             sles default  ----------- default  default       -------
stacki-230-20   230  20   backend1        sles default  ----------- default  console       -------
stacki-230-21   230  21   backend1        sles default  ----------- default  console       -------
stacki-230-23   230  23   backend         sles default  ----------- default  console       -------
stacki-230-29   230  29   backend         sles default  ----------- default  console       -------
stacki-230-31   230  31   backend1        sles default  ----------- default  console       -------
ethernet-230-43 230  43   switch          sles default  ----------- default  default       -------
cmic-230-63     230  63   cmic            sles default  ----------- default  default       -------
sws-230-70      230  70   sws             sles default  ----------- default  default       -------
vp-230-71       230  71   viewpoint       sles default  ----------- default  default       -------
snapi-230-72    230  72   virtual-machine sles default  ----------- default  default       -------
vini-2-73       230  73   virtual-machine sles default  ----------- default  default       -------
```

Changes:
```
HOST            RACK RANK APPLIANCE       OS   BOX      ENVIRONMENT OSACTION INSTALLACTION COMMENT
sd-stacki-132   0    0    frontend        sles frontend ----------- default  default       -------
ethernet-230-1  230  1    switch          sles default  ----------- -------- ------------- -------
vms-230-11      230  11   vms             sles default  ----------- -------- ------------- -------
stacki-230-20   230  20   backend1        sles default  ----------- -------- ------------- -------
stacki-230-21   230  21   backend1        sles default  ----------- -------- ------------- -------
stacki-230-23   230  23   backend         sles default  ----------- default  console       -------
stacki-230-29   230  29   backend         sles default  ----------- default  console       -------
stacki-230-31   230  31   backend1        sles default  ----------- -------- ------------- -------
ethernet-230-43 230  43   switch          sles default  ----------- -------- ------------- -------
cmic-230-63     230  63   cmic            sles default  ----------- default  default       -------
sws-230-70      230  70   sws             sles default  ----------- default  default       -------
vp-230-71       230  71   viewpoint       sles default  ----------- default  default       -------
snapi-230-72    230  72   virtual-machine sles default  ----------- -------- ------------- -------
vini-2-73       230  73   virtual-machine sles default  ----------- -------- ------------- -------
```

Kickstartable Attributes:
```
cmic-230-63     appliance var    kickstartable                  True
ethernet-230-1  appliance var    kickstartable                  False
ethernet-230-43 appliance var    kickstartable                  False
sd-stacki-132   appliance var    kickstartable                  True
snapi-230-72    appliance var    kickstartable                  False
stacki-230-20   appliance var    kickstartable                  False
stacki-230-21   appliance var    kickstartable                  False
stacki-230-23   appliance var    kickstartable                  True
stacki-230-29   appliance var    kickstartable                  True
stacki-230-31   appliance var    kickstartable                  False
sws-230-70      appliance var    kickstartable                  True
vini-2-73       appliance var    kickstartable                  False
vms-230-11      appliance var    kickstartable                  false
vp-230-71       appliance var    kickstartable                  True
```