### PR TITLE
FEATURE: ReportSys test for SLES pallet patch

### DIFF
--- a/common/src/stack/report-system/command/report/system/tests/test_sles_patch.py
+++ b/common/src/stack/report-system/command/report/system/tests/test_sles_patch.py
@@ -3,7 +3,9 @@ import os
 import stack.api
 import hashlib
 import json
-
+import pathlib
+import pprint
+import collections 
 
 # Returns hash of filename
 def get_hash(filename, sles):
@@ -18,10 +20,11 @@ def get_hash(filename, sles):
 
 	return hasher.hexdigest()
 
+def nested_dict():
+	return collections.defaultdict(nested_dict)
 
 # Verify SLES patches are installed
 def test_sles_pallet_patched(host, report_output):
-	total_matched = []
 	base_dir = '/export/stack/pallets/SLES/'
 	if not os.path.isdir(base_dir):
 		pytest.skip('No SLES pallet found - skipping patch check')
@@ -35,32 +38,35 @@ def test_sles_pallet_patched(host, report_output):
 
 	# If the stack-sles*images*.rpm installed?
 	result = host.run('rpm -qa | grep stack | grep images')
-	assert result
+	assert result.rc == 0
+
+	overall_dict = nested_dict()
 
 	# Test every sles flavor found
 	for sles_flavor in sles_flavors:
 		# Make sure installed patches match what's under /opt/stack/pallet-patches
 		patch_dir = '/opt/stack/pallet-patches'
 		patch_dir_files = []
-		found_source = False
+		not_matched_list = []
 		for (dir_path, dir_names, filenames) in os.walk(patch_dir):
 			# Only want particular SLES version
 			if sles_flavor in dir_path:
-				file_to_check = None
 				if '15sp' in sles_flavor:
-					file_to_check = 'CHECKSUMS'
+					pattern = f'SLES-{sles_flavor}-*/**/CHECKSUMS'
 				else:
-					file_to_check = 'content'
-				patch_dir_files += [os.path.join(dir_path, file) for file in filenames if file == file_to_check]
+					pattern = f'SLES-{sles_flavor}-*/**/content'
 
-		# We should have non-empty list here
-		assert patch_dir_files
+				# SLES-12sp3-sles12-sles-x86_64	
+				patch_dir_files = list(pathlib.Path(patch_dir).glob(pattern))
 
-		# Find img file from patch directory in SLES pallet
-		result = host.run(f'grep .img {patch_dir_files[0]}')
+		# We should have 1 file here
+		assert len(patch_dir_files) == 1
 
 		# Last item is the partial image path
-		part_img_file = result.stdout.split()[-1]
+		part_img_file = [
+			line for line in patch_dir_files[0].read_text().splitlines()
+			if line.endswith('.img')
+		][-1].split()[-1]
 
 		# Find full path to /export/stack/pallets/SLES/?
 		result = host.run(f'probepal {base_dir}')
@@ -70,7 +76,7 @@ def test_sles_pallet_patched(host, report_output):
         	# It shouldn't be empty
 		assert palinfo[base_dir]
 		
-		sles_pallet_root = None 
+		#sles_pallet_root = None
 		for pallet in palinfo[base_dir]:
 			# Grab the right sles sp level
 			if pallet['version'] == sles_flavor:
@@ -83,14 +89,16 @@ def test_sles_pallet_patched(host, report_output):
 
 		# Verify all the stack-sles-* rpm packages 
 		for rpm in RPM:
-			# Make sure we found pm file
-			assert '.rpm' in rpm
-
 			result = host.run(f'rpm -qp --dump {rpm}')	
 			# We don't want file under /opt/stack/images to be included in this list
-			patch_files = [line.split() for line in result.stdout.splitlines() if sles_flavor in line and '/images/' not in line]
+			patch_files = [
+				line.split() for line in result.stdout.splitlines()
+				if sles_flavor in line 
+				if '/add-stacki-squashfs/' in line
+			]
 
 			matched_list = []
+			not_matched_list = []
 			# Verify file(s) from images RPM actually exist
 			for this_list in patch_files:
 				file_to_check = this_list[0]
@@ -103,22 +111,55 @@ def test_sles_pallet_patched(host, report_output):
 				temp_path = sles_pallet_root + temp_path_list[1]
 				if get_hash(file_to_check,sles_flavor) == hash_value and get_hash(temp_path, sles_flavor) == hash_value:
 					matched_list.append(file_to_check)
+				else:
+					not_matched_list.append(file_to_check)
 
-			# Check if we found hash match as expected. Should be 4 files.	
-			if matched_list and len(matched_list) == 4: 
-				found_source = True
-				# trim the string
-				temp_path = rpm.split('stacki/')[1]
-				temp_path_list = temp_path.split('/')
-				version = temp_path_list[0]
-				os_type = temp_path_list[1]
-				version_string = 'stacki-' + version + '-' + os_type + '-sles-x86_64'
-				# Don't want duplicate entry
-				if version_string not in total_matched:
-					total_matched.append(version_string)
+			# Add info we have into nested dictionary 
+			good_dict = {rpm: []}
+			bad_dict = {rpm: []}
+			# Check if we found all the hash matches 	
+			if matched_list and len(matched_list) == len(patch_files): 
+				# this indicates if hash match was found for a sles flavor or not
+				good_dict[rpm].append(matched_list)
+				overall_dict[sles_flavor]['good'].update({rpm: matched_list})
+			elif not_matched_list:# and len(not_matched_list) == len(patch_files):
+				bad_dict[rpm].append(not_matched_list)
+				overall_dict[sles_flavor]['bad'].update({rpm: not_matched_list})
 
-		# Didn't find stacki source for this os
-		assert found_source == True
+	# Print entire dictionary for debug
+	#pp = pprint.PrettyPrinter(indent=4)
+	#pp.pprint(overall_dict)
 
-	for match in total_matched:
-		report_output('SLES pallet patch source', match)
+	assert overall_dict
+	# over all test result
+	final_status = True
+	for os_, results in overall_dict.items():
+		success = False 
+		if 'good' in results:
+			success = True
+		for result, rpms in results.items():
+			for rpm, filelist in rpms.items():
+				if result == 'good':
+					temp_path = rpm.split('stacki/')[1]
+					temp_path_list = temp_path.split('/')
+					version = temp_path_list[0]
+					os_type = temp_path_list[1]
+					version_string = 'stacki-' + version + '-' + os_type + '-sles-x86_64'
+					output = version_string + '\n'
+					report_output(f'SLES{os_} pallet patch source', output)
+				else:
+					# if we already found good case then skip all the bad cases
+					if success: 
+						continue;
+					else:
+						# overall status is bad if we find one valid bad case
+						final_status = False
+						output = ''
+						for val in rpms.get(rpm):
+							if len(output) == 0:
+								output = val
+							else:
+								output = output + '\n' + val
+						output += '\n'
+						report_output(f'SLES{os_} pallet patch source NOT found', output)
+	assert final_status 

--- a/common/src/stack/report-system/command/report/system/tests/test_sles_patch.py
+++ b/common/src/stack/report-system/command/report/system/tests/test_sles_patch.py
@@ -1,0 +1,124 @@
+import pytest
+import os
+import stack.api
+import hashlib
+import json
+
+
+# Returns hash of filename
+def get_hash(filename, sles):
+	# SLES15 uses sha256
+	if '15sp' in sles:
+		hasher = hashlib.sha256()
+	else:
+		hasher = hashlib.md5()
+
+	with open(filename, 'rb') as f:
+		hasher.update(f.read())
+
+	return hasher.hexdigest()
+
+
+# Verify SLES patches are installed
+def test_sles_pallet_patched(host, report_output):
+	total_matched = []
+	base_dir = '/export/stack/pallets/SLES/'
+	if not os.path.isdir(base_dir):
+		pytest.skip('No SLES pallet found - skipping patch check')
+	sles_flavors = os.listdir(base_dir)
+	assert sles_flavors
+
+	# Find out where is stack-sles*images*.rpm file(s)
+	result = host.run('find /export/stack/pallets/stacki/ -name "*stack-sles-*.rpm"')
+	RPM = result.stdout.splitlines()
+	assert RPM
+
+	# If the stack-sles*images*.rpm installed?
+	result = host.run('rpm -qa | grep stack | grep images')
+	assert result
+
+	# Test every sles flavor found
+	for sles_flavor in sles_flavors:
+		# Make sure installed patches match what's under /opt/stack/pallet-patches
+		patch_dir = '/opt/stack/pallet-patches'
+		patch_dir_files = []
+		found_source = False
+		for (dir_path, dir_names, filenames) in os.walk(patch_dir):
+			# Only want particular SLES version
+			if sles_flavor in dir_path:
+				file_to_check = None
+				if '15sp' in sles_flavor:
+					file_to_check = 'CHECKSUMS'
+				else:
+					file_to_check = 'content'
+				patch_dir_files += [os.path.join(dir_path, file) for file in filenames if file == file_to_check]
+
+		# We should have non-empty list here
+		assert patch_dir_files
+
+		# Find img file from patch directory in SLES pallet
+		result = host.run(f'grep .img {patch_dir_files[0]}')
+
+		# Last item is the partial image path
+		part_img_file = result.stdout.split()[-1]
+
+		# Find full path to /export/stack/pallets/SLES/?
+		result = host.run(f'probepal {base_dir}')
+		assert result.rc == 0
+		palinfo = json.loads(result.stdout)
+
+        	# It shouldn't be empty
+		assert palinfo[base_dir]
+		
+		sles_pallet_root = None 
+		for pallet in palinfo[base_dir]:
+			# Grab the right sles sp level
+			if pallet['version'] == sles_flavor:
+				assert host.file(f"{pallet['pallet_root']}").is_directory
+				sles_pallet_root = pallet['pallet_root']
+				break
+
+		# .img file should exist in sles pallet directory in relative path
+		assert os.path.exists(sles_pallet_root + '/' + part_img_file)
+
+		# Verify all the stack-sles-* rpm packages 
+		for rpm in RPM:
+			# Make sure we found pm file
+			assert '.rpm' in rpm
+
+			result = host.run(f'rpm -qp --dump {rpm}')	
+			# We don't want file under /opt/stack/images to be included in this list
+			patch_files = [line.split() for line in result.stdout.splitlines() if sles_flavor in line and '/images/' not in line]
+
+			matched_list = []
+			# Verify file(s) from images RPM actually exist
+			for this_list in patch_files:
+				file_to_check = this_list[0]
+				assert os.path.exists(file_to_check) 
+				hash_value = this_list[3]
+
+				# Grab hash for this file in patch directory and SLES pallet directory and compare against hash from img file. They should match
+				# Need to build the equivalent path first
+				temp_path_list = file_to_check.split('add-stacki-squashfs')	
+				temp_path = sles_pallet_root + temp_path_list[1]
+				if get_hash(file_to_check,sles_flavor) == hash_value and get_hash(temp_path, sles_flavor) == hash_value:
+					matched_list.append(file_to_check)
+
+			# Check if we found hash match as expected. Should be 4 files.	
+			if matched_list and len(matched_list) == 4: 
+				found_source = True
+				# trim the string
+				temp_path = rpm.split('stacki/')[1]
+				temp_path_list = temp_path.split('/')
+				version = temp_path_list[0]
+				os_type = temp_path_list[1]
+				version_string = 'stacki-' + version + '-' + os_type + '-sles-x86_64'
+				# Don't want duplicate entry
+				if version_string not in total_matched:
+					total_matched.append(version_string)
+
+		# Didn't find stacki source for this os
+		assert found_source == True
+
+	for match in total_matched:
+		report_output('SLES pallet patch source', match)


### PR DESCRIPTION
Output

```
frontend-0-0:/opt/stack/lib/python3.8/site-packages/stack/commands/report/system/tests # stack report system
====================================== test session starts ======================================
platform linux -- Python 3.8.3, pytest-6.0.1, py-1.9.0, pluggy-0.13.1 -- /opt/stack/bin/python3
cachedir: .pytest_cache
rootdir: /opt/stack/lib/python3.8/site-packages/stack/commands/report/system
plugins: testinfra-1.16.0
collected 35 items

tests/test_stacki.py::test_stack_list[local-box] PASSED
tests/test_stacki.py::test_stack_list[local-pallet] PASSED
tests/test_stacki.py::test_stack_list[local-cart] PASSED
tests/test_stacki.py::test_stack_list[local-network] PASSED
tests/test_stacki.py::test_stack_list[local-host] PASSED
tests/test_stacki.py::test_stack_list[local-host interface] PASSED
tests/test_stacki.py::test_stacki_pallets_sane[local] PASSED
tests/test_stacki.py::test_stacki_central_server[local] PASSED
tests/test_stacki.py::test_stacki_ca_correct[local] PASSED
tests/test_services.py::test_service_enabled_and_running[local-dhcpd] PASSED
tests/test_services.py::test_service_enabled_and_running[local-named] SKIPPED
tests/test_services.py::test_service_enabled_and_running[local-rsyslog] PASSED
tests/test_services.py::test_service_enabled_and_running[local-smq-processor] PASSED
tests/test_services.py::test_service_enabled_and_running[local-smq-producer] PASSED
tests/test_services.py::test_service_enabled_and_running[local-smq-publisher] PASSED
tests/test_services.py::test_service_enabled_and_running[local-sshd] PASSED
tests/test_services.py::test_service_enabled_and_running[local-chronyd] PASSED
tests/test_services.py::test_service_enabled_and_running[local-apache2] PASSED
tests/test_services.py::test_service_enabled_and_running[local-mysql] PASSED
tests/test_services.py::test_tftpd_enabled_and_running[local] PASSED
tests/test_services.py::test_logrotate_service_enabled[local] PASSED
tests/test_services.py::test_logrotate_configuration_valid[local] PASSED
tests/test_services.py::test_stacki_logrotate_file_exists[local] PASSED
tests/test_restapi.py::test_restapi_list_host PASSED
tests/test_backend_installs.py::TestBackendInstalls::test_backend[backend-0-0] PASSED
tests/test_partitions.py::TestStoragePartition::test_storage_partition[paramiko://backend-0-0] SKIPPED
tests/test_backend_link.py::TestLinkUp::test_link_status[paramiko://backend-0-0] PASSED
tests/test_other_dhcp.py::test_other_dhcp_server[eth1] PASSED
tests/test_networks.py::test_hosts_in_correct_networks PASSED
tests/test_df.py::test_slash_not_full[local] PASSED
tests/test_df.py::test_export_not_full[local] PASSED
tests/test_df.py::test_var_not_full[local] PASSED
tests/test_sles_patch.py::test_sles_pallet_patched[local] PASSED
tests/test_pkgs.py::test_rpms_are_clean[local] PASSED
tests/test_pkgs.py::test_no_duplicate_rpms[local] PASSED

======================================= warnings summary ========================================
tests/test_partitions.py::TestStoragePartition::test_storage_partition[paramiko://backend-0-0]
  /opt/stack/lib/python3.8/site-packages/paramiko/client.py:835: UserWarning: Unknown ssh-ed25519 host key for backend-0-0: b'f6d43303ee51d55add2c3ac4b0f8fac3'
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/warnings.html

========================================= Cluster Data ==========================================

------------------------------------------- list box --------------------------------------------

NAME     OS   PALLETS                                                       CARTS   REPOS
11sp3    sles SLES-11sp3-sles11 stacki-5.6.1-sles11                         ------- -----
12sp3    sles stacki-5.6.1-sles12 SLES-12sp3-sles12 stacki-5.6rc5-sles12    ------- -----
15sp1    sles SLES-15sp1-sles15 Packages-1-15sp1-sles15 stacki-5.6.1-sles15 ------- -----
default  sles stacki-5.6.1-sles12 SLES-12sp3-sles12                         vagrant -----
frontend sles stacki-5.6.1-sles12 SLES-12sp3-sles12                         ------- -----

------------------------------------------ list pallet ------------------------------------------

NAME       VERSION RELEASE ARCH   OS   BOXES
stacki     5.6.1   sles12  x86_64 sles default frontend 12sp3
SLES       12sp3   sles12  x86_64 sles default frontend 12sp3
SLES       15sp1   sles15  x86_64 sles 15sp1
Packages-1 15sp1   sles15  x86_64 sles 15sp1
SLES       11sp3   sles11  x86_64 sles 11sp3
stacki     5.6.1   sles15  x86_64 sles 15sp1
stacki     5.6.1   sles11  x86_64 sles 11sp3
stacki     5.6rc5  sles12  x86_64 sles 12sp3

------------------------------------------- list cart -------------------------------------------

NAME    BOXES
vagrant default

----------------------------------------- list network ------------------------------------------

NETWORK ADDRESS     MASK          GATEWAY       MTU ZONE DNS   PXE
private 192.168.0.0 255.255.255.0 192.168.121.1 --- ---- False True

------------------------------------------- list host -------------------------------------------

HOST         RACK RANK APPLIANCE OS   BOX      ENVIRONMENT OSACTION INSTALLACTION COMMENT
frontend-0-0 0    0    frontend  sles frontend ----------- default  default       -------
backend-0-0  0    0    backend   sles default  ----------- default  default       -------

-------------------------------------- list host interface --------------------------------------

HOST         INTERFACE DEFAULT NETWORK MAC               IP          NAME         MODULE VLAN OPTIONS CHANNEL
frontend-0-0 eth1      True    private 52:54:00:e3:a0:a8 192.168.0.2 frontend-0-0 ------ ---- ------- -------
backend-0-0  eth0      ------- ------- 52:54:00:75:5c:ff ----------- ------------ ------ ---- ------- -------
backend-0-0  eth1      True    private 52:54:00:00:00:03 192.168.0.1 backend-0-0  ------ ---- ------- -------

----------------------------------- SLES pallet patch source ------------------------------------

stacki-5.6rc5-sles12-sles-x86_64
----------------------------------- SLES pallet patch source ------------------------------------

stacki-5.6.1-sles15-sles-x86_64
==================================== short test summary info ====================================
SKIPPED [1] tests/test_services.py:38: named should only be running if a network is set to dns=true
SKIPPED [1] tests/test_partitions.py:37: Using default stacki partition config for host backend-0-0
=========================== 33 passed, 2 skipped, 1 warning in 12.02s ===========================

```

