### PR TITLE
INTERNAL: Don't build SLES15 VMWare images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1097,6 +1097,9 @@ pipeline {
                         not {
                             environment name: 'PLATFORM', value: 'sles11'
                         }
+                        not {
+                            environment name: 'PLATFORM', value: 'sles15'
+                        }
                     }
 
                     steps {


### PR DESCRIPTION
I'll need to do some sort of custom VMX template magic on ESXi to get it to do the install with two cdroms mounted. Since SLES15 isn't being used anytime soon, I'll just disable things for now, until it gets closer to being needed.