### PR TITLE
BUGFIX: Log pallet hook information to syslog

### DIFF
--- a/common/src/stack/command/stack/argument_processors/pallet.py
+++ b/common/src/stack/command/stack/argument_processors/pallet.py
@@ -2,6 +2,7 @@ import pathlib
 from operator import attrgetter
 import re
 import subprocess
+from stack.commands import Log
 from dataclasses import dataclass
 import jsoncomment
 from stack.exception import ArgNotFound
@@ -117,6 +118,7 @@ class PalletArgProcessor:
 		json_comment = jsoncomment.JsonComment()
 		for hook_file in hook_metadata_files:
 			hook_metadata = json_comment.loads(hook_file.read_text())
+			Log(f'{operation} pallet hook file found: {str(hook_file)}.')
 
 			# Check if any scripts called out in the file should be run.
 			# This should only happen if all conditions are satisfied and we
@@ -149,8 +151,12 @@ class PalletArgProcessor:
 		# Execute the hooks in name sorted order.
 		for hook in hooks:
 			self.notify(f'running hook: {hook}')
+			Log(f'Running {operation} pallet hook for pallet {"-".join(pallet_info_getter(pallet_info))}: {hook} ')
 			try:
-				self._exec(['/usr/bin/env', str(hook)], cwd=hook.parent, check=True)
+				result = self._exec(['/usr/bin/env', str(hook)], cwd=hook.parent, check=True)
+				Log(f'Result of running {hook} (rc=={result.returncode}):')
+				Log(f'Stdout:\n{result.stdout}')
+				Log(f'Stderr:\n{result.stderr}')
 			except (PermissionError, subprocess.CalledProcessError) as exception:
 				msg = f'Unable to run hook {hook}:\n\n{exception}\n'
 				# CalledProcessError has additional info...


### PR DESCRIPTION
in _get_pallet_hooks():
```
/var/log/local0:2020-04-22T16:18:43.822271+00:00 frontend-0-0 SCL[8661]: add pallet hook file: /opt/stack/pallet_hooks/stacki-5.5rc1_20200420_cc54900-sles12-x86_64-sles/sles/pallet_hooks/pallet_hooks.json.
```

in run_pallet_hooks():
```
/var/log/localmessages-2020-04-22T16:48:09.953035+00:00 localhost SCL[7293]: Running enable pallet hook for pallet stacki-5.5rc1_20200420_cc54900-sles12-x86_64-sles: /opt/stack/pallet_hooks/stacki-5.5rc1_20200420_cc54900-sles12-x86_64-sles/sles/pallet_hooks/stacki-sles12/010-add-stacki-images.sh
/var/log/localmessages:2020-04-22T16:48:11.240213+00:00 localhost SCL[7293]: Result of running /opt/stack/pallet_hooks/stacki-5.5rc1_20200420_cc54900-sles12-x86_64-sles/sles/pallet_hooks/stacki-sles12/010-add-stacki-images.sh (rc==0):
/var/log/localmessages-2020-04-22T16:48:11.240401+00:00 localhost SCL[7293]: Stdout:#012Building repository 'os' cache [....done]#012Loading repository data...#012Reading installed packages...#012'stack-sles-sles12-images' is already installed.#012Package 'stack-sles-sles12-images' is not available in your repositories. Cannot reinstall, upgrade, or downgrade.#012Resolving package dependencies...#012#012Nothing to do.
/var/log/localmessages-2020-04-22T16:48:11.240492+00:00 localhost SCL[7293]: Stderr:
```