### PR TITLE
FEATURE: Ansible module for getting network info

### DIFF
--- a/common/src/stack/ansible/plugins/modules/stacki_network_info.py
+++ b/common/src/stack/ansible/plugins/modules/stacki_network_info.py
@@ -1,0 +1,115 @@
+# @copyright@
+# Copyright (c) 2006 - 2020 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.stacki import run_stack_command, StackCommandError
+
+DOCUMENTATION = """
+module: stacki_network_info
+short_description: Return data about networks in Stacki
+description:
+    - If name is supplied, returns information about the single network
+    - If name is not supplied, returns information about all the networks in the system
+options:
+    name:
+        description:
+            - The name of the network 
+        required: false
+"""
+
+EXAMPLES = """
+- name: Get info on all the networks
+  stacki_network_info:
+  register: result
+
+- name: Get the primary netwrok info
+  stacki_network_info:
+    name: primary
+  register: result
+"""
+
+RETURN = """
+networks:
+    description:
+        - List of networks
+    returned: on success
+    type: complex
+    contains:
+        network:
+            description:
+                - Name of the network
+            type: str
+
+        address:
+            description:
+                - Address of the network
+            type: str
+
+        mask:
+            description:
+                - Mask of the network
+            type: str
+
+        gateway:
+            description:
+                - Gateway of the network
+            type: str
+
+        mtu:
+            description:
+                - MTU of the network
+            type: int
+
+        zone:
+            description:
+                - Zone of the network
+            type: str
+
+        dns:
+            description:
+                - Is DNS enabled on the network
+            type: boolean
+
+        pxe:
+            description:
+                - Is PXE enabled on the network
+            type: boolean
+"""
+
+
+def main():
+    argument_spec = dict(
+        name=dict(type="str", required=False, default=None)
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
+
+    results = {
+        "changed": False,
+        "networks": []
+    }
+
+    if module.check_mode:
+        module.exit_json(**results)
+
+    args = []
+    if module.params["name"]:
+        args.append(module.params["name"])
+
+    try:
+        results["networks"] = run_stack_command("list.network", args)
+
+    except StackCommandError as e:
+        module.fail_json(msg=e.message, **results)
+
+    module.exit_json(**results)
+
+
+if __name__ == "__main__":
+    main()

--- a/test-framework/test-suites/integration/tests/ansible/test_stacki_network_info.py
+++ b/test-framework/test-suites/integration/tests/ansible/test_stacki_network_info.py
@@ -1,0 +1,27 @@
+class TestStackiNetworkInfo:
+
+    def test_no_network_name(self, run_ansible_module):
+        result = run_ansible_module("stacki_network_info")
+
+        assert result.status == "SUCCESS"
+        assert result.data["changed"] is False
+        assert len(result.data["networks"]) == 1
+
+    def test_network_name(self, run_ansible_module):
+        network_name = "private"
+        result = run_ansible_module("stacki_network_info", name=network_name)
+
+        assert result.status == "SUCCESS"
+        assert result.data["changed"] is False
+        assert len(result.data["networks"]) == 1
+        assert result.data["networks"][0]["network"] == network_name
+
+    def test_invalid_network_name(self, run_ansible_module):
+        network_name = "fake_network_name"
+        result = run_ansible_module("stacki_network_info", name=network_name)
+
+        assert "FAIL" in result.status
+        assert result.data["changed"] is False
+
+        assert "error" in result.data["msg"]
+        assert "not a valid network" in result.data["msg"]


### PR DESCRIPTION
Example playbook:
```
---
- hosts: localhost
  tasks:
    - name: Get info on all the networks
      stacki_network_info:
      register: result

    - name: Multiple networks output
      debug:
        var: result

    - name: Get the primary network info
      stacki_network_info:
        name: primary
      register: result

    - name: Single network output
      debug:
        var: result

    - name: Get the fake network info
      stacki_network_info:
        name: fake
      register: result
```

Return Output:
```
TASK [Multiple networks output] *********************************
ok: [localhost] => {
    "result": {
        "changed": false,
        "failed": false,
        "networks": [
            {
                "address": "172.18.0.0",
                "dns": false,
                "gateway": "",
                "mask": "255.255.0.0",
                "mtu": 1500,
                "network": "bynet0",
                "pxe": false,
                "zone": "bynet0"
            },
            {
                "address": "172.19.0.0",
                "dns": false,
                "gateway": "",
                "mask": "255.255.0.0",
                "mtu": 1500,
                "network": "bynet1",
                "pxe": false,
                "zone": "bynet1"
            },...
        ]
    }
}
TASK [Single network output] *********************************
ok: [localhost] => {
    "result": {
        "changed": false,
        "failed": false,
        "networks": [
            {
                "address": "10.1.230.0",
                "dns": false,
                "gateway": "10.1.230.253",
                "mask": "255.255.255.0",
                "mtu": 1500,
                "network": "primary",
                "pxe": true,
                "zone": "primary"
            }
        ]
    }
}
TASK [Get the fake network info] *********************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "error - \"fake\" argument is not a valid network", "networks": []}
```