### PR TITLE
FEATURE: Add functionality for custom libvirt templates in report vm

### DIFF
--- a/test-framework/test-suites/integration/files/report/vm_config_custom_template.j2
+++ b/test-framework/test-suites/integration/files/report/vm_config_custom_template.j2
@@ -1,0 +1,51 @@
+<domain type="kvm">
+	<name>{{ name }}</name>
+	<uuid>{{ uuid }}</uuid>
+	<memory>{{ memory }}</memory>
+	<vcpu>{{ cpucount }}</vcpu>
+	<os>
+		<type arch="x86_64">hvm</type>
+	</os>
+	<features>
+		<acpi/>
+		<apic/>
+		{% if os == 'sles' %}
+		<vmport state="off"/>
+		{% endif %}
+	</features>
+	<clock offset="utc">
+		<timer name="rtc" tickpolicy="catchup"/>
+		<timer name="pit" tickpolicy="delay"/>
+		<timer name="hpet" present="no"/>
+	</clock>
+	<on_poweroff>destroy</on_poweroff>
+	<on_reboot>restart</on_reboot>
+	<on_crash>restart</on_crash>
+	<pm>
+		<suspend-to-mem enabled="no"/>
+		<suspend-to-disk enabled="no"/>
+	</pm>
+	<devices>
+		{% if os == 'redhat' %}
+		<emulator>/usr/libexec/qemu-kvm</emulator>
+		{% endif %}
+		{% if os == 'sles' %}
+		<emulator>/usr/bin/qemu-kvm</emulator>
+		{% endif %}
+		<serial type="pty">
+			<target port="0"/>
+		</serial>
+		<serial type="pty">
+			<target port="1"/>
+		</serial>
+		<input bus="ps2" type="mouse"/>
+		<graphics autoport="yes" keymap="en-us" type="vnc" port="-1"/>
+		<video>
+			<model heads="1" vram="9216" type="cirrus"/>
+		</video>
+		<rng model="virtio">
+			<backend model="random">/dev/random</backend>
+			<address type="pci" domain="0x0000" bus="0x00" slot="0x0c" function="0x0"/>
+		</rng>
+	</devices>
+</domain>

--- a/test-framework/test-suites/integration/files/report/vm_config_simple_redhat.txt
+++ b/test-framework/test-suites/integration/files/report/vm_config_simple_redhat.txt
@@ -1,0 +1,43 @@
+<domain type="kvm">
+	<name>vm-backend-0-3</name>
+	<uuid>00000000-0000-0000-0000-0000000000</uuid>
+	<memory>2097152</memory>
+	<vcpu>1</vcpu>
+	<os>
+		<type arch="x86_64">hvm</type>
+	</os>
+	<features>
+		<acpi/>
+		<apic/>
+	</features>
+	<clock offset="utc">
+		<timer name="rtc" tickpolicy="catchup"/>
+		<timer name="pit" tickpolicy="delay"/>
+		<timer name="hpet" present="no"/>
+	</clock>
+	<on_poweroff>destroy</on_poweroff>
+	<on_reboot>restart</on_reboot>
+	<on_crash>restart</on_crash>
+	<pm>
+		<suspend-to-mem enabled="no"/>
+		<suspend-to-disk enabled="no"/>
+	</pm>
+	<devices>
+		<emulator>/usr/libexec/qemu-kvm</emulator>
+		<serial type="pty">
+			<target port="0"/>
+		</serial>
+		<serial type="pty">
+			<target port="1"/>
+		</serial>
+		<input bus="ps2" type="mouse"/>
+		<graphics autoport="yes" keymap="en-us" type="vnc" port="-1"/>
+		<video>
+			<model heads="1" vram="9216" type="cirrus"/>
+		</video>
+		<rng model="virtio">
+			<backend model="random">/dev/random</backend>
+			<address type="pci" domain="0x0000" bus="0x00" slot="0x0c" function="0x0"/>
+		</rng>
+	</devices>
+</domain>

--- a/test-framework/test-suites/integration/files/report/vm_config_simple_sles.txt
+++ b/test-framework/test-suites/integration/files/report/vm_config_simple_sles.txt
@@ -1,0 +1,44 @@
+<domain type="kvm">
+	<name>vm-backend-0-3</name>
+	<uuid>00000000-0000-0000-0000-0000000000</uuid>
+	<memory>2097152</memory>
+	<vcpu>1</vcpu>
+	<os>
+		<type arch="x86_64">hvm</type>
+	</os>
+	<features>
+		<acpi/>
+		<apic/>
+		<vmport state="off"/>
+	</features>
+	<clock offset="utc">
+		<timer name="rtc" tickpolicy="catchup"/>
+		<timer name="pit" tickpolicy="delay"/>
+		<timer name="hpet" present="no"/>
+	</clock>
+	<on_poweroff>destroy</on_poweroff>
+	<on_reboot>restart</on_reboot>
+	<on_crash>restart</on_crash>
+	<pm>
+		<suspend-to-mem enabled="no"/>
+		<suspend-to-disk enabled="no"/>
+	</pm>
+	<devices>
+		<emulator>/usr/bin/qemu-kvm</emulator>
+		<serial type="pty">
+			<target port="0"/>
+		</serial>
+		<serial type="pty">
+			<target port="1"/>
+		</serial>
+		<input bus="ps2" type="mouse"/>
+		<graphics autoport="yes" keymap="en-us" type="vnc" port="-1"/>
+		<video>
+			<model heads="1" vram="9216" type="cirrus"/>
+		</video>
+		<rng model="virtio">
+			<backend model="random">/dev/random</backend>
+			<address type="pci" domain="0x0000" bus="0x00" slot="0x0c" function="0x0"/>
+		</rng>
+	</devices>
+</domain>


### PR DESCRIPTION
This adds a new feature to the `report vm` command: when the `vm_config_location` attribute is set, the jinja template at that location will be used to generate the libvirt config for that VM vs the default one. There is some basic error checking of the template, namely the command will check for VM name, uuid, cpu count, and memory variables are present. 

Some background is that this originally started out as a command line parameter instead but after discussion was changed to using attributes instead. It's been tested on my system bringing up VM's as well as integration tests for both good and bad templates.