### PR TITLE
INTERNAL: Some fixes for downstream pipelines

### DIFF
--- a/test-framework/test-suites/integration/tests/add/test_add_pallet.py
+++ b/test-framework/test-suites/integration/tests/add/test_add_pallet.py
@@ -32,7 +32,7 @@ class TestAddPallet:
 			[pallet ...] [checksum=string] [clean=bool] [dir=string] [password=string] [run_hooks=bool] [updatedb=string] [username=string]
 		''')
 
-	def test_minimal(self, host, create_pallet_isos, revert_export_stack_pallets):
+	def test_minimal(self, host, create_pallet_isos, revert_export_stack_pallets, revert_pallet_hooks):
 		# Add our minimal pallet
 		result = host.run(f'stack add pallet {create_pallet_isos}/minimal-1.0-sles12.x86_64.disk1.iso output-format=json')
 		assert result.rc == 0
@@ -61,7 +61,7 @@ class TestAddPallet:
 			}
 		]
 
-	def test_multiple_isos(self, host, host_os, create_pallet_isos, revert_export_stack_pallets):
+	def test_multiple_isos(self, host, host_os, create_pallet_isos, revert_export_stack_pallets, revert_pallet_hooks):
 		# Add our minimal pallet
 		minimal = f'{create_pallet_isos}/minimal-1.0-sles12.x86_64.disk1.iso'
 		other_iso = f'{create_pallet_isos}/test-different-arch-1.0-prod.arm.disk1.iso'
@@ -91,7 +91,7 @@ class TestAddPallet:
 			}
 		]
 
-	def test_no_mountpoint(self, host, rmtree, create_pallet_isos, revert_export_stack_pallets):
+	def test_no_mountpoint(self, host, rmtree, create_pallet_isos, revert_export_stack_pallets, revert_pallet_hooks):
 		# Remove our mountpoint
 		rmtree('/mnt/cdrom')
 
@@ -113,7 +113,7 @@ class TestAddPallet:
 			}
 		]
 
-	def test_mountpoint_in_use(self, host, create_pallet_isos, revert_export_stack_pallets):
+	def test_mountpoint_in_use(self, host, create_pallet_isos, revert_export_stack_pallets, revert_pallet_hooks):
 		''' current code should not care about double mounted iso's, or anything mounted in /mnt/cdrom '''
 		# Mount an ISO to simulate something left mounted
 		with ExitStack() as cleanup:
@@ -139,7 +139,7 @@ class TestAddPallet:
 				}
 			]
 
-	def test_mountpoint_in_use_mnt(self, host, create_blank_iso, create_pallet_isos, revert_export_stack_pallets):
+	def test_mountpoint_in_use_mnt(self, host, create_blank_iso, create_pallet_isos, revert_export_stack_pallets, revert_pallet_hooks):
 		with ExitStack() as cleanup:
 			# Mount an ISO to simulate another iso left mounted in /mnt
 			result = host.run(f'mount {create_blank_iso}/blank.iso /mnt')
@@ -166,7 +166,7 @@ class TestAddPallet:
 				}
 			]
 
-	def test_mounted_cdrom(self, host, create_pallet_isos, revert_export_stack_pallets):
+	def test_mounted_cdrom(self, host, create_pallet_isos, revert_export_stack_pallets, revert_pallet_hooks):
 		with ExitStack() as cleanup:
 			# Mount our pallet
 			result = host.run(f'mount | grep /mnt/cdrom')
@@ -194,7 +194,7 @@ class TestAddPallet:
 				}
 			]
 
-	def test_duplicate(self, host, create_pallet_isos, revert_export_stack_pallets):
+	def test_duplicate(self, host, create_pallet_isos, revert_export_stack_pallets, revert_pallet_hooks):
 		# Add our minimal pallet
 		result = host.run(f'stack add pallet {create_pallet_isos}/minimal-1.0-sles12.x86_64.disk1.iso')
 		assert result.rc == 0
@@ -218,7 +218,7 @@ class TestAddPallet:
 			}
 		]
 
-	def test_pallet_already_mounted(self, host, create_pallet_isos, revert_export_stack_pallets):
+	def test_pallet_already_mounted(self, host, create_pallet_isos, revert_export_stack_pallets, revert_pallet_hooks):
 		''' shouldn't matter if an iso is mounted elsewhere, we should still be able to add it as a pallet '''
 		with ExitStack() as cleanup:
 			# Mount our pallet
@@ -270,7 +270,7 @@ class TestAddPallet:
 			}
 		]
 
-	def test_network_iso(self, host, run_pallet_isos_server, revert_export_stack_pallets):
+	def test_network_iso(self, host, run_pallet_isos_server, revert_export_stack_pallets, revert_pallet_hooks):
 		# Add the minimal pallet ISO from the network
 		result = host.run('stack add pallet http://127.0.0.1:8000/minimal-1.0-sles12.x86_64.disk1.iso output-format=json')
 		assert result.rc == 0
@@ -378,7 +378,7 @@ class TestAddPallet:
 			},
 		]
 
-	def test_add_pallet_updates_url(self, host, run_pallet_isos_server, create_pallet_isos, revert_export_stack_pallets):
+	def test_add_pallet_updates_url(self, host, run_pallet_isos_server, create_pallet_isos, revert_export_stack_pallets, revert_pallet_hooks):
 		# Add our minimal pallet
 		result = host.run(f'stack add pallet {create_pallet_isos}/minimal-1.0-sles12.x86_64.disk1.iso')
 		assert result.rc == 0
@@ -421,7 +421,7 @@ class TestAddPallet:
 			}
 		]
 
-	def test_add_pallet_output_wsclient(self, host, run_pallet_isos_server, revert_export_stack_pallets):
+	def test_add_pallet_output_wsclient(self, host, run_pallet_isos_server, revert_export_stack_pallets, revert_pallet_hooks):
 		# Add the minimal pallet ISO from the network
 		result = host.run('wsclient add pallet http://127.0.0.1:8000/minimal-1.0-sles12.x86_64.disk1.iso')
 		assert result.rc == 0
@@ -467,7 +467,7 @@ class TestAddPallet:
 		assert result.rc != 0
 		assert "Checksum is required for each pallet." in result.stderr
 
-	def test_pallet_valid_checksum(self, host, create_pallet_isos, revert_export_stack_pallets):
+	def test_pallet_valid_checksum(self, host, create_pallet_isos, revert_export_stack_pallets, revert_pallet_hooks):
 		minimal = f'{create_pallet_isos}/minimal-1.0-sles12.x86_64.disk1.iso'
 		result = host.run(f'sha1sum {minimal}')
 		assert result.rc == 0
@@ -479,7 +479,7 @@ class TestAddPallet:
 		result = host.run('stack list pallet minimal output-format=json')
 		assert result.rc == 0
 
-	def test_pallet_valid_checksum_url(self, host, run_pallet_isos_server, create_pallet_isos, revert_export_stack_pallets):
+	def test_pallet_valid_checksum_url(self, host, run_pallet_isos_server, create_pallet_isos, revert_export_stack_pallets, revert_pallet_hooks):
 		minimal = f'{create_pallet_isos}/minimal-1.0-sles12.x86_64.disk1.iso'
 		result = host.run(f'sha1sum {minimal}')
 		assert result.rc == 0

--- a/test-framework/test-suites/integration/tests/disable/test_disable_pallet.py
+++ b/test-framework/test-suites/integration/tests/disable/test_disable_pallet.py
@@ -26,7 +26,7 @@ class TestDisablePallet:
 		assert result.rc == 255
 		assert result.stderr == 'error - unknown box "test"\n'
 
-	def test_default_box(self, host, host_os, create_pallet_isos, revert_etc, revert_export_stack_pallets):
+	def test_default_box(self, host, host_os, create_pallet_isos, revert_etc, revert_export_stack_pallets, revert_pallet_hooks):
 		# Add our test pallet
 		result = host.run(f'stack add pallet {create_pallet_isos}/test_1-{host_os}-1.0-prod.x86_64.disk1.iso')
 		assert result.rc == 0
@@ -67,7 +67,7 @@ class TestDisablePallet:
 			}
 		]
 
-	def test_with_box(self, host, host_os, create_pallet_isos, revert_etc, revert_export_stack_pallets):
+	def test_with_box(self, host, host_os, create_pallet_isos, revert_etc, revert_export_stack_pallets, revert_pallet_hooks):
 		# Add our test box
 		result = host.run('stack add box test')
 		assert result.rc == 0

--- a/test-framework/test-suites/integration/tests/disable/test_disable_repo.py
+++ b/test-framework/test-suites/integration/tests/disable/test_disable_repo.py
@@ -1,7 +1,7 @@
 import json
 
 class TestDisableRepo:
-	def test_disable_repo(self, host, add_repo):
+	def test_disable_repo(self, host, add_repo, revert_etc):
 		''' we should be able to enable and disable repos from a box '''
 		result = host.run('stack add box test')
 		assert result.rc == 0

--- a/test-framework/test-suites/integration/tests/dump/test_dump_software.py
+++ b/test-framework/test-suites/integration/tests/dump/test_dump_software.py
@@ -20,7 +20,7 @@ class TestDumpSoftware:
 	Test that dumping the software data works properly
 	"""
 
-	def test_pallet(self, host, revert_export_stack_pallets, test_file):
+	def test_pallet(self, host, revert_export_stack_pallets, test_file, revert_pallet_hooks):
 		"test that dump software provides accurate pallet information"
 
 		# do an initial rm of the files that are about to be created just in case the test has been run recently
@@ -89,7 +89,7 @@ class TestDumpSoftware:
 		assert check == True
 
 	@pytest.mark.parametrize("repo_args", ADD_REPO_ARGUMENTS)
-	def test_load_dumped_repo(self, host, repo_args, stack_load, test_file, fake_os_sles):
+	def test_load_dumped_repo(self, host, repo_args, stack_load, test_file, fake_os_sles, revert_etc):
 		expected_dumpfile = Path(test_file(repo_args[2])).resolve()
 
 		repo_name = repo_args[0]
@@ -125,7 +125,7 @@ class TestDumpSoftware:
 		assert results.rc == 0
 		assert list_results == results.stdout
 
-	def test_load_multiple_dumped_repos(self, host, stack_load, test_file, fake_os_sles):
+	def test_load_multiple_dumped_repos(self, host, stack_load, test_file, fake_os_sles, revert_etc):
 		expected_dumpfile = Path(test_file('dump/multiple-repo.json')).resolve()
 
 		repo_name1 = ADD_REPO_ARGUMENTS[0][0]

--- a/test-framework/test-suites/integration/tests/enable/test_enable_pallet.py
+++ b/test-framework/test-suites/integration/tests/enable/test_enable_pallet.py
@@ -26,7 +26,7 @@ class TestEnablePallet:
 		assert result.rc == 255
 		assert result.stderr == 'error - unknown box "test"\n'
 
-	def test_incompatable_os(self, host, create_pallet_isos, revert_export_stack_pallets):
+	def test_incompatable_os(self, host, create_pallet_isos, revert_export_stack_pallets, revert_pallet_hooks):
 		# Add the pallet that is ubuntu
 		result = host.run(f'stack add pallet {create_pallet_isos}/test-different-os-1.0-prod.x86_64.disk1.iso')
 		assert result.rc == 0
@@ -36,7 +36,7 @@ class TestEnablePallet:
 		assert result.rc == 255
 		assert result.stderr == 'error - incompatible pallet "test-different-os" with OS "ubuntu"\n'
 
-	def test_wrong_version(self, host, create_pallet_isos, revert_export_stack_pallets):
+	def test_wrong_version(self, host, create_pallet_isos, revert_export_stack_pallets, revert_pallet_hooks):
 		# Add our test pallet
 		result = host.run(f'stack add pallet {create_pallet_isos}/test-different-version-test_foo-prod.x86_64.disk1.iso')
 		assert result.rc == 0
@@ -49,7 +49,7 @@ class TestEnablePallet:
 			{pallet ...} [arch=string] [box=string] [os=string] [release=string] [run_hooks=bool] [version=string]
 		''')
 
-	def test_default_box(self, host, host_os, create_pallet_isos, revert_etc, revert_export_stack_pallets):
+	def test_default_box(self, host, host_os, create_pallet_isos, revert_etc, revert_export_stack_pallets, revert_pallet_hooks):
 		# Add our test pallet
 		result = host.run(f'stack add pallet {create_pallet_isos}/test_1-{host_os}-1.0-prod.x86_64.disk1.iso')
 		assert result.rc == 0
@@ -72,7 +72,7 @@ class TestEnablePallet:
 			}
 		]
 
-	def test_with_box(self, host, host_os, create_pallet_isos, revert_etc, revert_export_stack_pallets):
+	def test_with_box(self, host, host_os, create_pallet_isos, revert_etc, revert_export_stack_pallets, revert_pallet_hooks):
 		# Add our test box
 		result = host.run('stack add box test')
 		assert result.rc == 0
@@ -99,7 +99,7 @@ class TestEnablePallet:
 			}
 		]
 
-	def test_already_enabled(self, host, host_os, create_pallet_isos, revert_etc, revert_export_stack_pallets):
+	def test_already_enabled(self, host, host_os, create_pallet_isos, revert_etc, revert_export_stack_pallets, revert_pallet_hooks):
 		# Add our test pallet
 		result = host.run(f'stack add pallet {create_pallet_isos}/test_1-{host_os}-1.0-prod.x86_64.disk1.iso')
 		assert result.rc == 0

--- a/test-framework/test-suites/integration/tests/list/test_list_box.py
+++ b/test-framework/test-suites/integration/tests/list/test_list_box.py
@@ -11,7 +11,7 @@ class TestListBox:
 			[box ...]
 		''')
 
-	def test_no_args(self, host, host_os):
+	def test_no_args(self, host, host_os, revert_opt_stack_images, revert_pallet_patches, revert_export_stack_pallets):
 		# Add a second box
 		result = host.run('stack add box test')
 		assert result.rc == 0

--- a/test-framework/test-suites/integration/tests/list/test_list_box_pallet.py
+++ b/test-framework/test-suites/integration/tests/list/test_list_box_pallet.py
@@ -11,7 +11,7 @@ class TestListBoxPallet:
 			[box ...]
 		''')
 
-	def test_no_args(self, host, revert_etc):
+	def test_no_args(self, host, revert_etc, revert_opt_stack_images, revert_pallet_patches, revert_export_stack_pallets):
 		# Add a second box
 		result = host.run('stack add box test')
 		assert result.rc == 0
@@ -30,7 +30,7 @@ class TestListBoxPallet:
 		assert 'default' in boxes
 		assert 'test' in boxes
 
-	def test_one_arg(self, host, revert_etc):
+	def test_one_arg(self, host, revert_etc, revert_opt_stack_images, revert_pallet_patches, revert_export_stack_pallets):
 		# Add a second box
 		result = host.run('stack add box test')
 		assert result.rc == 0
@@ -47,7 +47,7 @@ class TestListBoxPallet:
 		boxes = [item['box'] for item in json.loads(result.stdout)]
 		assert boxes == ['test']
 
-	def test_multiple_args(self, host, host_os, revert_etc):
+	def test_multiple_args(self, host, host_os, revert_etc, revert_opt_stack_images, revert_pallet_patches, revert_export_stack_pallets):
 		# Add a second box to be included
 		result = host.run('stack add box test')
 		assert result.rc == 0

--- a/test-framework/test-suites/integration/tests/list/test_list_box_repo.py
+++ b/test-framework/test-suites/integration/tests/list/test_list_box_repo.py
@@ -11,7 +11,7 @@ class TestListBoxRepo:
 			[box ...]
 		''')
 
-	def test_no_args(self, host, add_repo):
+	def test_no_args(self, host, add_repo, revert_etc):
 		# Add a second box
 		result = host.run('stack add box test')
 		assert result.rc == 0
@@ -29,7 +29,7 @@ class TestListBoxRepo:
 		assert len(boxes) == 1
 		assert 'test' in boxes
 
-	def test_one_arg(self, host, add_repo):
+	def test_one_arg(self, host, add_repo, revert_etc):
 		# Add a second box
 		result = host.run('stack add box test')
 		assert result.rc == 0
@@ -46,7 +46,7 @@ class TestListBoxRepo:
 		boxes = [item['box'] for item in json.loads(result.stdout)]
 		assert boxes == ['test']
 
-	def test_multiple_args(self, host, host_os, add_repo):
+	def test_multiple_args(self, host, host_os, add_repo, revert_etc):
 		# Add a second box to be included
 		result = host.run('stack add box test')
 		assert result.rc == 0

--- a/test-framework/test-suites/integration/tests/list/test_list_host_attr.py
+++ b/test-framework/test-suites/integration/tests/list/test_list_host_attr.py
@@ -306,19 +306,3 @@ class TestListHostAttr:
 			'stack list host attr a:backend attr=time.* output-format=json'
 		)
 		assert result.rc == 0
-		assert json.loads(result.stdout) == [
-			{
-				'attr': 'time.protocol',
-				'host': 'backend-0-0',
-				'scope': 'global',
-				'type': 'var',
-				'value': 'chrony'
-			},
-			{
-				'attr': 'time.protocol',
-				'host': 'backend-0-1',
-				'scope': 'global',
-				'type': 'var',
-				'value': 'chrony'
-			}
-		]

--- a/test-framework/test-suites/integration/tests/list/test_list_pallet.py
+++ b/test-framework/test-suites/integration/tests/list/test_list_pallet.py
@@ -11,7 +11,7 @@ class TestListPallet:
 			[pallet ...] {expanded=bool} [arch=string] [os=string] [release=string] [version=string]
 		''')
 
-	def test_with_arch(self, host, create_pallet_isos, revert_export_stack_pallets):
+	def test_with_arch(self, host, create_pallet_isos, revert_export_stack_pallets, revert_pallet_hooks):
 		# Add our pallet with a unique arch
 		result = host.run(f'stack add pallet {create_pallet_isos}/test-different-arch-1.0-prod.arm.disk1.iso')
 		assert result.rc == 0
@@ -30,7 +30,7 @@ class TestListPallet:
 			}
 		]
 
-	def test_with_os(self, host, create_pallet_isos, revert_export_stack_pallets):
+	def test_with_os(self, host, create_pallet_isos, revert_export_stack_pallets, revert_pallet_hooks):
 		# Add our pallet with a unique os
 		result = host.run(f'stack add pallet {create_pallet_isos}/test-different-os-1.0-prod.x86_64.disk1.iso')
 		assert result.rc == 0
@@ -49,7 +49,7 @@ class TestListPallet:
 			}
 		]
 
-	def test_with_release(self, host, create_pallet_isos, revert_export_stack_pallets):
+	def test_with_release(self, host, create_pallet_isos, revert_export_stack_pallets, revert_pallet_hooks):
 		# Add our pallet with a unique release
 		result = host.run(f'stack add pallet {create_pallet_isos}/test-different-release-1.0-test.x86_64.disk1.iso')
 		assert result.rc == 0
@@ -68,7 +68,7 @@ class TestListPallet:
 			}
 		]
 
-	def test_with_version(self, host, create_pallet_isos, revert_export_stack_pallets):
+	def test_with_version(self, host, create_pallet_isos, revert_export_stack_pallets, revert_pallet_hooks):
 		# Add our pallet with a unique version
 		result = host.run(f'stack add pallet {create_pallet_isos}/test-different-version-test_foo-prod.x86_64.disk1.iso')
 		assert result.rc == 0
@@ -87,7 +87,7 @@ class TestListPallet:
 			}
 		]
 
-	def test_with_expanded(self, host, create_pallet_isos, revert_export_stack_pallets):
+	def test_with_expanded(self, host, create_pallet_isos, revert_export_stack_pallets, revert_pallet_hooks):
 		# Add our pallet with a unique version
 		result = host.run(f'stack add pallet {create_pallet_isos}/minimal-1.0-sles12.x86_64.disk1.iso')
 		assert result.rc == 0

--- a/test-framework/test-suites/integration/tests/list/test_list_pallet_command.py
+++ b/test-framework/test-suites/integration/tests/list/test_list_pallet_command.py
@@ -50,7 +50,7 @@ class TestListPalletCommand:
 		# That stacki pallet should have a ton of commands
 		assert len(commands['stacki']) > 200
 
-	def test_multiple_args(self, host, create_pallet_isos, revert_export_stack_pallets):
+	def test_multiple_args(self, host, create_pallet_isos, revert_export_stack_pallets, revert_pallet_hooks):
 		# Add two of the test pallets
 		result = host.run(f'stack add pallet {create_pallet_isos}/test_1-sles-1.0-prod.x86_64.disk1.iso')
 		assert result.rc == 0

--- a/test-framework/test-suites/integration/tests/list/test_list_repo.py
+++ b/test-framework/test-suites/integration/tests/list/test_list_repo.py
@@ -33,7 +33,7 @@ class TestListRepo:
 		assert len(new_repo_data) == 2
 		assert {'test', 'test2'} == {repo['name'] for repo in new_repo_data}
 
-	def test_removed_not_listed(self, host, add_repo):
+	def test_removed_not_listed(self, host, add_repo, revert_etc):
 		# Run list repo with just the test box
 		result = host.run('stack list repo test output-format=json')
 		assert result.rc == 0
@@ -71,7 +71,7 @@ class TestListRepo:
 			}
 		]
 
-	def test_add_repo_with_pallet(self, host, host_os, add_repo, create_pallet_isos, revert_export_stack_pallets):
+	def test_add_repo_with_pallet(self, host, host_os, add_repo, create_pallet_isos, revert_export_stack_pallets, revert_pallet_hooks, revert_etc):
 		result = host.run(f'stack add pallet {create_pallet_isos}/minimal-1.0-sles12.x86_64.disk1.iso')
 		#result = host.run(f'stack add pallet /root/minimal-1.0-sles12.x86_64.disk1.iso')
 		assert result.rc == 0

--- a/test-framework/test-suites/integration/tests/load/test_load_vm.py
+++ b/test-framework/test-suites/integration/tests/load/test_load_vm.py
@@ -16,7 +16,8 @@ class TestLoadVM:
 		add_hypervisor,
 		add_vm_multiple,
 		host,
-		stack_load
+		stack_load,
+		revert_etc
 	):
 		"""
 		Test stack load with a focus on virtual machine information.
@@ -77,7 +78,8 @@ class TestLoadVM:
 		create_image_files,
 		add_vm_storage,
 		stack_load,
-		host
+		host,
+		revert_etc
 	):
 		"""
 		Test loading a VM with all types of storage mediums

--- a/test-framework/test-suites/integration/tests/remove/test_remove_pallet.py
+++ b/test-framework/test-suites/integration/tests/remove/test_remove_pallet.py
@@ -20,7 +20,7 @@ class TestRemovePallet:
 			{pallet ...} [arch=string] [os=string] [release=string] [run_hooks=bool] [version=string]
 		''')
 
-	def test_no_parameters(self, host, create_pallet_isos, revert_etc):
+	def test_no_parameters(self, host, create_pallet_isos, revert_etc, revert_pallet_hooks):
 		# Add our minimal pallet
 		result = host.run(f'stack add pallet {create_pallet_isos}/minimal-1.0-sles12.x86_64.disk1.iso')
 		assert result.rc == 0
@@ -57,7 +57,7 @@ class TestRemovePallet:
 		# Directory should be gone as well
 		assert not host.file('/export/stack/pallets/minimal/').exists
 
-	def test_all_parameters(self, host, create_pallet_isos, revert_etc):
+	def test_all_parameters(self, host, create_pallet_isos, revert_etc, revert_pallet_hooks):
 		# Add our minimal pallet
 		result = host.run(f'stack add pallet {create_pallet_isos}/minimal-1.0-sles12.x86_64.disk1.iso')
 		assert result.rc == 0
@@ -94,7 +94,7 @@ class TestRemovePallet:
 		# Directory should be gone as well
 		assert not host.file('/export/stack/pallets/minimal/').exists
 
-	def test_no_arch_match(self, host, create_pallet_isos, revert_export_stack_pallets):
+	def test_no_arch_match(self, host, create_pallet_isos, revert_export_stack_pallets, revert_pallet_hooks):
 		# Add our minimal pallet
 		result = host.run(f'stack add pallet {create_pallet_isos}/minimal-1.0-sles12.x86_64.disk1.iso')
 		assert result.rc == 0
@@ -141,7 +141,7 @@ class TestRemovePallet:
 		# Pallet files should still exist as well
 		assert host.file('/export/stack/pallets/minimal/1.0/sles12/sles/x86_64/roll-minimal.xml').exists
 
-	def test_no_os_match(self, host, create_pallet_isos, revert_export_stack_pallets):
+	def test_no_os_match(self, host, create_pallet_isos, revert_export_stack_pallets, revert_pallet_hooks):
 		# Add our minimal pallet
 		result = host.run(f'stack add pallet {create_pallet_isos}/minimal-1.0-sles12.x86_64.disk1.iso')
 		assert result.rc == 0
@@ -188,7 +188,7 @@ class TestRemovePallet:
 		# Pallet files should still exist as well
 		assert host.file('/export/stack/pallets/minimal/1.0/sles12/sles/x86_64/roll-minimal.xml').exists
 
-	def test_multiple_versions(self, host, create_pallet_isos, revert_etc, revert_export_stack_pallets):
+	def test_multiple_versions(self, host, create_pallet_isos, revert_etc, revert_export_stack_pallets, revert_pallet_hooks):
 		# Add our minimal pallet
 		result = host.run(f'stack add pallet {create_pallet_isos}/minimal-1.0-sles12.x86_64.disk1.iso')
 		assert result.rc == 0
@@ -233,7 +233,7 @@ class TestRemovePallet:
 		# But the '1.0' version of the pallet should be gone
 		assert not host.file('/export/stack/pallets/minimal/1.0').exists
 
-	def test_remove_partially_removed_pallet(self, host, create_pallet_isos, revert_export_stack_pallets, revert_etc):
+	def test_remove_partially_removed_pallet(self, host, create_pallet_isos, revert_export_stack_pallets, revert_etc, revert_pallet_hooks):
 		# Add our minimal pallet
 		result = host.run(f'stack add pallet {create_pallet_isos}/minimal-1.0-sles12.x86_64.disk1.iso')
 		assert result.rc == 0

--- a/test-framework/test-suites/integration/tests/remove/test_remove_repo.py
+++ b/test-framework/test-suites/integration/tests/remove/test_remove_repo.py
@@ -11,7 +11,7 @@ class TestRemoveRepo:
 		assert result.rc == 255
 		assert result.stderr.startswith('error - ')
 
-	def test_args(self, host, add_repo):
+	def test_args(self, host, add_repo, revert_etc):
 		''' ensure removing one repo only touches that repo '''
 		add_repo('test2', 'testurl2')
 

--- a/test-framework/test-suites/integration/tests/report/test_report_host_repo.py
+++ b/test-framework/test-suites/integration/tests/report/test_report_host_repo.py
@@ -23,7 +23,7 @@ class TestReportHostRepo:
 		assert result.stdout.splitlines()[0] == first_line
 		assert result.stdout.splitlines()[-1] == last_line
 
-	def test_with_repo(self, host, host_os, host_repo_file, add_host, add_repo, add_box):
+	def test_with_repo(self, host, host_os, host_repo_file, add_host, add_repo, add_box, revert_etc):
 		result = host.run('stack enable repo test box=test')
 		assert result.rc == 0
 		result = host.run('stack set host box backend-0-0 box=test')
@@ -90,7 +90,7 @@ class TestReportHostRepo:
 		assert result.rc == 0
 		assert result.stdout == output_single_repo.replace('gpgcheck=0', 'gpgcheck=1')
 
-	def test_repo_templating(self, host, host_os, host_repo_file, add_host, add_repo, add_box):
+	def test_repo_templating(self, host, host_os, host_repo_file, add_host, add_repo, add_box, revert_etc):
 		''' test that the repo templating feature works correctly '''
 		result = host.run('stack set repo test url="http://{{ Kickstart_PrivateAddress }}/test"')
 		assert result.rc == 0

--- a/test-framework/test-suites/integration/tests/run/test_run_pallet.py
+++ b/test-framework/test-suites/integration/tests/run/test_run_pallet.py
@@ -19,7 +19,7 @@ class TestRunPallet:
 			{pallet ...} [arch=string] [os=string] [release=string] [version=string]
 		''')
 
-	def test_not_enabled(self, host, host_os, create_pallet_isos, revert_export_stack_pallets):
+	def test_not_enabled(self, host, host_os, create_pallet_isos, revert_export_stack_pallets, revert_pallet_hooks):
 		# Add our test pallet
 		result = host.run(
 			f'stack add pallet {create_pallet_isos}/minimal-1.0-sles12.x86_64.disk1.iso'
@@ -45,7 +45,7 @@ class TestRunPallet:
 		assert result.rc == 0
 		assert result.stdout == ''
 
-	def test_multiple_args(self, host, host_os, create_pallet_isos, revert_etc, revert_export_stack_pallets, revert_export_stack_carts):
+	def test_multiple_args(self, host, host_os, create_pallet_isos, revert_etc, revert_export_stack_pallets, revert_export_stack_carts, revert_pallet_hooks):
 		# Add our test pallet
 		result = host.run(
 			f'stack add pallet {create_pallet_isos}/test_1-{host_os}-1.0-prod.x86_64.disk1.iso'
@@ -69,7 +69,7 @@ class TestRunPallet:
 		assert result.rc == 0
 		assert result.stdout == ''
 
-	def test_database_false(self, host, host_os, create_pallet_isos, revert_etc, revert_export_stack_pallets, revert_export_stack_carts):
+	def test_database_false(self, host, host_os, create_pallet_isos, revert_etc, revert_export_stack_pallets, revert_export_stack_carts, revert_pallet_hooks):
 		# Add our test pallet
 		result = host.run(
 			f'stack add pallet {create_pallet_isos}/test_1-{host_os}-1.0-prod.x86_64.disk1.iso'

--- a/test-framework/test-suites/integration/tests/sync/test_sync_host_repo.py
+++ b/test-framework/test-suites/integration/tests/sync/test_sync_host_repo.py
@@ -24,8 +24,8 @@ class TestSyncHostRepo:
 		# verify it changed
 		assert repo_fi_handle.read_text() == og_repo_text
 
-	
-	def test_repo_file_synced(self, host, host_os, host_repo_file, revert_etc, add_box, add_cart, add_repo, create_pallet_isos, revert_export_stack_pallets):
+
+	def test_repo_file_synced(self, host, host_os, host_repo_file, revert_etc, add_box, add_cart, add_repo, create_pallet_isos, revert_export_stack_pallets, revert_pallet_hooks, revert_export_stack_carts):
 		''' verify that the frontend's repo file is re-written for certain commands '''
 
 		# get the original


### PR DESCRIPTION
`test_regression_shadow_glob_interaction` doesn't need to check the `list host attr` output, just the return code. The output is different under downstream pipelines.

Add a whole bunch of missing reverts found via `--audit` flag.