### PR TITLE
BUGFIX: the sles15 pallet patch was still using zypper

### DIFF
--- a/sles/pallet_hooks/stacki-sles15/010-add-stacki-images.sh
+++ b/sles/pallet_hooks/stacki-sles15/010-add-stacki-images.sh
@@ -2,8 +2,17 @@
 
 set -e
 
-# Install the stack SLES images.
-zypper --non-interactive install stack-sles-sles15-images
+# Install the stack SLES images.  Use find + rpm because networking might be in a bad state.
+PALLET_DIR=/export/stack/pallets/${name}/${version}/${rel}/${os}/${arch}/
+images=$(find $PALLET_DIR -name stack-${os}-${rel}-images*rpm)
+if (( $(echo $images | wc --lines) > 1 )); then
+  echo found more than one stack-images package in ${PALLET_DIR}:
+  echo $images
+  exit 1
+else
+  echo installing $images
+  rpm --force -Uv $images
+fi
 
 # Copy the vmlinuz and initrd
 cp /opt/stack/images/initrd-sles-sles15-15sp1-x86_64 /tftpboot/pxelinux/


### PR DESCRIPTION
... which may not work if networking is down, or if the pallet isn't in the frontend's box (for example a sles12 frontend shouldn't have the sles15 pallet in the box).