### PR TITLE
INTERNAL: Fix check for when custom template file is present

### DIFF
--- a/common/src/stack/command/stack/commands/report/vm/__init__.py
+++ b/common/src/stack/command/stack/commands/report/vm/__init__.py
@@ -91,13 +91,19 @@ class Command(command, VmArgProcessor):
 
 			template_conf = Path(template_loc)
 			env = Environment()
-			ast = env.parse(template_conf.read_text())
-			var_list = meta.find_undeclared_variables(ast)
 
-			if template_conf.is_file() and req_vars.issubset(var_list):
+			# Check if the template exists
+			# and has the required variables
+			if template_conf.is_file():
+				ast = env.parse(template_conf.read_text())
+				var_list = meta.find_undeclared_variables(ast)
+			else:
+				raise CommandError(self, f'Unable to find template file: {template_conf}')
+
+			if req_vars.issubset(var_list):
 				libvirt_template = jinja2.Template(template_conf.read_text(), lstrip_blocks=True, trim_blocks=True)
 			else:
-				raise CommandError(self, f'Unable to parse or missing variables for template file: {template_conf}')
+				raise CommandError(self, f'Missing required template variables for libvirt config file: {template_conf}')
 
 			# If the hypervisor param is set
 			# ignore any VM not belonging to the

--- a/test-framework/test-suites/integration/files/report/vm_config_bad_template.j2
+++ b/test-framework/test-suites/integration/files/report/vm_config_bad_template.j2
@@ -1,0 +1,50 @@
+<domain type="kvm">
+	<name>{{ name }}</name>
+	<memory>{{ memory }}</memory>
+	<vcpu>{{ cpucount }}</vcpu>
+	<os>
+		<type arch="x86_64">hvm</type>
+	</os>
+	<features>
+		<acpi/>
+		<apic/>
+		{% if os == 'sles' %}
+		<vmport state="off"/>
+		{% endif %}
+	</features>
+	<clock offset="utc">
+		<timer name="rtc" tickpolicy="catchup"/>
+		<timer name="pit" tickpolicy="delay"/>
+		<timer name="hpet" present="no"/>
+	</clock>
+	<on_poweroff>destroy</on_poweroff>
+	<on_reboot>restart</on_reboot>
+	<on_crash>restart</on_crash>
+	<pm>
+		<suspend-to-mem enabled="no"/>
+		<suspend-to-disk enabled="no"/>
+	</pm>
+	<devices>
+		{% if os == 'redhat' %}
+		<emulator>/usr/libexec/qemu-kvm</emulator>
+		{% endif %}
+		{% if os == 'sles' %}
+		<emulator>/usr/bin/qemu-kvm</emulator>
+		{% endif %}
+		<serial type="pty">
+			<target port="0"/>
+		</serial>
+		<serial type="pty">
+			<target port="1"/>
+		</serial>
+		<input bus="ps2" type="mouse"/>
+		<graphics autoport="yes" keymap="en-us" type="vnc" port="-1"/>
+		<video>
+			<model heads="1" vram="9216" type="cirrus"/>
+		</video>
+		<rng model="virtio">
+			<backend model="random">/dev/random</backend>
+			<address type="pci" domain="0x0000" bus="0x00" slot="0x0c" function="0x0"/>
+		</rng>
+	</devices>
+</domain>


### PR DESCRIPTION
This fixes a bug found when attempting to load in a custom libvirt template that doesn't exist at the path given.
A traceback would occur due to the call to the Jinja ast (which is used for checking if certain template variables exist) attempting to read the config file before the check for if the file exists. 

The behavior now corrects this by checking for the config file's existence at the specified path before doing anything else and raising a `CommandError` if its not found. In addition, a test is now added to check for this.