### PR TITLE
Feature/ansible stacki group info module

### DIFF
--- a/common/src/stack/ansible/plugins/modules/stacki_group_info.py
+++ b/common/src/stack/ansible/plugins/modules/stacki_group_info.py
@@ -1,0 +1,74 @@
+# @copyright@
+# Copyright (c) 2006 - 2020 Teradata
+# All rights reserved. Stacki(r) v5.x stacki.com
+# https://github.com/Teradata/stacki/blob/master/LICENSE.txt
+# @copyright@
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.stacki import run_stack_command, StackCommandError
+
+DOCUMENTATION = """
+module: stacki_group_info
+short_description: Return data about Stacki groups
+description: List the current groups and the number of member hosts in each.
+"""
+
+EXAMPLES = """
+- name: Get info on all the groups
+  stacki_group_info:
+  register: result
+"""
+
+RETURN = """
+groups:
+  description:
+    - List of groups
+  returned_on: success
+  type: complex
+  contains:
+    group:
+      description:
+        - Name of the group
+      type: str
+    hosts:
+      description:
+        - List of hosts in the given group
+       type: list
+       elements: str
+"""
+
+
+def main():
+    # Create our module object
+    module = AnsibleModule(
+        argument_spec=dict(),
+        supports_check_mode=True
+    )
+
+    # Initialize a blank result
+    result = {
+        "changed": False,
+        "groups": []
+    }
+
+    # Bail if the user is just checking syntax of their playbook
+    if module.check_mode:
+        module.exit_json(**result)
+
+    try:
+        for group in run_stack_command("list.group"):
+            group["hosts"] = group["hosts"].split()
+
+            # Add it to the results
+            result["groups"].append(group)
+
+    except StackCommandError as e:
+        # Fetching the data failed
+        module.fail_json(msg=e.message, **result)
+
+    # Return our data
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/test-framework/test-suites/integration/tests/ansible/test_stacki_group_info.py
+++ b/test-framework/test-suites/integration/tests/ansible/test_stacki_group_info.py
@@ -1,0 +1,42 @@
+class TestStackiGroupInfo:
+    def test_no_groups(self, run_ansible_module):
+        result = run_ansible_module("stacki_group_info")
+
+        assert result.status == "SUCCESS"
+        assert result.data["changed"] is False
+        assert len(result.data["groups"]) == 0
+
+    def test_single_groups(self, add_group, run_ansible_module):
+        result = run_ansible_module("stacki_group_info")
+
+        assert result.status == "SUCCESS"
+        assert result.data["changed"] is False
+        assert len(result.data["groups"]) == 1
+
+    def test_multiple_groups(self, host, add_group, add_host, run_ansible_module):
+        add_group("test2")
+        add_host("backend-0-1", "0", "1", "backend")
+
+        result = host.run("stack add host group backend-0-0 group=test")
+
+        assert result.rc == 0
+
+        result = host.run("stack add host group backend-0-1 group=test")
+
+        assert result.rc == 0
+
+        result = host.run("stack add host group backend-0-1 group=test2")
+
+        assert result.rc == 0
+
+        result = run_ansible_module("stacki_group_info")
+
+        assert result.status == "SUCCESS"
+        assert result.data["changed"] is False
+        assert len(result.data["groups"]) == 2
+
+        assert result.data["groups"][0]["group"] == "test"
+        assert len(result.data["groups"][0]["hosts"]) == 2
+
+        assert result.data["groups"][1]["group"] == "test2"
+        assert len(result.data["groups"][1]["hosts"]) == 1


### PR DESCRIPTION
Sample Playbook:
```
---
- hosts: localhost
  tasks:
    - name: Get info on all the groups
      stacki_group_info:
      register: result

    - name: Multiple groups output
      debug:
        var: result
```

Output:
```
TASK [Multiple groups output] *************************************
ok: [localhost] => {
    "result": {
        "changed": false,
        "failed": false,
        "groups": [
            {
                "group": "cindy-test",
                "hosts": [
                    "stacki-230-16"
                ]
            },
            {
                "group": "cindy-test2",
                "hosts": [
                    "stacki-230-16"
                ]
            },
            {
                "group": "cindy3",
                "hosts": []
            }
        ]
    }
}
```