### PR TITLE
BUGFIX: we should specify rpm package dependencies in the spec file, …

### DIFF
--- a/common/src/stack/command/Makefile
+++ b/common/src/stack/command/Makefile
@@ -15,7 +15,7 @@ ROLLROOT	= ../../../..
 DEPENDS.DIRS	= stack
 DEPENDS.FILES	= stack.py
 PY.TEST.FLAGS   = -s
-RPM.REQUIRES	= foundation-python-Jinja2
+RPM.REQUIRES	= foundation-python-Jinja2 foundation-python-jsoncomment foundation-python-PyYAML foundation-python-PyMySQL stack-templates
 
 include $(STACKBUILD)/etc/CCRules.mk
 

--- a/tools/fab/frontend-install.py
+++ b/tools/fab/frontend-install.py
@@ -274,7 +274,6 @@ repoconfig(stacki_iso, extra_isos)
 
 pkgs = [
 	'foundation-python',
-	'foundation-python-PyMySQL',
 	'stack-command',
 	'stack-pylib',
 	'stack-mq',
@@ -290,11 +289,7 @@ if osname == 'redhat':
 
 # Workaround to add new packages but not break this script for older stacki releases
 new_pkgs = [
-	'stack-templates',
 	'stack-probepal',
-	'foundation-python-jsoncomment',
-	'foundation-python-json-spec',
-	'foundation-python-six',
 ]
 
 for new_pkg in new_pkgs:


### PR DESCRIPTION
…not in frontend-install.py