### PR TITLE
Fix apache2 log file path.

### DIFF
--- a/common/src/stack/discovery/pylib/discovery.py
+++ b/common/src/stack/discovery/pylib/discovery.py
@@ -433,8 +433,8 @@ class Discovery:
 			# Find our apache log
 			if os.path.isfile("/var/log/httpd/ssl_access_log"):
 				kickstart_log = "/var/log/httpd/ssl_access_log"
-			elif os.path.isfile("/var/log/apache2/ssl_access_log"):
-				kickstart_log = "/var/log/apache2/ssl_access_log"
+			elif os.path.isfile("/var/log/apache2/access.log"):
+				kickstart_log = "/var/log/apache2/access.log"
 			else:
 				raise ValueError("Apache log does not exist")
 


### PR DESCRIPTION
Why is this a file check and not an os family check? Weird.

Discovery doesn't quite work yet. But this fix at least let's me enable it. 