### PR TITLE
BUGFIX: enable/disable pallet need sudo access from the WS

### DIFF
--- a/common/src/stack/ws/setup/ws_setup.sh
+++ b/common/src/stack/ws/setup/ws_setup.sh
@@ -35,6 +35,8 @@ STACK_CMDS=( "sync *"	\
 	"unload *"	\
 	"remove host"	\
 	"add pallet" 	\
+	"enable pallet" 	\
+	"disable pallet" 	\
 	"remove pallet"	\
 	"list host switch" \
 	)


### PR DESCRIPTION
Bugfix to let pallet hooks work on enable/disable when called via the Webservice.