### PR TITLE
BUGFIX: tell the json parser in stack load to treat jinja templates a…

### DIFF
--- a/common/src/stack/command/stack/commands/load/__init__.py
+++ b/common/src/stack/command/stack/commands/load/__init__.py
@@ -24,9 +24,9 @@ class command(stack.commands.Command):
 	MustBeRoot = 0
 
 	def _load(self, text):
-		parser = JsonComment(json) # standard JSON is stupid
+		parser = JsonComment() # standard JSON is stupid
 		try:
-			data = parser.loads(text)
+			data = parser.loads(text, template=False)
 		except ValueError as e:
 			# parse the error message and split the input at the
 			# syntax error
@@ -106,6 +106,7 @@ class command(stack.commands.Command):
 			data = fin.read()
 		except IOError:
 			raise CommandError(self, f'cannot read {filename}')
+
 		document = self._load(data)
 		if scope == 'global':
 			return document

--- a/test-framework/test-suites/integration/files/load/json/network_with_jinja.json
+++ b/test-framework/test-suites/integration/files/load/json/network_with_jinja.json
@@ -1,0 +1,14 @@
+{
+  "network": [
+    {
+      "name": "bogus",
+      "address": "10.35.100.0",
+      "gateway": null,
+      "netmask": "255.255.255.0",
+      "dns": false,
+      "pxe": false,
+      "mtu": 65492,
+      "zone": "{{ fake }}"
+    }
+  ]
+}

--- a/test-framework/test-suites/integration/tests/load/test_load.py
+++ b/test-framework/test-suites/integration/tests/load/test_load.py
@@ -165,3 +165,13 @@ class TestLoad:
 			/opt/stack/bin/stack "add box" test os=sles
 			/opt/stack/bin/stack "enable cart" test box=test
 		''')
+
+
+	def test_load_json_with_jinja(self, host, test_file):
+		""" test that the json parser doesn't swallow jinja templates """
+		json_path = Path(test_file("load/json/network_with_jinja.json"))
+
+		result = host.run(f'stack load {json_path}')
+		assert result.rc == 0
+		assert result.stdout.lstrip().startswith('''/opt/stack/bin/stack "add network" bogus''')
+		assert "zone='{{ fake }}'" in result.stdout


### PR DESCRIPTION
…s strings

our current json parser will attempt to interpret things between double curly braces - some json thing.