### PR TITLE
INTERNAL: Add VM info to ansible dynamic inventory plugin

### DIFF
--- a/common/src/stack/ansible/plugins/inventory/stacki.py
+++ b/common/src/stack/ansible/plugins/inventory/stacki.py
@@ -129,3 +129,23 @@ class InventoryModule(BaseInventoryPlugin):
 				pass
 
 			self.inventory.set_variable(row["host"], "stacki_%s" % row["attr"], value)
+
+		# Add VM values for virtual machine hosts
+		for row in stack.api.Call("list vm"):
+			name = row["virtual machine"]
+
+			self.inventory.set_variable(name, "stacki_vm_cpu", row["cpu"])
+			self.inventory.set_variable(name, "stacki_vm_memory", row["memory"])
+			self.inventory.set_variable(name, "stacki_vm_hypervisor", row["hypervisor"])
+
+		# Add VM storage info
+		for row in stack.api.Call("list vm storage"):
+			host = row["Virtual Machine"]
+			name = row["Name"]
+
+			self.inventory.set_variable(host, f"stacki_vm_disk_{name}_name", row["Name"])
+			self.inventory.set_variable(host, f"stacki_vm_disk_{name}_type", row["Type"])
+			self.inventory.set_variable(host, f"stacki_vm_disk_{name}_location", row["Location"])
+			self.inventory.set_variable(host, f"stacki_vm_disk_{name}_size", row["Size"])
+			self.inventory.set_variable(host, f"stacki_vm_disk_{name}_image", row["Image Name"])
+			self.inventory.set_variable(host, f"stacki_vm_disk_{name}_mountpoint", row["Mountpoint"])

--- a/test-framework/test-suites/integration/tests/ansible/test_ansible_dynamic_inventory.py
+++ b/test-framework/test-suites/integration/tests/ansible/test_ansible_dynamic_inventory.py
@@ -50,3 +50,25 @@ class TestAnsibleDynamicInventory:
 		# Check that our added attributes exist
 		assert inventory["_meta"]["hostvars"]["frontend-0-0"]["stacki_foo"] == "frontend"
 		assert inventory["_meta"]["hostvars"]["backend-0-0"]["stacki_bar"] == "backend"
+
+	def test_vm_attributes(self, add_hypervisor, add_vm, host):
+		"""
+		Test the plugin creates vars for VM host information
+		"""
+
+		result = host.run("ansible-inventory --list")
+		assert result.rc == 0
+		inventory = json.loads(result.stdout)
+
+		# Check basic VM related data is added
+		assert inventory["_meta"]["hostvars"]["vm-backend-0-3"]["stacki_vm_cpu"] == 1
+		assert inventory["_meta"]["hostvars"]["vm-backend-0-3"]["stacki_vm_memory"] == 2048
+		assert inventory["_meta"]["hostvars"]["vm-backend-0-3"]["stacki_vm_hypervisor"] == "hypervisor-0-1"
+
+		# Check for VM storage info
+		assert inventory["_meta"]["hostvars"]["vm-backend-0-3"]["stacki_vm_disk_sda_name"] == "sda"
+		assert inventory["_meta"]["hostvars"]["vm-backend-0-3"]["stacki_vm_disk_sda_size"] == 100
+		assert inventory["_meta"]["hostvars"]["vm-backend-0-3"]["stacki_vm_disk_sda_image"] == "vm-backend-0-3_disk1.qcow2"
+		assert inventory["_meta"]["hostvars"]["vm-backend-0-3"]["stacki_vm_disk_sda_location"] == "/export/pools/stacki/vm-backend-0-3"
+		assert inventory["_meta"]["hostvars"]["vm-backend-0-3"]["stacki_vm_disk_sda_mountpoint"] == None
+		assert inventory["_meta"]["hostvars"]["vm-backend-0-3"]["stacki_vm_disk_sda_type"] == "disk"


### PR DESCRIPTION
This adds VM information into the Stacki ansible dynamic inventory plugin.