### PR TITLE
BUGFIX: sles12 frontends lacked sles15 bootactions

### DIFF
--- a/sles/nodes/sles-bootaction.xml
+++ b/sles/nodes/sles-bootaction.xml
@@ -77,6 +77,27 @@
 			"ramdisk": "initrd-&os;-sles12-12sp3-&arch;",
 			"args":    "splash=silent rescue=1 showopts brokenmodules=mptfc,qla2xxx,mpt2sas,mpt3sas,mlx4_core,mlx4_ib,mlx4_en,mlx5_core,mlx5_ib"
 		},
+		{
+			"name":    "install sles 15.1",
+			"type":    "install",
+			"kernel":  "vmlinuz-&os;-sles15-15sp1-&arch;",
+			"ramdisk": "initrd-&os;-sles15-15sp1-&arch;",
+			"args":    "install=http://&Kickstart_PrivateAddress;/install/pallets/SLES/15sp1/sles15/&os;/&arch; autoyast=file:///tmp/profile/autoinst.xml ramdisk_size=300000 biosdevname=0 Server=&Kickstart_PrivateAddress;"
+		},
+		{
+			"name":    "install sles 15.1 console",
+			"type":    "install",
+			"kernel":  "vmlinuz-&os;-sles15-15sp1-&arch;",
+			"ramdisk": "initrd-&os;-sles15-15sp1-&arch;",
+			"args":    "install=http://&Kickstart_PrivateAddress;/install/pallets/SLES/15sp1/sles15/&os;/&arch; autoyast=file:///tmp/profile/autoinst.xml ramdisk_size=300000 biosdevname=0 Server=&Kickstart_PrivateAddress; console=ttyS0,115200n8 nomodeset=1 textmode=1"
+		},
+		{
+			"name":    "install sles 15.1 rescue",
+			"type":    "install",
+			"kernel":  "vmlinuz-&os;-sles15-15sp1-&arch;",
+			"ramdisk": "initrd-&os;-sles15-15sp1-&arch;",
+			"args":    "splash=silent rescue=1 showopts brokenmodules=mptfc,qla2xxx,mpt2sas,mpt3sas,mlx4_core,mlx4_ib,mlx4_en,mlx5_core,mlx5_ib"
+		},
 </stack:file>
 <stack:file stack:name="/tmp/dump-bootaction.json" stack:mode="append">
 		{


### PR DESCRIPTION
This somehow got dropped during our sles15 work.  This is required to install sles15 backends from sles12 (sles15 to sles15 should work without it).