### PR TITLE
Feature/logical semaphore settings

### DIFF
--- a/common/nodes/apache.xml
+++ b/common/nodes/apache.xml
@@ -69,13 +69,6 @@ DocumentRoot "/var/www/html"
 </Directory>
 ]]>
 </stack:file>
-
-<!-- Create Apache Profile.cgi mutex and semaphore -->
-mkdir -p /var/tmp
-touch /var/tmp/profile.mutex
-chown apache:root /var/tmp/profile.mutex
-cat /proc/cpuinfo  | awk -F: '/^processor/{print $2;}' | wc -l > /var/tmp/profile.semaphore
-chown apache:root /var/tmp/profile.semaphore
 </stack:script>
 
 <!-- REDHAT -->

--- a/common/nodes/database-data-init.xml
+++ b/common/nodes/database-data-init.xml
@@ -78,14 +78,6 @@ with open('/tmp/site.json', 'w') as file:
                         "value": true
                 },
                 {
-                        "name": "discovery.base.rack",
-                        "value": "0"
-                },
-                {
-                        "name": "discovery.base.rank",
-                        "value": 0
-                },
-                {
                         "name": "os",
                         "value": "&os;"
                 },

--- a/common/nodes/frontend-server.xml
+++ b/common/nodes/frontend-server.xml
@@ -6,6 +6,13 @@ All rights reserved. Stacki(r) v5.x stacki.com
 https://github.com/Teradata/stacki/blob/master/LICENSE.txt
 </stack:copyright>
 
+<!-- create the stack.yml -->
+<stack:script stack:shell="/opt/stack/bin/python3" stack:stage="install-post">
+import stack.settings
+
+stack.settings.write_default_settings_file(overwrite=True)
+</stack:script>
+
 <!-- Make sure to add the frontend box, and enable all added pallets for both the default and frontend box. -->
 <stack:script stack:shell='/opt/stack/bin/python3' stack:stage="install-post" stack:cond="platform != 'aws' and not barnacle">
 import pathlib

--- a/common/src/foundation/python-packages/pyproject.toml
+++ b/common/src/foundation/python-packages/pyproject.toml
@@ -108,5 +108,5 @@ cryptography = { appliances = ["server"] }
 jinja2 = { appliances = ["server"], bootstrap = true }
 markupsafe = { appliances = ["server"] }
 pycparser = { appliances = ["server"] }
-pyyaml = { appliances = ["server"] }
+pyyaml = { appliances = ["server"], bootstrap = true }
 six = { appliances = ["server"] }

--- a/common/src/stack/command/stack/commands/list/node/xml/__init__.py
+++ b/common/src/stack/command/stack/commands/list/node/xml/__init__.py
@@ -81,7 +81,7 @@ class Command(stack.commands.list.command, BoxArgProcessor):
 		# but let the graph treat them as attributes
 		# yaml supports multiple data types - just convert to strings
 
-		attrs = {k: str(v) for k, v in stack.settings.get_settings().items()}
+		attrs = {f'settings.{k}': str(v) for k, v in stack.settings.get_settings().items()}
 
 		if attributes_input:
 			try:

--- a/common/src/stack/command/stack/commands/list/node/xml/__init__.py
+++ b/common/src/stack/command/stack/commands/list/node/xml/__init__.py
@@ -10,7 +10,7 @@
 # https://github.com/Teradata/stacki/blob/master/LICENSE-ROCKS.txt
 # @rocks@
 
-
+import importlib
 import ast
 import os
 import subprocess
@@ -22,6 +22,7 @@ from stack.argument_processors.box import BoxArgProcessor
 import stack.commands
 from stack.exception import ArgRequired, CommandError
 import stack.profile
+import stack.roll
 
 class Command(stack.commands.list.command, BoxArgProcessor):
 	"""
@@ -140,10 +141,8 @@ class Command(stack.commands.list.command, BoxArgProcessor):
 		doEval = self.str2bool(evalp)
 		allowMissing = self.str2bool(missing)
 
-		# yes, this was already imported above.  Take it out and it crashes looking up .version.
-		# First added in commit 38623be.  No one knows why it's needed.
-		import stack
-
+		# get the version/release populated during frontend install
+		importlib.reload(stack)
 		# Add more values to the attributes
 		attrs['version'] = stack.version
 		attrs['release'] = stack.release
@@ -168,8 +167,6 @@ class Command(stack.commands.list.command, BoxArgProcessor):
 			# pallet info from '/tmp/rolls.xml' or
 			# '/tmp/pallets.xml'
 			#
-
-			import stack.roll
 
 			g = stack.roll.Generator()
 

--- a/common/src/stack/command/stack/commands/report/siteattr/__init__.py
+++ b/common/src/stack/command/stack/commands/report/siteattr/__init__.py
@@ -52,11 +52,6 @@ class Command(stack.commands.report.command):
 					nameserver = line[10:].strip()
 
 		attrs = { 
-#			'Info_CertificateCountry'        : 'US',
-#			'Info_CertificateLocality'       : 'San Diego',
-#			'Info_CertificateOrganization'   : 'Stacki',
-#			'Info_CertificateState'          : 'California',
-#			'Info_ClusterLatlong'            : 'N32.87 W117.22',
 			'Info_FQDN'                      : fqdn,
 			'Kickstart_Keyboard'             : 'us',
 			'Kickstart_Lang'                 : 'en_US',

--- a/common/src/stack/command/stack/commands/report/siteattr/__init__.py
+++ b/common/src/stack/command/stack/commands/report/siteattr/__init__.py
@@ -52,11 +52,11 @@ class Command(stack.commands.report.command):
 					nameserver = line[10:].strip()
 
 		attrs = { 
-			'Info_CertificateCountry'        : 'US',
-			'Info_CertificateLocality'       : 'San Diego',
-			'Info_CertificateOrganization'   : 'Stacki',
-			'Info_CertificateState'          : 'California',
-			'Info_ClusterLatlong'            : 'N32.87 W117.22',
+#			'Info_CertificateCountry'        : 'US',
+#			'Info_CertificateLocality'       : 'San Diego',
+#			'Info_CertificateOrganization'   : 'Stacki',
+#			'Info_CertificateState'          : 'California',
+#			'Info_ClusterLatlong'            : 'N32.87 W117.22',
 			'Info_FQDN'                      : fqdn,
 			'Kickstart_Keyboard'             : 'us',
 			'Kickstart_Lang'                 : 'en_US',

--- a/common/src/stack/discovery/command/enable/discovery/__init__.py
+++ b/common/src/stack/discovery/command/enable/discovery/__init__.py
@@ -25,7 +25,7 @@ class Command(stack.commands.enable.command):
 	</param>
 
 	<param type='string' name='rack' optional='1'>
-	The rack number to use for discovered nodes. Defaults to the 'discovery.base.rack' attribute.
+	The rack number to use for discovered nodes. Defaults to the 'discovery.base.rack' setting.
 	</param>
 
 	<param type='string' name='rank' optional='1'>

--- a/common/src/stack/discovery/pylib/discovery.py
+++ b/common/src/stack/discovery/pylib/discovery.py
@@ -20,6 +20,7 @@ import sys
 import stack.api
 from stack.exception import CommandError
 import stack.mq
+import stack.settings
 
 
 class Discovery:
@@ -364,6 +365,8 @@ class Discovery:
 		if self.is_running():
 			return
 
+		stacki_settings = stack.settings.get_settings()
+
 		# Make sure our appliance name is valid
 		if appliance_name:
 			try:
@@ -382,14 +385,14 @@ class Discovery:
 
 		# Set up the rack
 		if rack is None:
-			self._rack = int(stack.api.Call("list.host.attr", ["localhost", "attr=discovery.base.rack"])[0]['value'])
+			self._rack = int(stacki_settings['discovery.base.rack'])
 		else:
 			self._rack = int(rack)
 
 		# Set up the rank
 		if rank is None:
 			# Start with with default
-			self._rank = int(stack.api.Call("list.host.attr", ["localhost", "attr=discovery.base.rank"])[0]['value'])
+			self._rank = int(stacki_settings['discovery.base.rank'])
 
 			# Try to pull the next rank based on the DB
 			for host in stack.api.Call("list.host"):

--- a/common/src/stack/kickstart/profile.py
+++ b/common/src/stack/kickstart/profile.py
@@ -24,6 +24,7 @@ import stack.api
 import stack.bool
 import stack.mq
 import stack.commands
+import stack.settings
 
 
 class Client:
@@ -161,21 +162,15 @@ syslog.openlog('profile', syslog.LOG_PID, syslog.LOG_LOCAL0)
 syslog.syslog(syslog.LOG_DEBUG, 'request %s:%s' % (client.addr, client.port))
 client.pre()
 
-# Use a semaphore to restrict the number of concurrent profile
-# generators.  The first time through we set the semaphore to the
-# number of CPUs (not a great guess, but reasonable).
+# Use a semaphore to restrict the number of concurrent profile generators.
 
 empty = False
 mutex.acquire()
 count = semaphore.read()
 if count is None:
 	syslog.syslog(syslog.LOG_DEBUG, 'semaphore not found')
-	try:
-		cmd = "grep 'processor' /proc/cpuinfo | wc -l"
-		out = os.popen(cmd).readline()
-		count = int(out)
-	except:
-		count = 8
+	count = stack.settings.get_settings()['max_concurrent_profile_requests']
+
 if count == 0:
 	syslog.syslog(syslog.LOG_DEBUG, 'semaphore found but zero')
 	# Out of resources force the client to retry,

--- a/common/src/stack/pylib/Makefile
+++ b/common/src/stack/pylib/Makefile
@@ -16,6 +16,7 @@ PYAPI		= $(wildcard api/*.py)
 PKGROOT		= /opt/stack
 ROLLROOT	= ../../../..
 DEPENDS.DIRS	= stack
+RPM.REQUIRES    = foundation-python-PyYAML
 
 include $(STACKBUILD)/etc/CCRules.mk
 

--- a/common/src/stack/pylib/stack/settings.py
+++ b/common/src/stack/pylib/stack/settings.py
@@ -27,10 +27,10 @@ max_concurrent_profile_requests: {2 * os.cpu_count()}
 
 # these are used to generate the CA for frontend's ssl cert
 # These are used at frontend installation time.
-Info_CertificateCountry: 'US'
-Info_CertificateLocality: 'Solana Beach'
-Info_CertificateOrganization: 'StackIQ'
-Info_CertificateState: 'California'
+ssl.organization: 'StackIQ'
+ssl.locality: 'Solana Beach'
+ssl.state: 'California'
+ssl.country: 'US'
 
 # these settings control the starting points for discover-nodes (nee insert ethers)
 discovery.base.rack: '0'

--- a/common/src/stack/pylib/stack/settings.py
+++ b/common/src/stack/pylib/stack/settings.py
@@ -1,0 +1,94 @@
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+import syslog
+
+import yaml
+
+from stack.util import _exec
+
+syslog.openlog('settings', syslog.LOG_PID, syslog.LOG_LOCAL0)
+
+SETTINGS_FILE = '/opt/stack/etc/stacki.yml'
+
+# these are the base default settings.
+# stacki.yaml will override these, but if a setting (or even the whole file) is missing
+# these will be the fallback.
+DEFAULT_YAML = f'''\
+---
+# This is the stacki settings file.
+
+# This is the most profiles we will serve at one time. Requests beyond this will be told to retry.
+# Doubling the number of cpu cores is a reasonable starting point
+# NOTE: You will need to restart apache for changes to take effect
+max_concurrent_profile_requests: {2 * os.cpu_count()}
+
+# these are used to generate the CA for frontend's ssl cert
+# These are used at frontend installation time.
+Info_CertificateCountry: 'US'
+Info_CertificateLocality: 'Solana Beach'
+Info_CertificateOrganization: 'StackIQ'
+Info_CertificateState: 'California'
+
+# these settings control the starting points for discover-nodes (nee insert ethers)
+discovery.base.rack: '0'
+discovery.base.rank: '0'
+'''
+
+def get_settings():
+	'''
+	get the default values, then update it from SETTINGS_FILE.
+
+	if SETTINGS_FILE is missing or unparsable, log and ignore
+	'''
+	settings_data = yaml.safe_load(DEFAULT_YAML)
+
+	try:
+		with Path(SETTINGS_FILE).open() as fi:
+			yaml_data = yaml.safe_load(fi)
+		settings_data.update(yaml_data)
+	except FileNotFoundError:
+		syslog.syslog(syslog.LOG_ERR, f'could not find {SETTINGS_FILE}')
+	except yaml.YAMLError as e:
+		syslog.syslog(syslog.LOG_ERR, f'invalid yaml settings file:\n' + str(e))
+	except Exception as e:
+		syslog.syslog(syslog.LOG_ERR, f'unable to parse settings file:\n' + str(e))
+
+	return settings_data
+
+def write_default_settings_file(overwrite=False):
+	'''
+	write a clean SETTINGS_FILE
+	if SETTINGS_FILE does not exist, do not overwrite it unless `overwrite` is True
+	'''
+	fi = Path(SETTINGS_FILE)
+	if fi.exists() and not overwrite:
+		syslog.syslog(syslog.LOG_ERR, f'refusing to overwrite existing settings file.')
+		raise FileExistsError
+	elif fi.exists() and overwrite:
+		syslog.syslog(syslog.LOG_ERR, f'attemping to overwrite existing settings file.')
+	if not fi.exists():
+		# create /opt/stack/etc/stacki.yml if needed
+		fi.parent.mkdir(parents=True, exist_ok=True)
+		fi.touch(mode=0o744, exist_ok=True)
+	fi.write_text(DEFAULT_YAML)
+
+def main(args):
+	parser = argparse.ArgumentParser()
+	parser.add_argument('--write-default', help=f'Write the default settings file to {SETTINGS_FILE}', action='store_true')
+	parser.add_argument('--force-write-default', help='Overwrite the settings file if it exists', action='store_true')
+	parser.add_argument('--print-json', help='Print a json representation of the settings - this is the default if no options are passed', action='store_true')
+	args = parser.parse_args(args)
+
+	if args.force_write_default or args.write_default:
+		try:
+			write_default_settings_file(args.force_write_default)
+		except FileExistsError:
+			sys.exit(f'settings file already exists at: {SETTINGS_FILE}. Remove or rerun with `--force-write-default`')
+	if args.print_json or not any([args.write_default, args.force_write_default, args.print_json]):
+		print(json.dumps(get_settings(), indent=4))
+
+if __name__ == '__main__':
+	main(sys.argv[1:])

--- a/common/src/stack/pylib/stack/wizard.py
+++ b/common/src/stack/pylib/stack/wizard.py
@@ -18,11 +18,6 @@ from xml.etree.ElementTree import Element, SubElement, ElementTree
 
 
 class Attr:
-	Info_CertificateCountry = "US"
-	Info_CertificateLocality = "Solana Beach"
-	Info_CertificateOrganization = "StackIQ"
-	Info_CertificateState = "California"
-	Info_ClusterLatlong = "N32.87 W117.22"
 	Info_FQDN = ""
 	Kickstart_Keyboard = "us"
 	Kickstart_Lang = "en_US"

--- a/redhat/nodes/ca.xml
+++ b/redhat/nodes/ca.xml
@@ -42,10 +42,10 @@ commonName		= Common Name (hostname, IP, or your name)
 
 commonName_default		= &Info_FQDN;
 organizationalUnitName_default	= &Kickstart_PrivateHostname;-CA
-0.organizationName_default	= &Info_CertificateOrganization;
-localityName_default		= &Info_CertificateLocality;
-stateOrProvinceName_default	= &Info_CertificateState;
-countryName_default		= &Info_CertificateCountry;
+0.organizationName_default	= &settings.ssl.organization;
+localityName_default		= &settings.ssl.locality;
+stateOrProvinceName_default	= &settings.ssl.state;
+countryName_default		= &settings.ssl.country;
 </stack:file>
 
 </stack:script>

--- a/redhat/nodes/ssl-client.xml
+++ b/redhat/nodes/ssl-client.xml
@@ -23,10 +23,10 @@ cd /etc/security/ca; \
 /usr/bin/openssl req -new -nodes -config ca.cfg \
 	-keyout $cert/key \
 	-subj "\
-/C=&Info_CertificateCountry;/\
-ST=&Info_CertificateState;/\
-L=&Info_CertificateLocality;/\
-O=&Info_CertificateOrganization;/\
+/C=&settings.ssl.country;/\
+ST=&settings.ssl.state;/\
+L=&settings.ssl.locality;/\
+O=&settings.ssl.organization;/\
 OU=&Kickstart_PrivateHostname;/\
 CN=&hostname;.&Kickstart_PrivateDNSDomain;" \
 	&gt; $cert/csr 2&gt;/dev/null

--- a/sles/nodes/ca.xml
+++ b/sles/nodes/ca.xml
@@ -36,10 +36,10 @@ commonName		= Common Name (hostname, IP, or your name)
 
 commonName_default		= &Info_FQDN;
 organizationalUnitName_default	= &Kickstart_PrivateHostname;-CA
-0.organizationName_default	= &Info_CertificateOrganization;
-localityName_default		= &Info_CertificateLocality;
-stateOrProvinceName_default	= &Info_CertificateState;
-countryName_default		= &Info_CertificateCountry;
+0.organizationName_default	= &settings.ssl.organization;
+localityName_default		= &settings.ssl.locality;
+stateOrProvinceName_default	= &settings.ssl.state;
+countryName_default		= &settings.ssl.country;
 </stack:file>
 
 </stack:script>

--- a/test-framework/test-suites/integration/files/wizard/boss_config_snack_minimal_site.attrs
+++ b/test-framework/test-suites/integration/files/wizard/boss_config_snack_minimal_site.attrs
@@ -1,8 +1,3 @@
-Info_CertificateCountry:US
-Info_CertificateLocality:Solana Beach
-Info_CertificateOrganization:StackIQ
-Info_CertificateState:California
-Info_ClusterLatlong:N32.87 W117.22
 Info_FQDN:test.example.com
 Kickstart_Keyboard:us
 Kickstart_Lang:en_US

--- a/test-framework/test-suites/unit/tests/pylib/stack/test_pylib_stack_settings.py
+++ b/test-framework/test-suites/unit/tests/pylib/stack/test_pylib_stack_settings.py
@@ -1,0 +1,71 @@
+import pytest
+from unittest.mock import patch, mock_open
+
+import json
+import os
+from pathlib import Path
+
+import yaml
+
+import stack.settings
+
+DEFAULT_SETTING_KEYS = [
+	'max_concurrent_profile_requests',
+	'ssl.country',
+	'ssl.locality',
+	'ssl.organization',
+	'ssl.state',
+	'discovery.base.rack',
+	'discovery.base.rank',
+]
+
+CUSTOM_YAML = '''\
+max_concurrent_profile_requests: 9001
+random_setting: foo
+'''
+
+class TestSettings:
+	def test_default_string_parses_yaml(self):
+		assert yaml.safe_load(stack.settings.DEFAULT_YAML)
+
+	def test_default_settings_has_known_keys(self):
+		assert set(DEFAULT_SETTING_KEYS).issubset(stack.settings.get_settings())
+
+	def test_default_settings_sets_cpus(self):
+		assert stack.settings.get_settings()['max_concurrent_profile_requests'] == (2 * os.cpu_count())
+
+	def test_read_settings_if_no_file(self):
+		''' if there is no settings file, or it's empty, get_settings() should just get the defaults '''
+		# mock_open replaces Path's open() with empy string, as if the file was empty
+		with patch.object(Path, 'open', mock_open):
+			assert stack.settings.get_settings() == yaml.safe_load(stack.settings.DEFAULT_YAML)
+
+	def test_read_settings_if_settings_changed(self):
+		'''
+		explicitly check what happens if the file is replaced with a subset of the settings
+		current design is that it should load in the defaults (in memory), and then replace the settings which do exist
+		'''
+
+		# now replace the open file with CUSTOM_YAML
+		with patch.object(Path, 'open', mock_open(read_data=CUSTOM_YAML)):
+			custom_settings = stack.settings.get_settings()
+
+		# overlay the hard-coded settings with CUSTOM_YAML settings
+		# this code should effectively mirror stack.settings.get_settings()
+		base_settings = yaml.safe_load(stack.settings.DEFAULT_YAML)
+
+		assert custom_settings != base_settings
+
+		additional_settings = yaml.safe_load(CUSTOM_YAML)
+		base_settings.update(additional_settings)
+
+		assert custom_settings == base_settings
+
+# test overwriting file
+
+# test writing file
+# test failing to write file
+
+# report system test that semaphore file exists
+
+

--- a/tools/fab/frontend-install.py
+++ b/tools/fab/frontend-install.py
@@ -1,15 +1,17 @@
 #! /opt/stack/bin/python3
 
 from __future__ import print_function
-import os
-import sys
-import subprocess
 import getopt
-import logging
-import socket
-import re
-import struct
 import json
+import logging
+import os
+import re
+import socket
+import struct
+import subprocess
+import sys
+
+from pathlib import Path
 
 # Bail if being run in python2.
 if sys.version_info[0] < 3:
@@ -37,11 +39,6 @@ logger.addHandler(filehandler)
 logger.addHandler(handler)
 
 SITE_ATTRS_TEMPLATE = """\
-Info_CertificateCountry:US
-Info_CertificateLocality:Solana Beach
-Info_CertificateOrganization:StackIQ
-Info_CertificateState:California
-Info_ClusterLatlong:N32.87 W117.22
 Info_FQDN:{FQDN}
 Kickstart_Keyboard:us
 Kickstart_Lang:en_US
@@ -315,6 +312,9 @@ if result.returncode != 0:
 # Note: we need to refresh the library cache so the wizard
 # code can find the Newt library and its dependencies
 run_and_warn(['ldconfig'])
+
+if not Path('/opt/stack/etc/stacki.yml').exists():
+	run_and_warn("/opt/stack/bin/python3 -c 'import stack.settings; stack.settings.write_default_settings_file()'", shell=True)
 
 if not os.path.exists('/tmp/site.attrs') and not os.path.exists('/tmp/rolls.xml'):
 	if use_existing:


### PR DESCRIPTION
This is the branch where I'm working on moving some attributes (and some non-attributes like the semaphore highlevel mark) to a settings file.

Note that these are no longer available in `list attr` commands, but *are* available in the profile/graph prefixed by `settings.`, and individual commands can access them just by importing `stack.settings`