### PR TITLE
BUGFIX: Fix eth1 for the Backends under KVM

### DIFF
--- a/tools/cluster-up/Vagrantfile
+++ b/tools/cluster-up/Vagrantfile
@@ -183,7 +183,6 @@ if File.file?('.vagrant/cluster-up.json')
         else
           config.vm.network "private_network",
             mac: sprintf("5254000000%02X", i+3),
-            type: "dhcp",
             virtualbox__intnet: NAME,
             libvirt__network_name: NAME,
             libvirt__dhcp_enabled: false,


### PR DESCRIPTION
If you set the network type to "dhcp" under vagrant-libvirt, it doesn't choose the correct named network.

I confirmed that this allows `cluster-up` to properly provision backends under both Virtualbox and KVM.