### PR TITLE
BUGFIX: Fix Centos 7.6 Everythign ISO URLs

### DIFF
--- a/tools/cluster-up/cluster-up.sh
+++ b/tools/cluster-up/cluster-up.sh
@@ -303,7 +303,7 @@ then
         then
             echo
             echo -e "\033[37mDownloading from the Internet ...\033[0m"
-            curl -f --progress-bar --retry 3 -o $DOWNLOAD_DIR/CentOS-7-x86_64-Everything-1810.iso http://mirrors.edge.kernel.org/centos/7.6.1810/isos/x86_64/CentOS-7-x86_64-Everything-1810.iso
+            curl -f --progress-bar --retry 3 -o $DOWNLOAD_DIR/CentOS-7-x86_64-Everything-1810.iso https://archive.kernel.org/centos-vault/7.6.1810/isos/x86_64/CentOS-7-x86_64-Everything-1810.iso
         fi
     fi
 

--- a/tools/iso-builder/provision.sh
+++ b/tools/iso-builder/provision.sh
@@ -107,7 +107,7 @@ else
         then
             curl -sfSLO --retry 3 $INSTALLER_ISOS/CentOS-7-x86_64-Everything-1810.iso
         else
-            curl -sfSLO --retry 3  http://mirrors.edge.kernel.org/centos/7.6.1810/isos/x86_64/CentOS-7-x86_64-Everything-1810.iso
+            curl -sfSLO --retry 3 https://archive.kernel.org/centos-vault/7.6.1810/isos/x86_64/CentOS-7-x86_64-Everything-1810.iso
         fi
     fi
 


### PR DESCRIPTION
Point `cluster-up` and `iso-builder` at the new location for the Centos 7.6 Everything ISO, when not on the Teradata network