### PR TITLE
BUGFIX: Delete pallet tags when associated pallet is deleted.

### DIFF
--- a/common/nodes/database-schema.xml
+++ b/common/nodes/database-schema.xml
@@ -26,18 +26,6 @@ CREATE TABLE access (
 <!-- enable root to run all commands -->
 INSERT INTO access(command, groupid) VALUES ("*", 0);
 
-<!-- Tags -->
-DROP TABLE IF EXISTS tags;
-CREATE TABLE tags (
-	scope		ENUM('box', 'cart', 'network', 'pallet') NOT NULL,
-	tag		VARCHAR(128) NOT NULL,
-	value		TEXT,
-	scopeid		INT NOT NULL,
-	INDEX (scope),
-	INDEX (tag),
-	INDEX (scopeid)
-);
-
 <!-- Attributes -->
 DROP TABLE IF EXISTS attributes_doc;
 CREATE TABLE attributes_doc (
@@ -218,6 +206,18 @@ CREATE TABLE rolls (
 	os		VARCHAR(32) NOT NULL DEFAULT '&os;',
 	url		TEXT DEFAULT '',
 	INDEX (Name)
+);
+
+<!-- Tags -->
+DROP TABLE IF EXISTS tags;
+CREATE TABLE tags (
+	scope		ENUM('box', 'cart', 'network', 'pallet') NOT NULL,
+	tag		VARCHAR(128) NOT NULL,
+	value		TEXT,
+	scopeid		INT NOT NULL,
+	INDEX (scope),
+	INDEX (tag),
+	FOREIGN KEY (scopeid) REFERENCES rolls(id) ON DELETE CASCADE
 );
 
 <!-- Repos -->


### PR DESCRIPTION
Moved the `tags` table def after the `rolls` def and added
`FOREIGN KEY (scopeid) REFERENCES rolls(id) ON DELETE CASCADE`

This will delete tags with the associated pallet is removed.
eg

```
sd-stacki-100:~/kurt/remove_tags_table # stack add pallet tag tdc-manufacturing tag=kurt value=test

sd-stacki-100:~/kurt/remove_tags_table # stack add pallet tag tdc-manufacturing tag=kurt value=test
error - Failed to run sub-command 'set pallet tag tdc-manufacturing tag=kurt value=test force=no' with error:
	tag "kurt" exists for tdc-manufacturing-1.0_20180424_d2ba150-sles12-x86_64-sles

sd-stacki-100:~/kurt/remove_tags_table # stack list pallet tag
PALLET            VERSION              RELEASE ARCH   OS   TAG   VALUE
tdc-manufacturing 1.0_20180424_d2ba150 sles12  x86_64 sles kurt  test

sd-stacki-100:~/kurt/remove_tags_table # ./select_tags.sh
tag	value	id
kurt	test	1
kurt	test	2
kurt	test	6
kurt	test	1477
kurt	test	1478
kurt	test	1627

sd-stacki-100:~/kurt/remove_tags_table # stack remove pallet tdc-manufacturing
checking for hooks in /opt/stack/pallet_hooks for tdc-manufacturing-1.0_20180424_d2ba150-sles12-x86_64-sles
Removing tdc-manufacturing 1.0_20180424_d2ba150-sles12-sles-x86_64 pallet ...

sd-stacki-100:~/kurt/remove_tags_table # ./select_tags.sh
<BLANK>

sd-stacki-100:~/kurt/remove_tags_table # stack list pallet tag
<BLANK>
```