### PR TITLE
FEATURE: Ansible module for getting pallet info

### DIFF
--- a/common/src/stack/ansible/plugins/modules/stacki_pallet_info.py
+++ b/common/src/stack/ansible/plugins/modules/stacki_pallet_info.py
@@ -1,0 +1,109 @@
+# @copyright@
+# Copyright (c) 2006 - 2020 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.stacki import run_stack_command, StackCommandError
+
+DOCUMENTATION = """
+module: stacki_pallet_info
+short_description: Return data about pallets in Stacki
+description:
+    - If name is supplied, returns information about the single pallet
+    - If name is not supplied, returns information about all the pallets in the system
+options:
+    name:
+        description:
+            - The name of the pallet 
+        required: false
+"""
+
+EXAMPLES = """
+- name: Get info on all the pallets
+      stacki_pallet_info:
+      register: result
+
+- name: Get the stacki pallet info
+  stacki_pallet_info:
+    name: stacki
+  register: result
+"""
+
+RETURN = """
+pallets:
+    description:
+        - List of pallets on the frontend
+    returned: on success
+    type: complex
+    contains:
+        name:
+            description:
+                - Name of the pallet
+            type: str
+        
+        version:
+            description:
+                - Version of the pallet
+            type: str
+        
+        release:
+            description:
+                - Release of the pallet
+            type: str
+            
+        arch: 
+            description:
+                - Architecture of the pallet
+            type: str
+            
+        os:
+            description:
+                - OS the pallet works with
+            type: str
+        
+        boxes:
+            description:
+                - Boxes the pallet is in
+            type: list
+            elements: str
+"""
+
+
+def main():
+    argument_spec = dict(
+        name=dict(type="str", required=False, default=None)
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
+
+    results = {
+        "changed": False,
+        "pallets": []
+    }
+
+    if module.check_mode:
+        module.exit_json(**results)
+
+    args = []
+    if module.params["name"]:
+        args.append(module.params["name"])
+
+    try:
+        for pallet in run_stack_command("list.pallet", args):
+            pallet["boxes"] = pallet["boxes"].split()
+
+            results["pallets"].append(pallet)
+
+    except StackCommandError as e:
+        module.fail_json(msg=e.message, **results)
+
+    module.exit_json(**results)
+
+
+if __name__ == "__main__":
+    main()

--- a/test-framework/test-suites/integration/tests/ansible/test_ansible_stacki_pallet_info.py
+++ b/test-framework/test-suites/integration/tests/ansible/test_ansible_stacki_pallet_info.py
@@ -1,0 +1,26 @@
+class TestStackiPalletInfo:
+
+    def test_no_pallet_name(self, run_ansible_module):
+        result = run_ansible_module("stacki_pallet_info")
+
+        assert result.status == "SUCCESS"
+        assert result.data["changed"] is False
+
+    def test_pallet_name(self, run_ansible_module):
+        pallet_name = "stacki"
+        result = run_ansible_module("stacki_pallet_info", name=pallet_name)
+
+        assert result.status == "SUCCESS"
+        assert result.data["changed"] is False
+        assert len(result.data["pallets"]) == 1
+        assert result.data["pallets"][0]["name"] == pallet_name
+
+    def test_invalid_pallet_name(self, run_ansible_module):
+        pallet_name = "fake_pallet_name"
+        result = run_ansible_module("stacki_pallet_info", name=pallet_name)
+
+        assert "FAIL" in result.status
+        assert result.data["changed"] is False
+
+        assert "error" in result.data["msg"]
+        assert "not a valid pallet" in result.data["msg"]


### PR DESCRIPTION
Example Playbook:
```
---
- hosts: localhost
  tasks:
    - name: Get info on all the pallets
      stacki_pallet_info:
      register: result

    - name: Multiple pallets output
      debug:
        var: result

    - name: Get the stacki pallet info
      stacki_pallet_info:
        name: stacki
      register: result

    - name: Single stacki pallet output
      debug:
        var: result

    - name: Get an invalid pallet info
      stacki_pallet_info:
        name: invalid_pallet
```

Output:
```
TASK [Multiple pallets output] **************************************
ok: [localhost] => {
    "result": {
        "changed": false,
        "failed": false,
        "pallets": [
            {
                "arch": "x86_64",
                "boxes": [
                    "default",
                    "frontend"
                ],
                "name": "stacki",
                "os": "sles",
                "release": "sles12",
                "version": "5.5"
            },
            {
                "arch": "x86_64",
                "boxes": [
                    "default",
                    "frontend"
                ],
                "name": "SLES",
                "os": "sles",
                "release": "sles12",
                "version": "12sp3"
            },...
        ]
    }
}

TASK [Single stacki pallet output] **************************************
ok: [localhost] => {
    "result": {
        "changed": false,
        "failed": false,
        "pallets": [
            {
                "arch": "x86_64",
                "boxes": [
                    "default",
                    "frontend"
                ],
                "name": "stacki",
                "os": "sles",
                "release": "sles12",
                "version": "5.5"
            }
        ]
    }
}

TASK [Get an invalid pallet info] **************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "error - \"invalid_pallet\" argument is not a valid pallet with parameters output-format=json", "pallets": []}
```