### PR TITLE
BUGFIX: not sure why xinetd is still being installed (it was used for…

### DIFF
--- a/common/nodes/pxe.xml
+++ b/common/nodes/pxe.xml
@@ -20,7 +20,6 @@ stack-&os;-&release;-images
 
 <stack:package>
 syslinux
-xinetd
 stack-pxeboot
 </stack:package>
 


### PR DESCRIPTION
… managing tftp, but systemd does that now)