### PR TITLE
INTERNAL: Try to generate passwords in a more secure way

### DIFF
--- a/common/src/stack/pylib/stack/password.py
+++ b/common/src/stack/pylib/stack/password.py
@@ -6,6 +6,7 @@
 # @copyright@
 
 import crypt
+import os
 import random
 import time
 import string
@@ -15,7 +16,20 @@ class Password:
 	def get_rand(self, num_bytes=16, choices=string.ascii_letters + string.digits):
 		password = ''
 		for _ in range(num_bytes):
-			random.seed(int(time.time() * pow(10, 9)))
+			# Note: The `getrandom` system call will never block once the entropy
+			# pool has been initialized, which seems to happen before any of our
+			# code would ever run, probably due to only needing to collect 4096 bits
+			# of entropy. The RDRAND x86 instruction has been available since 2012
+			# and the Linux kernel will use it to initialize the entropy pool.
+
+			try:
+				# Try seeding random in a non-blocking way
+				# Note: Using 64 bits (8 bytes) of entropy per password byte
+				random.seed(os.getrandom(8, flags=os.GRND_NONBLOCK))
+			except BlockingIOError:
+				# Blocked getting entropy from the OS, so use milliseconds instead
+				random.seed(int(time.time() * pow(10, 9)))
+
 			password += random.choice(choices)
 
 		return password

--- a/test-framework/test-suites/unit/tests/pylib/stack/test_pylib_stack_password.py
+++ b/test-framework/test-suites/unit/tests/pylib/stack/test_pylib_stack_password.py
@@ -1,0 +1,12 @@
+from stack.password import Password
+
+from unittest.mock import patch
+
+class TestPassword:
+	@patch("os.getrandom")
+	@patch("time.time")
+	def test_get_rand_blocking_io(self, mock_time, mock_getrandom):
+		mock_getrandom.side_effect = BlockingIOError
+
+		assert len(Password().get_rand(16)) == 16
+		assert mock_time.call_count == 16


### PR DESCRIPTION
I've included a unit test to cover the code path that I haven't been able to reach on actual systems.

The `getrandom` system call will never block once the entropy pool has been initialized, which seems to happen before any of our code would ever run, probably due to only needing to collect 4096 bits of entropy, and modern CPUs having hardware random number seed generation. The RDRAND x86 instruction has been available since 2012 and the Linux kernel will use it to initialize the entropy pool.