### PR TITLE
BUGFIX: Fix VM error messages not being output

### DIFF
--- a/common/src/stack/pylib/stack/kvm.py
+++ b/common/src/stack/pylib/stack/kvm.py
@@ -66,13 +66,12 @@ class Hypervisor:
 
 	# Connect automatically and close the connection when
 	# calling the hypervisor class as a context manager
-	def __enter__(self, *args):
+	def __enter__(self):
 		self.kvm = self.connect()
 		return self
 
-	def __exit__(self, *args):
+	def __exit__(self, exc_type, exc_value, traceback):
 		self.close()
-		return self
 
 	def connect(self):
 		"""


### PR DESCRIPTION
This fixes a bug in the VM pylib library where error output was suppressed due to Contextlib suppressing any exceptions if the return value was False. 