### PR TITLE
INTERAL: Remove network interfaces from VM boot order when kickstarta…

### DIFF
--- a/common/src/stack/command/stack/commands/report/vm/__init__.py
+++ b/common/src/stack/command/stack/commands/report/vm/__init__.py
@@ -222,6 +222,7 @@ class Command(command, VmArgProcessor):
 		"""
 
 		vm_host = self.get_hypervisor_by_name(host)
+		kickstartable = self.str2bool(self.getHostAttr(host, 'kickstartable'))
 		interfaces = []
 
 		for interface in self.call('list.host.interface', [host]):
@@ -253,7 +254,9 @@ class Command(command, VmArgProcessor):
 			out['mac'] = interface['mac']
 			out['name'] = host_interface
 
-			if network_pxe:
+			# Only set the bootorder for the interface  if the network
+			# is set to pxe and that the kickstartable attr is true for the host
+			if network_pxe and kickstartable:
 				out['bootorder'] = self.bootorder
 				self.bootorder+=1
 

--- a/test-framework/test-suites/integration/files/report/vm_config_no_kickstart_redhat.txt
+++ b/test-framework/test-suites/integration/files/report/vm_config_no_kickstart_redhat.txt
@@ -1,0 +1,54 @@
+<domain type="kvm">
+	<name>vm-backend-0-3</name>
+	<uuid>00000000-0000-0000-0000-0000000000</uuid>
+	<memory>2097152</memory>
+	<vcpu>1</vcpu>
+	<os>
+		<type arch="x86_64">hvm</type>
+	</os>
+	<features>
+		<acpi/>
+		<apic/>
+	</features>
+	<clock offset="utc">
+		<timer name="rtc" tickpolicy="catchup"/>
+		<timer name="pit" tickpolicy="delay"/>
+		<timer name="hpet" present="no"/>
+	</clock>
+	<on_poweroff>destroy</on_poweroff>
+	<on_reboot>restart</on_reboot>
+	<on_crash>restart</on_crash>
+	<pm>
+		<suspend-to-mem enabled="no"/>
+		<suspend-to-disk enabled="no"/>
+	</pm>
+	<devices>
+		<emulator>/usr/libexec/qemu-kvm</emulator>
+		<interface type="bridge">
+			<mac address="52:54:00:4a:7d:91"/>
+			<source bridge="eth0"/>
+			<model type="virtio"/>
+		</interface>
+		<disk device="disk" type="file">
+			<driver cache="none" type="qcow2" name="qemu" io="native"/>
+			<source file="/export/pools/stacki/vm-backend-0-3/vm-backend-0-3_disk1.qcow2"/>
+			<target dev="sda" bus="sata"/>
+			<boot order="1"/>
+		</disk>
+		<serial type="pty">
+			<target port="0"/>
+		</serial>
+		<serial type="pty">
+			<target port="1"/>
+		</serial>
+		<input bus="ps2" type="mouse"/>
+		<graphics autoport="yes" keymap="en-us" type="vnc" port="-1"/>
+		<video>
+			<model heads="1" vram="9216" type="cirrus"/>
+		</video>
+		<rng model="virtio">
+			<backend model="random">/dev/random</backend>
+			<address type="pci" domain="0x0000" bus="0x00" slot="0x0c" function="0x0"/>
+		</rng>
+	</devices>
+</domain>

--- a/test-framework/test-suites/integration/files/report/vm_config_no_kickstart_sles.txt
+++ b/test-framework/test-suites/integration/files/report/vm_config_no_kickstart_sles.txt
@@ -1,0 +1,55 @@
+<domain type="kvm">
+	<name>vm-backend-0-3</name>
+	<uuid>00000000-0000-0000-0000-0000000000</uuid>
+	<memory>2097152</memory>
+	<vcpu>1</vcpu>
+	<os>
+		<type arch="x86_64">hvm</type>
+	</os>
+	<features>
+		<acpi/>
+		<apic/>
+		<vmport state="off"/>
+	</features>
+	<clock offset="utc">
+		<timer name="rtc" tickpolicy="catchup"/>
+		<timer name="pit" tickpolicy="delay"/>
+		<timer name="hpet" present="no"/>
+	</clock>
+	<on_poweroff>destroy</on_poweroff>
+	<on_reboot>restart</on_reboot>
+	<on_crash>restart</on_crash>
+	<pm>
+		<suspend-to-mem enabled="no"/>
+		<suspend-to-disk enabled="no"/>
+	</pm>
+	<devices>
+		<emulator>/usr/bin/qemu-kvm</emulator>
+		<interface type="bridge">
+			<mac address="52:54:00:4a:7d:91"/>
+			<source bridge="eth0"/>
+			<model type="virtio"/>
+		</interface>
+		<disk device="disk" type="file">
+			<driver cache="none" type="qcow2" name="qemu" io="native"/>
+			<source file="/export/pools/stacki/vm-backend-0-3/vm-backend-0-3_disk1.qcow2"/>
+			<target dev="sda" bus="sata"/>
+			<boot order="1"/>
+		</disk>
+		<serial type="pty">
+			<target port="0"/>
+		</serial>
+		<serial type="pty">
+			<target port="1"/>
+		</serial>
+		<input bus="ps2" type="mouse"/>
+		<graphics autoport="yes" keymap="en-us" type="vnc" port="-1"/>
+		<video>
+			<model heads="1" vram="9216" type="cirrus"/>
+		</video>
+		<rng model="virtio">
+			<backend model="random">/dev/random</backend>
+			<address type="pci" domain="0x0000" bus="0x00" slot="0x0c" function="0x0"/>
+		</rng>
+	</devices>
+</domain>

--- a/test-framework/test-suites/integration/tests/report/test_report_vm.py
+++ b/test-framework/test-suites/integration/tests/report/test_report_vm.py
@@ -212,3 +212,32 @@ class TestReportVM:
 		)
 
 		assert sub_uuid == expect_output
+
+	def test_report_vm_no_kickstartable(
+		self,
+		add_hypervisor,
+		add_vm_multiple,
+		host,
+		host_os,
+		test_file
+	):
+		expect_output = Path(test_file(f'report/vm_config_no_kickstart_{host_os}.txt')).read_text()
+
+		conf = host.run('stack report vm vm-backend-0-3')
+		no_kickstart = host.run('stack set host attr vm-backend-0-3 attr=kickstartable value=False')
+		assert no_kickstart.rc == 0
+
+		conf = host.run('stack report vm vm-backend-0-3 bare=y')
+		assert conf.rc == 0
+
+		# Remove the generated UUID
+		# as it is different each
+		# test run
+		sub_uuid = re.sub(
+			r'<uuid>.*</uuid>',
+			'<uuid>00000000-0000-0000-0000-0000000000</uuid>',
+			conf.stdout
+		)
+
+		assert sub_uuid == expect_output
+


### PR DESCRIPTION
This adds a small change to the `report vm` command. When the kickstartable attribute is set to False for the host, the libvirt config generated removes network booting from the VM's boot ordering. When kickstartable is True, network booting is the first option to boot the VM from.