### PR TITLE
BUGFIX: Sort numeric rack and rank numerically

### DIFF
--- a/common/src/stack/command/stack/argument_processors/host.py
+++ b/common/src/stack/command/stack/argument_processors/host.py
@@ -104,9 +104,9 @@ class HostArgProcessor:
 			# (intable-ness of rack, rack, intable-ness of rank, rank)
 			key=lambda h: (
 				not h['rack'].isnumeric(),
-				h['rack'],
+				int(h['rack']) if h['rack'].isnumeric() else h['rack'],
 				not h['rank'].isnumeric(),
-				h['rank']
+				int(h['rank']) if h['rank'].isnumeric() else h['rank']
 			)
 		)
 

--- a/test-framework/test-suites/integration/tests/list/test_list_host.py
+++ b/test-framework/test-suites/integration/tests/list/test_list_host.py
@@ -106,12 +106,14 @@ class TestListHost:
 			("stacki-2-12"     , "2"         , "12"         , "backend"),
 			("stacki-2-10"     , "2"         , "10"         , "backend"),
 			("backend-1-0"     , "1"         , "station-11" , "backend"),
+			("stacki-2-2"      , "2"         , "2"         , "backend"),
 			("ethernet-2-43"   , "2"         , "43"         , "switch"),
 			("backend-0-1"     , "sector-42" , "2"          , "backend"),
 			("backend-0-3"     , "sector-42" , "4"          , "backend"),
 			("backend-0-4"     , "sector-42" , "station-8"  , "backend"),
 			("infiniband-2-20" , "2"         , "20"         , "switch"),
 			("backend-0-2"     , "sector-42" , "3"          , "backend"),
+			("stacki-2-4"      , "2"         , "4"         , "backend"),
 		]
 
 		# backend-0-0 and frontend-0-0 already added at test initialization...
@@ -123,6 +125,8 @@ class TestListHost:
 			backend-0-0
 			backend-1-0
 			ethernet-2-1
+			stacki-2-2
+			stacki-2-4
 			stacki-2-10
 			stacki-2-11
 			stacki-2-12


### PR DESCRIPTION
This will sort multi-digit rack and rack so that this:
```
HOST           RACK RANK APPLIANCE OS   BOX      ENVIRONMENT OSACTION INSTALLACTION COMMENT
stacki-667-123 0    0    frontend  sles frontend ----------- default  default       -------
stacki-667-14  667  14   backend   sles default  ----------- default  console       -------
stacki-667-15  667  15   backend   sles default  ----------- default  console       -------
stacki-667-5   667  5    backend   sles default  ----------- default  console       -------
stacki-667-6   667  6    backend   sles default  ----------- default  console       -------
stacki-667-7   667  7    backend   sles default  ----------- default  console       -------
```

Will now be sorted in rack order, like this:
```
HOST           RACK RANK APPLIANCE OS   BOX      ENVIRONMENT OSACTION INSTALLACTION COMMENT
stacki-667-123 0    0    frontend  sles frontend ----------- default  default       -------
stacki-667-5   667  5    backend   sles default  ----------- default  console       -------
stacki-667-6   667  6    backend   sles default  ----------- default  console       -------
stacki-667-7   667  7    backend   sles default  ----------- default  console       -------
stacki-667-14  667  14   backend   sles default  ----------- default  console       -------
stacki-667-15  667  15   backend   sles default  ----------- default  console       -------
```