### PR TITLE
INTERNAL: Pack authorized_keys into VM images that lack a .ssh dir

### DIFF
--- a/test-framework/test-suites/unit/tests/command/stack/commands/sync/vm/test_sync_vm_plugin_storage.py
+++ b/test-framework/test-suites/unit/tests/command/stack/commands/sync/vm/test_sync_vm_plugin_storage.py
@@ -439,7 +439,7 @@ class TestSyncVmStorage:
 		# to simulate all commands executing successfully
 		mock_completed_process.returncode = 0
 		mock_exec.return_value = mock_completed_process
-		key_dir = '/tmp/foo_keys'
+		key_dir = Path('/tmp/foo_keys/.ssh')
 
 		disk = {
 			'Name': 'disk1',
@@ -457,17 +457,17 @@ class TestSyncVmStorage:
 		# values
 		expect_calls = [
 			call(f'ssh hypervisor-foo "mkdir -p {key_dir}"', shlexsplit=True),
-			call(f'scp /root/.ssh/id_rsa.pub hypervisor-foo:{key_dir}/frontend_key', shlexsplit=True),
+			call(f'scp /root/.ssh/id_rsa.pub hypervisor-foo:{key_dir.parent}/frontend_key', shlexsplit=True),
 			call(f'ssh hypervisor-foo "virt-copy-out -a loc/disk_name /root/.ssh/authorized_keys {key_dir}"',
 				shlexsplit=True
 			),
-			call(f'ssh hypervisor-foo "cat {key_dir}/frontend_key >> {key_dir}/authorized_keys"',
+			call(f'ssh hypervisor-foo "cat {key_dir.parent}/frontend_key >> {key_dir}/authorized_keys"',
 				shlexsplit=True
 			),
-			call(f'ssh hypervisor-foo "virt-copy-in -a loc/disk_name {key_dir}/authorized_keys /root/.ssh/"',
+			call(f'ssh hypervisor-foo "virt-copy-in -a loc/disk_name {key_dir} /root"',
 				shlexsplit=True
 			),
-			call(shlex.split(f'ssh hypervisor-foo "rm -r {key_dir}"'))
+			call(shlex.split(f'ssh hypervisor-foo "rm -r {key_dir.parent}"'))
 		]
 		assert output is None and mock_exec.call_args_list == expect_calls
 


### PR DESCRIPTION
This tweaks a feature of the storage plugin of sync vm that packs the frontend's ssh key into the authorized keys file of a premade VM image. Before if there was no /root/.ssh directory, the feature would fail but now it takes advantage of `virt-copy-in` (the utility to put stuff into VM images) recursive directory copying to create a .ssh folder effectively if it doesn't exist. 

I've tested to make sure it doesn't overwrite the contents of an existing .ssh folder, and like before will only append to `authorized_keys` if it exists as well.